### PR TITLE
fix: differentiate between query and path params in getSchemas

### DIFF
--- a/examples/advanced/src/gen/clients/petController/getPetById.ts
+++ b/examples/advanced/src/gen/clients/petController/getPetById.ts
@@ -1,16 +1,15 @@
 import client from '../../../client'
 
-import type { GetPetByIdResponse, GetPetByIdPathParams, GetPetByIdQueryParams } from '../../models/ts/GetPetById'
+import type { GetPetByIdResponse, GetPetByIdPathParams } from '../../models/ts/GetPetById'
 
 /**
  * @description Returns a single pet
  * @summary Find pet by ID
  * @link /pet/{petId}
  */
-export function getPetById<TData = GetPetByIdResponse>(petId: GetPetByIdPathParams['petId'], params?: GetPetByIdQueryParams) {
+export function getPetById<TData = GetPetByIdResponse>(petId: GetPetByIdPathParams['petId']) {
   return client<TData>({
     method: 'get',
     url: `/pet/${petId}`,
-    params,
   })
 }

--- a/examples/advanced/src/gen/clients/storeController/getOrderById.ts
+++ b/examples/advanced/src/gen/clients/storeController/getOrderById.ts
@@ -1,16 +1,15 @@
 import client from '../../../client'
 
-import type { GetOrderByIdResponse, GetOrderByIdPathParams, GetOrderByIdQueryParams } from '../../models/ts/GetOrderById'
+import type { GetOrderByIdResponse, GetOrderByIdPathParams } from '../../models/ts/GetOrderById'
 
 /**
  * @description For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
  * @summary Find purchase order by ID
  * @link /store/order/{orderId}
  */
-export function getOrderById<TData = GetOrderByIdResponse>(orderId: GetOrderByIdPathParams['orderId'], params?: GetOrderByIdQueryParams) {
+export function getOrderById<TData = GetOrderByIdResponse>(orderId: GetOrderByIdPathParams['orderId']) {
   return client<TData>({
     method: 'get',
     url: `/store/order/${orderId}`,
-    params,
   })
 }

--- a/examples/advanced/src/gen/clients/userController/getUserByName.ts
+++ b/examples/advanced/src/gen/clients/userController/getUserByName.ts
@@ -1,15 +1,14 @@
 import client from '../../../client'
 
-import type { GetUserByNameResponse, GetUserByNamePathParams, GetUserByNameQueryParams } from '../../models/ts/GetUserByName'
+import type { GetUserByNameResponse, GetUserByNamePathParams } from '../../models/ts/GetUserByName'
 
 /**
  * @summary Get user by user name
  * @link /user/{username}
  */
-export function getUserByName<TData = GetUserByNameResponse>(username: GetUserByNamePathParams['username'], params?: GetUserByNameQueryParams) {
+export function getUserByName<TData = GetUserByNameResponse>(username: GetUserByNamePathParams['username']) {
   return client<TData>({
     method: 'get',
     url: `/user/${username}`,
-    params,
   })
 }

--- a/examples/advanced/src/gen/models/ts/FindPetsByStatus.ts
+++ b/examples/advanced/src/gen/models/ts/FindPetsByStatus.ts
@@ -1,7 +1,5 @@
 import type { Pet } from './Pet'
 
-export type FindPetsByStatusPathParams = {}
-
 export const findPetsByStatusQueryParamsStatus = {
   available: 'available',
   pending: 'pending',

--- a/examples/advanced/src/gen/models/ts/FindPetsByTags.ts
+++ b/examples/advanced/src/gen/models/ts/FindPetsByTags.ts
@@ -1,7 +1,5 @@
 import type { Pet } from './Pet'
 
-export type FindPetsByTagsPathParams = {}
-
 export type FindPetsByTagsQueryParams = {
   /**
    * @type array | undefined

--- a/examples/advanced/src/gen/models/ts/GetOrderById.ts
+++ b/examples/advanced/src/gen/models/ts/GetOrderById.ts
@@ -7,8 +7,6 @@ export type GetOrderByIdPathParams = {
   orderId: number
 }
 
-export type GetOrderByIdQueryParams = {}
-
 /**
  * @description successful operation
  */

--- a/examples/advanced/src/gen/models/ts/GetPetById.ts
+++ b/examples/advanced/src/gen/models/ts/GetPetById.ts
@@ -7,8 +7,6 @@ export type GetPetByIdPathParams = {
   petId: number
 }
 
-export type GetPetByIdQueryParams = {}
-
 /**
  * @description successful operation
  */

--- a/examples/advanced/src/gen/models/ts/GetUserByName.ts
+++ b/examples/advanced/src/gen/models/ts/GetUserByName.ts
@@ -7,8 +7,6 @@ export type GetUserByNamePathParams = {
   username: string
 }
 
-export type GetUserByNameQueryParams = {}
-
 /**
  * @description successful operation
  */

--- a/examples/advanced/src/gen/models/ts/LoginUser.ts
+++ b/examples/advanced/src/gen/models/ts/LoginUser.ts
@@ -1,5 +1,3 @@
-export type LoginUserPathParams = {}
-
 export type LoginUserQueryParams = {
   /**
    * @type string | undefined

--- a/examples/advanced/src/gen/models/ts/UpdateUser.ts
+++ b/examples/advanced/src/gen/models/ts/UpdateUser.ts
@@ -7,8 +7,6 @@ export type UpdateUserPathParams = {
   username: string
 }
 
-export type UpdateUserQueryParams = {}
-
 export type UpdateUserResponse = any | null
 
 /**

--- a/examples/advanced/src/gen/reactQuery/petController/useGetPetById.ts
+++ b/examples/advanced/src/gen/reactQuery/petController/useGetPetById.ts
@@ -3,13 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import client from '../../../client'
 
 import type { QueryKey, UseQueryResult, UseQueryOptions, QueryOptions } from '@tanstack/react-query'
-import type { GetPetByIdResponse, GetPetByIdPathParams, GetPetByIdQueryParams } from '../../models/ts/GetPetById'
+import type { GetPetByIdResponse, GetPetByIdPathParams } from '../../models/ts/GetPetById'
 
-export const getPetByIdQueryKey = (petId: GetPetByIdPathParams['petId'], params?: GetPetByIdQueryParams) =>
-  [`/pet/${petId}`, ...(params ? [params] : [])] as const
+export const getPetByIdQueryKey = (petId: GetPetByIdPathParams['petId']) => [`/pet/${petId}`] as const
 
-export function getPetByIdQueryOptions<TData = GetPetByIdResponse>(petId: GetPetByIdPathParams['petId'], params?: GetPetByIdQueryParams): QueryOptions<TData> {
-  const queryKey = getPetByIdQueryKey(petId, params)
+export function getPetByIdQueryOptions<TData = GetPetByIdResponse>(petId: GetPetByIdPathParams['petId']): QueryOptions<TData> {
+  const queryKey = getPetByIdQueryKey(petId)
 
   return {
     queryKey,
@@ -17,7 +16,6 @@ export function getPetByIdQueryOptions<TData = GetPetByIdResponse>(petId: GetPet
       return client<TData>({
         method: 'get',
         url: `/pet/${petId}`,
-        params,
       })
     },
   }
@@ -30,14 +28,13 @@ export function getPetByIdQueryOptions<TData = GetPetByIdResponse>(petId: GetPet
  */
 export function useGetPetById<TData = GetPetByIdResponse>(
   petId: GetPetByIdPathParams['petId'],
-  params?: GetPetByIdQueryParams,
   options?: { query?: UseQueryOptions<TData> }
 ): UseQueryResult<TData> & { queryKey: QueryKey } {
   const { query: queryOptions } = options ?? {}
-  const queryKey = queryOptions?.queryKey ?? getPetByIdQueryKey(petId, params)
+  const queryKey = queryOptions?.queryKey ?? getPetByIdQueryKey(petId)
 
   const query = useQuery<TData>({
-    ...getPetByIdQueryOptions<TData>(petId, params),
+    ...getPetByIdQueryOptions<TData>(petId),
     ...queryOptions,
   }) as UseQueryResult<TData> & { queryKey: QueryKey }
 

--- a/examples/advanced/src/gen/reactQuery/storeController/useGetOrderById.ts
+++ b/examples/advanced/src/gen/reactQuery/storeController/useGetOrderById.ts
@@ -3,16 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import client from '../../../client'
 
 import type { QueryKey, UseQueryResult, UseQueryOptions, QueryOptions } from '@tanstack/react-query'
-import type { GetOrderByIdResponse, GetOrderByIdPathParams, GetOrderByIdQueryParams } from '../../models/ts/GetOrderById'
+import type { GetOrderByIdResponse, GetOrderByIdPathParams } from '../../models/ts/GetOrderById'
 
-export const getOrderByIdQueryKey = (orderId: GetOrderByIdPathParams['orderId'], params?: GetOrderByIdQueryParams) =>
-  [`/store/order/${orderId}`, ...(params ? [params] : [])] as const
+export const getOrderByIdQueryKey = (orderId: GetOrderByIdPathParams['orderId']) => [`/store/order/${orderId}`] as const
 
-export function getOrderByIdQueryOptions<TData = GetOrderByIdResponse>(
-  orderId: GetOrderByIdPathParams['orderId'],
-  params?: GetOrderByIdQueryParams
-): QueryOptions<TData> {
-  const queryKey = getOrderByIdQueryKey(orderId, params)
+export function getOrderByIdQueryOptions<TData = GetOrderByIdResponse>(orderId: GetOrderByIdPathParams['orderId']): QueryOptions<TData> {
+  const queryKey = getOrderByIdQueryKey(orderId)
 
   return {
     queryKey,
@@ -20,7 +16,6 @@ export function getOrderByIdQueryOptions<TData = GetOrderByIdResponse>(
       return client<TData>({
         method: 'get',
         url: `/store/order/${orderId}`,
-        params,
       })
     },
   }
@@ -33,14 +28,13 @@ export function getOrderByIdQueryOptions<TData = GetOrderByIdResponse>(
  */
 export function useGetOrderById<TData = GetOrderByIdResponse>(
   orderId: GetOrderByIdPathParams['orderId'],
-  params?: GetOrderByIdQueryParams,
   options?: { query?: UseQueryOptions<TData> }
 ): UseQueryResult<TData> & { queryKey: QueryKey } {
   const { query: queryOptions } = options ?? {}
-  const queryKey = queryOptions?.queryKey ?? getOrderByIdQueryKey(orderId, params)
+  const queryKey = queryOptions?.queryKey ?? getOrderByIdQueryKey(orderId)
 
   const query = useQuery<TData>({
-    ...getOrderByIdQueryOptions<TData>(orderId, params),
+    ...getOrderByIdQueryOptions<TData>(orderId),
     ...queryOptions,
   }) as UseQueryResult<TData> & { queryKey: QueryKey }
 

--- a/examples/advanced/src/gen/reactQuery/userController/useGetUserByName.ts
+++ b/examples/advanced/src/gen/reactQuery/userController/useGetUserByName.ts
@@ -3,16 +3,12 @@ import { useQuery } from '@tanstack/react-query'
 import client from '../../../client'
 
 import type { QueryKey, UseQueryResult, UseQueryOptions, QueryOptions } from '@tanstack/react-query'
-import type { GetUserByNameResponse, GetUserByNamePathParams, GetUserByNameQueryParams } from '../../models/ts/GetUserByName'
+import type { GetUserByNameResponse, GetUserByNamePathParams } from '../../models/ts/GetUserByName'
 
-export const getUserByNameQueryKey = (username: GetUserByNamePathParams['username'], params?: GetUserByNameQueryParams) =>
-  [`/user/${username}`, ...(params ? [params] : [])] as const
+export const getUserByNameQueryKey = (username: GetUserByNamePathParams['username']) => [`/user/${username}`] as const
 
-export function getUserByNameQueryOptions<TData = GetUserByNameResponse>(
-  username: GetUserByNamePathParams['username'],
-  params?: GetUserByNameQueryParams
-): QueryOptions<TData> {
-  const queryKey = getUserByNameQueryKey(username, params)
+export function getUserByNameQueryOptions<TData = GetUserByNameResponse>(username: GetUserByNamePathParams['username']): QueryOptions<TData> {
+  const queryKey = getUserByNameQueryKey(username)
 
   return {
     queryKey,
@@ -20,7 +16,6 @@ export function getUserByNameQueryOptions<TData = GetUserByNameResponse>(
       return client<TData>({
         method: 'get',
         url: `/user/${username}`,
-        params,
       })
     },
   }
@@ -32,14 +27,13 @@ export function getUserByNameQueryOptions<TData = GetUserByNameResponse>(
  */
 export function useGetUserByName<TData = GetUserByNameResponse>(
   username: GetUserByNamePathParams['username'],
-  params?: GetUserByNameQueryParams,
   options?: { query?: UseQueryOptions<TData> }
 ): UseQueryResult<TData> & { queryKey: QueryKey } {
   const { query: queryOptions } = options ?? {}
-  const queryKey = queryOptions?.queryKey ?? getUserByNameQueryKey(username, params)
+  const queryKey = queryOptions?.queryKey ?? getUserByNameQueryKey(username)
 
   const query = useQuery<TData>({
-    ...getUserByNameQueryOptions<TData>(username, params),
+    ...getUserByNameQueryOptions<TData>(username),
     ...queryOptions,
   }) as UseQueryResult<TData> & { queryKey: QueryKey }
 

--- a/examples/advanced/src/gen/zod/findPetsByStatusSchema.ts
+++ b/examples/advanced/src/gen/zod/findPetsByStatusSchema.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 import { petSchema } from './petSchema'
 
-export const findPetsByStatusPathParamsSchema = z.object({})
 export const findPetsByStatusQueryParamsSchema = z.object({ status: z.enum([`available`, `pending`, `sold`]).optional() })
 
 /**

--- a/examples/advanced/src/gen/zod/findPetsByTagsSchema.ts
+++ b/examples/advanced/src/gen/zod/findPetsByTagsSchema.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 import { petSchema } from './petSchema'
 
-export const findPetsByTagsPathParamsSchema = z.object({})
 export const findPetsByTagsQueryParamsSchema = z.object({ tags: z.array(z.string()).optional() })
 
 /**

--- a/examples/advanced/src/gen/zod/getOrderByIdSchema.ts
+++ b/examples/advanced/src/gen/zod/getOrderByIdSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { orderSchema } from './orderSchema'
 
 export const getOrderByIdPathParamsSchema = z.object({ orderId: z.number() })
-export const getOrderByIdQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/advanced/src/gen/zod/getPetByIdSchema.ts
+++ b/examples/advanced/src/gen/zod/getPetByIdSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { petSchema } from './petSchema'
 
 export const getPetByIdPathParamsSchema = z.object({ petId: z.number() })
-export const getPetByIdQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/advanced/src/gen/zod/getUserByNameSchema.ts
+++ b/examples/advanced/src/gen/zod/getUserByNameSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { userSchema } from './userSchema'
 
 export const getUserByNamePathParamsSchema = z.object({ username: z.string() })
-export const getUserByNameQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/advanced/src/gen/zod/loginUserSchema.ts
+++ b/examples/advanced/src/gen/zod/loginUserSchema.ts
@@ -1,6 +1,5 @@
 import z from 'zod'
 
-export const loginUserPathParamsSchema = z.object({})
 export const loginUserQueryParamsSchema = z.object({ username: z.string().optional(), password: z.string().optional() })
 
 /**

--- a/examples/advanced/src/gen/zod/updateUserSchema.ts
+++ b/examples/advanced/src/gen/zod/updateUserSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { userSchema } from './userSchema'
 
 export const updateUserPathParamsSchema = z.object({ username: z.string() })
-export const updateUserQueryParamsSchema = z.object({})
 export const updateUserResponseSchema = z.any()
 
 /**

--- a/examples/simple-single/src/gen/hooks.ts
+++ b/examples/simple-single/src/gen/hooks.ts
@@ -3,15 +3,7 @@ import { useQuery, useMutation } from '@tanstack/react-query'
 import client from '@kubb/swagger-client/client'
 
 import type { QueryKey, UseQueryResult, UseQueryOptions, QueryOptions, UseMutationOptions } from '@tanstack/react-query'
-import type {
-  ListPetsResponse,
-  ListPetsQueryParams,
-  CreatePetsRequest,
-  CreatePetsResponse,
-  ShowPetByIdResponse,
-  ShowPetByIdPathParams,
-  ShowPetByIdQueryParams,
-} from './models'
+import type { ListPetsResponse, ListPetsQueryParams, CreatePetsRequest, CreatePetsResponse, ShowPetByIdResponse, ShowPetByIdPathParams } from './models'
 
 export const listPetsQueryKey = (params?: ListPetsQueryParams) => [`/pets`, ...(params ? [params] : [])] as const
 
@@ -72,15 +64,13 @@ export function useCreatePets<TData = CreatePetsResponse, TVariables = CreatePet
   })
 }
 
-export const showPetByIdQueryKey = (petId: ShowPetByIdPathParams['petId'], testId: ShowPetByIdPathParams['testId'], params?: ShowPetByIdQueryParams) =>
-  [`/pets/${petId}`, ...(params ? [params] : [])] as const
+export const showPetByIdQueryKey = (petId: ShowPetByIdPathParams['petId'], testId: ShowPetByIdPathParams['testId']) => [`/pets/${petId}`] as const
 
 export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
   petId: ShowPetByIdPathParams['petId'],
-  testId: ShowPetByIdPathParams['testId'],
-  params?: ShowPetByIdQueryParams
+  testId: ShowPetByIdPathParams['testId']
 ): QueryOptions<TData> {
-  const queryKey = showPetByIdQueryKey(petId, testId, params)
+  const queryKey = showPetByIdQueryKey(petId, testId)
 
   return {
     queryKey,
@@ -88,7 +78,6 @@ export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
       return client<TData>({
         method: 'get',
         url: `/pets/${petId}`,
-        params,
       })
     },
   }
@@ -101,14 +90,13 @@ export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
 export function useShowPetById<TData = ShowPetByIdResponse>(
   petId: ShowPetByIdPathParams['petId'],
   testId: ShowPetByIdPathParams['testId'],
-  params?: ShowPetByIdQueryParams,
   options?: { query?: UseQueryOptions<TData> }
 ): UseQueryResult<TData> & { queryKey: QueryKey } {
   const { query: queryOptions } = options ?? {}
-  const queryKey = queryOptions?.queryKey ?? showPetByIdQueryKey(petId, testId, params)
+  const queryKey = queryOptions?.queryKey ?? showPetByIdQueryKey(petId, testId)
 
   const query = useQuery<TData>({
-    ...showPetByIdQueryOptions<TData>(petId, testId, params),
+    ...showPetByIdQueryOptions<TData>(petId, testId),
     ...queryOptions,
   }) as UseQueryResult<TData> & { queryKey: QueryKey }
 

--- a/examples/simple-single/src/gen/models.ts
+++ b/examples/simple-single/src/gen/models.ts
@@ -49,8 +49,6 @@ export type Pet = {
 
 export type Pets = Pet[]
 
-export type ListPetsPathParams = {}
-
 export type ListPetsQueryParams = {
   /**
    * @type string | undefined
@@ -89,8 +87,6 @@ export type ShowPetByIdPathParams = {
    */
   testId: string
 }
-
-export type ShowPetByIdQueryParams = {}
 
 /**
  * @description Expected response to a valid request

--- a/examples/simple/src/gen/hooks/useShowPetById.ts
+++ b/examples/simple/src/gen/hooks/useShowPetById.ts
@@ -3,17 +3,15 @@ import { useQuery } from '@tanstack/react-query'
 import client from '@kubb/swagger-client/client'
 
 import type { QueryKey, UseQueryResult, UseQueryOptions, QueryOptions } from '@tanstack/react-query'
-import type { ShowPetByIdResponse, ShowPetByIdPathParams, ShowPetByIdQueryParams } from '../models/ShowPetById'
+import type { ShowPetByIdResponse, ShowPetByIdPathParams } from '../models/ShowPetById'
 
-export const showPetByIdQueryKey = (petId: ShowPetByIdPathParams['petId'], testId: ShowPetByIdPathParams['testId'], params?: ShowPetByIdQueryParams) =>
-  [`/pets/${petId}`, ...(params ? [params] : [])] as const
+export const showPetByIdQueryKey = (petId: ShowPetByIdPathParams['petId'], testId: ShowPetByIdPathParams['testId']) => [`/pets/${petId}`] as const
 
 export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
   petId: ShowPetByIdPathParams['petId'],
-  testId: ShowPetByIdPathParams['testId'],
-  params?: ShowPetByIdQueryParams
+  testId: ShowPetByIdPathParams['testId']
 ): QueryOptions<TData> {
-  const queryKey = showPetByIdQueryKey(petId, testId, params)
+  const queryKey = showPetByIdQueryKey(petId, testId)
 
   return {
     queryKey,
@@ -21,7 +19,6 @@ export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
       return client<TData>({
         method: 'get',
         url: `/pets/${petId}`,
-        params,
       })
     },
   }
@@ -34,14 +31,13 @@ export function showPetByIdQueryOptions<TData = ShowPetByIdResponse>(
 export function useShowPetById<TData = ShowPetByIdResponse>(
   petId: ShowPetByIdPathParams['petId'],
   testId: ShowPetByIdPathParams['testId'],
-  params?: ShowPetByIdQueryParams,
   options?: { query?: UseQueryOptions<TData> }
 ): UseQueryResult<TData> & { queryKey: QueryKey } {
   const { query: queryOptions } = options ?? {}
-  const queryKey = queryOptions?.queryKey ?? showPetByIdQueryKey(petId, testId, params)
+  const queryKey = queryOptions?.queryKey ?? showPetByIdQueryKey(petId, testId)
 
   const query = useQuery<TData>({
-    ...showPetByIdQueryOptions<TData>(petId, testId, params),
+    ...showPetByIdQueryOptions<TData>(petId, testId),
     ...queryOptions,
   }) as UseQueryResult<TData> & { queryKey: QueryKey }
 

--- a/examples/simple/src/gen/models/ListPets.ts
+++ b/examples/simple/src/gen/models/ListPets.ts
@@ -1,7 +1,5 @@
 import type { Pets } from './Pets'
 
-export type ListPetsPathParams = {}
-
 export type ListPetsQueryParams = {
   /**
    * @type string | undefined

--- a/examples/simple/src/gen/models/ShowPetById.ts
+++ b/examples/simple/src/gen/models/ShowPetById.ts
@@ -11,8 +11,6 @@ export type ShowPetByIdPathParams = {
   testId: string
 }
 
-export type ShowPetByIdQueryParams = {}
-
 /**
  * @description Expected response to a valid request
  */

--- a/examples/zod/src/gen/zod/findPetsByStatusSchema.ts
+++ b/examples/zod/src/gen/zod/findPetsByStatusSchema.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 import { petSchema } from './petSchema'
 
-export const findPetsByStatusPathParamsSchema = z.object({})
 export const findPetsByStatusQueryParamsSchema = z.object({ status: z.enum([`available`, `pending`, `sold`]).optional() })
 
 /**

--- a/examples/zod/src/gen/zod/findPetsByTagsSchema.ts
+++ b/examples/zod/src/gen/zod/findPetsByTagsSchema.ts
@@ -2,7 +2,6 @@ import z from 'zod'
 
 import { petSchema } from './petSchema'
 
-export const findPetsByTagsPathParamsSchema = z.object({})
 export const findPetsByTagsQueryParamsSchema = z.object({ tags: z.array(z.string()).optional() })
 
 /**

--- a/examples/zod/src/gen/zod/getOrderByIdSchema.ts
+++ b/examples/zod/src/gen/zod/getOrderByIdSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { orderSchema } from './orderSchema'
 
 export const getOrderByIdPathParamsSchema = z.object({ orderId: z.number() })
-export const getOrderByIdQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/zod/src/gen/zod/getPetByIdSchema.ts
+++ b/examples/zod/src/gen/zod/getPetByIdSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { petSchema } from './petSchema'
 
 export const getPetByIdPathParamsSchema = z.object({ petId: z.number() })
-export const getPetByIdQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/zod/src/gen/zod/getUserByNameSchema.ts
+++ b/examples/zod/src/gen/zod/getUserByNameSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { userSchema } from './userSchema'
 
 export const getUserByNamePathParamsSchema = z.object({ username: z.string() })
-export const getUserByNameQueryParamsSchema = z.object({})
 
 /**
  * @description successful operation

--- a/examples/zod/src/gen/zod/loginUserSchema.ts
+++ b/examples/zod/src/gen/zod/loginUserSchema.ts
@@ -1,6 +1,5 @@
 import z from 'zod'
 
-export const loginUserPathParamsSchema = z.object({})
 export const loginUserQueryParamsSchema = z.object({ username: z.string().optional(), password: z.string().optional() })
 
 /**

--- a/examples/zod/src/gen/zod/updateUserSchema.ts
+++ b/examples/zod/src/gen/zod/updateUserSchema.ts
@@ -3,7 +3,6 @@ import z from 'zod'
 import { userSchema } from './userSchema'
 
 export const updateUserPathParamsSchema = z.object({ username: z.string() })
-export const updateUserQueryParamsSchema = z.object({})
 export const updateUserResponseSchema = z.any()
 
 /**

--- a/packages/swagger-client/src/generators/OperationGenerator.ts
+++ b/packages/swagger-client/src/generators/OperationGenerator.ts
@@ -82,8 +82,7 @@ export class OperationGenerator extends Generator<Options> {
     if (!schemas.queryParams && schemas.pathParams) {
       sources.push(`
         ${createJSDocBlockText({ comments })}
-        export function ${controllerName} <TData = ${schemas.response.name}>(${pathParamsTyped}
-      }) {
+        export function ${controllerName} <TData = ${schemas.response.name}>(${pathParamsTyped}) {
           return client<TData>({
             method: "get",
             url: \`${url}\`

--- a/packages/swagger-react-query/src/generators/OperationGenerator.ts
+++ b/packages/swagger-react-query/src/generators/OperationGenerator.ts
@@ -75,7 +75,7 @@ export class OperationGenerator extends Generator<Options> {
       `)
 
       sources.push(`
-        export function ${camelCase(`${operation.getOperationId()}QueryOptions`)} <TData = ${schemas.response.name}>(params: ${
+        export function ${camelCase(`${operation.getOperationId()}QueryOptions`)} <TData = ${schemas.response.name}>(params?: ${
         schemas.queryParams.name
       }): QueryOptions<TData> {
           const queryKey = ${queryKey}(params);
@@ -102,7 +102,7 @@ export class OperationGenerator extends Generator<Options> {
           const queryKey = queryOptions?.queryKey ?? ${queryKey}(params);
           
           const query = useQuery<TData>({
-            ...${camelCase(`${operation.getOperationId()}QueryOptions`)}(params),
+            ...${camelCase(`${operation.getOperationId()}QueryOptions`)}<TData>(params),
             ...queryOptions
           }) as UseQueryResult<TData> & { queryKey: QueryKey };
 
@@ -136,8 +136,9 @@ export class OperationGenerator extends Generator<Options> {
 
       sources.push(`
         ${createJSDocBlockText({ comments })}
-        export function ${hookName} <TData = ${schemas.response.name}>(${pathParamsTyped}
-      }, options?: { query?: UseQueryOptions<TData> }): UseQueryResult<TData> & { queryKey: QueryKey } {
+        export function ${hookName} <TData = ${
+        schemas.response.name
+      }>(${pathParamsTyped} options?: { query?: UseQueryOptions<TData> }): UseQueryResult<TData> & { queryKey: QueryKey } {
           const { query: queryOptions } = options ?? {};
           const queryKey = queryOptions?.queryKey ?? ${queryKey}(${pathParams});
           

--- a/packages/swagger/src/generators/OperationGenerator.ts
+++ b/packages/swagger/src/generators/OperationGenerator.ts
@@ -38,6 +38,10 @@ export abstract class OperationGenerator<TOptions extends { oas: Oas } = { oas: 
       }
     })
 
+    if (!params.length) {
+      return null
+    }
+
     return params.reduce(
       (schema, pathParameters) => {
         return {
@@ -54,25 +58,20 @@ export abstract class OperationGenerator<TOptions extends { oas: Oas } = { oas: 
   }
 
   getSchemas(operation: Operation): OperationSchemas {
-    const parameters = operation.getParameters()
-
-    const queryParams = parameters.filter((param) => param.in === 'query')
-    const hasQueryParams = queryParams.length
-
-    const pathParams = parameters.filter((param) => param.in === 'path')
-    const hasPathParams = pathParams.length
+    const pathParams = this.getParametersSchema(operation, 'path')
+    const queryParams = this.getParametersSchema(operation, 'query')
 
     return {
-      pathParams: hasPathParams
+      pathParams: pathParams
         ? {
             name: pascalCase(`${operation.getOperationId()} "PathParams"`, { delimiter: '' }),
-            schema: this.getParametersSchema(operation, 'path'),
+            schema: pathParams,
           }
         : undefined,
-      queryParams: hasQueryParams
+      queryParams: queryParams
         ? {
             name: pascalCase(`${operation.getOperationId()} "QueryParams"`, { delimiter: '' }),
-            schema: this.getParametersSchema(operation, 'query'),
+            schema: queryParams,
           }
         : undefined,
       request: {

--- a/packages/swagger/src/generators/OperationGenerator.ts
+++ b/packages/swagger/src/generators/OperationGenerator.ts
@@ -3,11 +3,12 @@ import { pascalCase } from 'change-case'
 import type { FileManager, File } from '@kubb/core'
 import { Generator } from '@kubb/core'
 
+import { isReference } from '../utils/isReference'
+
 import type { Operation } from 'oas'
 import type { MediaTypeObject, RequestBodyObject } from 'oas/dist/rmoas.types'
 import type { OpenAPIV3 } from 'openapi-types'
 import type Oas from 'oas'
-import { isReference } from '../utils/isReference'
 
 type OperationSchema = {
   name: string
@@ -53,14 +54,22 @@ export abstract class OperationGenerator<TOptions extends { oas: Oas } = { oas: 
   }
 
   getSchemas(operation: Operation): OperationSchemas {
+    const parameters = operation.getParameters()
+
+    const queryParams = parameters.filter((param) => param.in === 'query')
+    const hasQueryParams = queryParams.length
+
+    const pathParams = parameters.filter((param) => param.in === 'path')
+    const hasPathParams = pathParams.length
+
     return {
-      pathParams: operation.hasParameters()
+      pathParams: hasPathParams
         ? {
             name: pascalCase(`${operation.getOperationId()} "PathParams"`, { delimiter: '' }),
             schema: this.getParametersSchema(operation, 'path'),
           }
         : undefined,
-      queryParams: operation.hasParameters()
+      queryParams: hasQueryParams
         ? {
             name: pascalCase(`${operation.getOperationId()} "QueryParams"`, { delimiter: '' }),
             schema: this.getParametersSchema(operation, 'query'),


### PR DESCRIPTION
While debugging, I noticed there was no difference being made between query params and path params.
So for my test with the petStore.yml I was getting true on `schemas.pathParams` even though there were no path params. It returned true because it found parameters in the query.
I'll write a test still but I just want to make sure if you also think this is indeed a bug :)