### PR TITLE
Remove encoding on regex -> Issue on zod models

### DIFF
--- a/packages/swagger-zod/src/generators/ZodGenerator.ts
+++ b/packages/swagger-zod/src/generators/ZodGenerator.ts
@@ -99,7 +99,7 @@ export class ZodGenerator extends SchemaGenerator<Options, OpenAPIV3.SchemaObjec
           const isStartWithSlash = matches.startsWith('/')
           const isEndWithSlash = matches.endsWith('/')
 
-          const regexp = `new RegExp('${(matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined)}')`
+          const regexp = `new RegExp('${matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined)}')`
 
           validationFunctions.push({ keyword: zodKeywords.matches, args: regexp })
         }

--- a/packages/swagger-zod/src/generators/ZodGenerator.ts
+++ b/packages/swagger-zod/src/generators/ZodGenerator.ts
@@ -99,7 +99,7 @@ export class ZodGenerator extends SchemaGenerator<Options, OpenAPIV3.SchemaObjec
           const isStartWithSlash = matches.startsWith('/')
           const isEndWithSlash = matches.endsWith('/')
 
-          const regexp = `new RegExp('${escape(matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined))}')`
+          const regexp = `new RegExp('${(matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined)}')`
 
           validationFunctions.push({ keyword: zodKeywords.matches, args: regexp })
         }


### PR DESCRIPTION
Remove Escape 
- depreciated
- regex encoding is not required --> causes issues on Zod models

```
openapi: pattern: ^[a-zA-Z0-9.-]*$
zod: new RegExp('%5E%5Ba-zA-Z0-9.-%5D*%24')
```