### PR TITLE
feat(swagger-ts): enumType `asPascalConst`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,6 +34,7 @@ module.exports = {
     'no-debugger': 'off',
     'no-unused-vars': 'off',
     'no-plusplus': 'off',
+    'no-redeclare': 'warn',
     'no-undef': 'error',
     'no-continue': 'off',
     'no-shadow': 'off',

--- a/docs/pages/plugins/swagger-ts.mdx
+++ b/docs/pages/plugins/swagger-ts.mdx
@@ -54,9 +54,11 @@ Example: `models/{{tag}}Controller` => `models/PetController` <br/>
 Default: `${output}/{{tag}}Controller`
 
 ### enumType
-Choose to use `enum` or `as const` for enums
+Choose to use `enum` or `as const` for enums. 
+`asConst` will use camelCase for the naming.
+`asPascalConst` will use PascalCase for the naming.
 
-Type: `'enum' | 'asConst'` <br/>
+Type: `'enum' | 'asConst' | 'asPascalConst'` <br/>
 Default: `asConst`
 
 ## Depended

--- a/examples/advanced/kubb.config.ts
+++ b/examples/advanced/kubb.config.ts
@@ -28,6 +28,7 @@ export default defineConfig(async () => {
           groupBy: {
             type: 'tag',
           },
+          enumType: 'asPascalConst',
         },
       ],
       ['@kubb/swagger-tanstack-query', { output: './clients/hooks', groupBy: { type: 'tag' }, client: './src/client.ts' }],

--- a/examples/advanced/src/gen/models/ts/AddPetRequest.ts
+++ b/examples/advanced/src/gen/models/ts/AddPetRequest.ts
@@ -1,12 +1,12 @@
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-export const addPetRequestStatus = {
+export const AddPetRequestStatus = {
   available: 'available',
   pending: 'pending',
   sold: 'sold',
 } as const
-export type AddPetRequestStatus = (typeof addPetRequestStatus)[keyof typeof addPetRequestStatus]
+export type AddPetRequestStatus = (typeof AddPetRequestStatus)[keyof typeof AddPetRequestStatus]
 export type AddPetRequest = {
   /**
    * @type integer | undefined int64

--- a/examples/advanced/src/gen/models/ts/Order.ts
+++ b/examples/advanced/src/gen/models/ts/Order.ts
@@ -1,9 +1,9 @@
-export const orderStatus = {
+export const OrderStatus = {
   placed: 'placed',
   approved: 'approved',
   delivered: 'delivered',
 } as const
-export type OrderStatus = (typeof orderStatus)[keyof typeof orderStatus]
+export type OrderStatus = (typeof OrderStatus)[keyof typeof OrderStatus]
 export type Order = {
   /**
    * @type integer | undefined int64

--- a/examples/advanced/src/gen/models/ts/Pet.ts
+++ b/examples/advanced/src/gen/models/ts/Pet.ts
@@ -1,12 +1,12 @@
 import type { Category } from './Category'
 import type { Tag } from './Tag'
 
-export const petStatus = {
+export const PetStatus = {
   available: 'available',
   pending: 'pending',
   sold: 'sold',
 } as const
-export type PetStatus = (typeof petStatus)[keyof typeof petStatus]
+export type PetStatus = (typeof PetStatus)[keyof typeof PetStatus]
 export type Pet = {
   /**
    * @type integer | undefined int64

--- a/examples/advanced/src/gen/models/ts/petController/FindPetsByStatus.ts
+++ b/examples/advanced/src/gen/models/ts/petController/FindPetsByStatus.ts
@@ -5,12 +5,12 @@ import type { Pet } from '../Pet'
  */
 export type FindPetsByStatus400 = any | null
 
-export const findPetsByStatusQueryParamsStatus = {
+export const FindPetsByStatusQueryParamsStatus = {
   available: 'available',
   pending: 'pending',
   sold: 'sold',
 } as const
-export type FindPetsByStatusQueryParamsStatus = (typeof findPetsByStatusQueryParamsStatus)[keyof typeof findPetsByStatusQueryParamsStatus]
+export type FindPetsByStatusQueryParamsStatus = (typeof FindPetsByStatusQueryParamsStatus)[keyof typeof FindPetsByStatusQueryParamsStatus]
 export type FindPetsByStatusQueryParams = {
   /**
    * @type string | undefined

--- a/packages/swagger-ts/src/builders/TypeBuilder.ts
+++ b/packages/swagger-ts/src/builders/TypeBuilder.ts
@@ -15,7 +15,7 @@ type Config = {
   fileResolver?: FileResolver
   withJSDocs?: boolean
   withImports?: boolean
-  enumType: 'enum' | 'asConst'
+  enumType: 'enum' | 'asConst' | 'asPascalConst'
 }
 
 // TODO create another function that sort based on the refs(first the ones without refs)

--- a/packages/swagger-ts/src/generators/OperationGenerator.ts
+++ b/packages/swagger-ts/src/generators/OperationGenerator.ts
@@ -11,7 +11,7 @@ type Options = {
   resolvePath: PluginContext['resolvePath']
   resolveName: PluginContext['resolveName']
   mode: PathMode
-  enumType: 'enum' | 'asConst'
+  enumType: 'enum' | 'asConst' | 'asPascalConst'
 }
 
 export class OperationGenerator extends Generator<Options> {

--- a/packages/swagger-ts/src/generators/TypeGenerator.ts
+++ b/packages/swagger-ts/src/generators/TypeGenerator.ts
@@ -35,7 +35,7 @@ export type Refs = Record<string, { name: string; key: string; as?: string }>
 type Options = {
   withJSDocs?: boolean
   resolveName: PluginContext['resolveName']
-  enumType: 'enum' | 'asConst'
+  enumType: 'enum' | 'asConst' | 'asPascalConst'
 }
 export class TypeGenerator extends SchemaGenerator<Options, OpenAPIV3.SchemaObject, ts.Node[]> {
   // Collect the types of all referenced schemas so we can export them later

--- a/packages/swagger-ts/src/types.ts
+++ b/packages/swagger-ts/src/types.ts
@@ -28,7 +28,7 @@ export type Options = {
    * Choose to use `enum` or `as const` for enums
    * @default `asConst`
    */
-  enumType?: 'enum' | 'asConst'
+  enumType?: 'enum' | 'asConst' | 'asPascalConst'
 }
 
 export type ResolvePathOptions = { tag?: string }

--- a/packages/ts-codegen/src/codegen.ts
+++ b/packages/ts-codegen/src/codegen.ts
@@ -197,8 +197,14 @@ export function createEnumDeclaration({
   enums,
   type,
 }: {
-  type: 'enum' | 'asConst'
+  type: 'enum' | 'asConst' | 'asPascalConst'
+  /**
+   * Enum name in camelCase.
+   */
   name: string
+  /**
+   * Enum name in PascalCase.
+   */
   typeName: string
   enums: [key: string, value: string | number][]
 }) {
@@ -217,13 +223,16 @@ export function createEnumDeclaration({
     ]
   }
 
+  // used when using `as const` instead of an TypeScript enum.
+  const identifierName = type === 'asPascalConst' ? typeName : name
+
   return [
     factory.createVariableStatement(
       [factory.createToken(ts.SyntaxKind.ExportKeyword)],
       factory.createVariableDeclarationList(
         [
           factory.createVariableDeclaration(
-            factory.createIdentifier(name),
+            factory.createIdentifier(identifierName),
             undefined,
             undefined,
             factory.createAsExpression(
@@ -248,8 +257,8 @@ export function createEnumDeclaration({
       factory.createIdentifier(typeName),
       undefined,
       factory.createIndexedAccessTypeNode(
-        factory.createParenthesizedType(factory.createTypeQueryNode(factory.createIdentifier(name), undefined)),
-        factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, factory.createTypeQueryNode(factory.createIdentifier(name), undefined))
+        factory.createParenthesizedType(factory.createTypeQueryNode(factory.createIdentifier(identifierName), undefined)),
+        factory.createTypeOperatorNode(ts.SyntaxKind.KeyOfKeyword, factory.createTypeQueryNode(factory.createIdentifier(identifierName), undefined))
       )
     ),
   ]


### PR DESCRIPTION
`kubb.config.ts`

Added `asPascalConst` as new property for `enumType`. This will transform the name of the export to PascalCase instead of the default(`asConst`) that is using camelCase.


```typescript

import { defineConfig } from '@kubb/core'

export default defineConfig(() => {
  return {
    root: '.',
    input: {
      path: './petStore.yaml',
    },
    output: {
      path: './src/gen',
      clean: true,
    },
    hooks: {
      done: ['npx eslint --fix ./src/gen', 'pnpm typecheck'],
    },
    plugins: [
      ['@kubb/swagger', { output: false, validate: true }],
      [
        '@kubb/swagger-ts',
        {
          enumType: 'asPascalConst', // can be 'enum' | 'asConst' | 'asPascalConst'
        },
      ],
    ],
  }
})


```