### PR TITLE
fix: proper escape Regex for Zod

### DIFF
--- a/e2e/schemas/petStore.yaml
+++ b/e2e/schemas/petStore.yaml
@@ -733,6 +733,14 @@ components:
         name:
           type: string
           example: doggie
+        log:
+          type: string
+          maxLength: 42
+          minLength: 2
+          pattern: >-
+            ^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_.
+            \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$
+          example: my_log_destination
         category:
           $ref: '#/components/schemas/Category'
         photoUrls:

--- a/packages/core/src/utils/transformers/escape.test.ts
+++ b/packages/core/src/utils/transformers/escape.test.ts
@@ -1,0 +1,21 @@
+import { escape, jsStringEscape } from './escape.ts'
+
+describe('escape', () => {
+  test('return escape text', () => {
+    expect(escape()).toBe('')
+    expect(escape('`test')).toBe('\\`test')
+  })
+
+  test('return jsStringEscape text', () => {
+    expect(jsStringEscape('"Hello World!"')).toBe('\\"Hello World!\\"')
+    expect(jsStringEscape(null)).toBe('null')
+    expect(jsStringEscape(undefined)).toBe('undefined')
+    expect(jsStringEscape(false)).toBe('false')
+    expect(jsStringEscape(0.0)).toBe('0')
+    expect(jsStringEscape({})).toBe('[object Object]')
+    expect(jsStringEscape('')).toBe('')
+
+    expect(globalThis.escape('^[a-zA-Z0-9.-]*$')).not.toBe('^[a-zA-Z0-9.-]*$')
+    expect(jsStringEscape('^[a-zA-Z0-9.-]*$')).toBe('^[a-zA-Z0-9.-]*$')
+  })
+})

--- a/packages/core/src/utils/transformers/escape.ts
+++ b/packages/core/src/utils/transformers/escape.ts
@@ -1,0 +1,31 @@
+export function escape(text?: string): string {
+  return text ? text.replaceAll('`', '\\`') : ''
+}
+
+/**
+ * Escape all characters not included in SingleStringCharacters and DoubleStringCharacters on
+ * @link http://www.ecma-international.org/ecma-262/5.1/#sec-7.8.4
+ * @link https://github.com/joliss/js-string-escape/blob/master/index.js
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function jsStringEscape(input: any): string {
+  return `${input}`.replace(/["'\\\n\r\u2028\u2029]/g, (character) => {
+    switch (character) {
+      case '"':
+      case "'":
+      case '\\':
+        return '\\' + character
+      // Four possible LineTerminator characters need to be escaped:
+      case '\n':
+        return '\\n'
+      case '\r':
+        return '\\r'
+      case '\u2028':
+        return '\\u2028'
+      case '\u2029':
+        return '\\u2029'
+      default:
+        return ''
+    }
+  })
+}

--- a/packages/core/src/utils/transformers/getEncodedText.test.ts
+++ b/packages/core/src/utils/transformers/getEncodedText.test.ts
@@ -1,8 +1,0 @@
-import { getEncodedText } from './getEncodedText.ts'
-
-describe('getEncodedText', () => {
-  test('return encoded text', () => {
-    expect(getEncodedText()).toBe('')
-    expect(getEncodedText('`test')).toBe('\\`test')
-  })
-})

--- a/packages/core/src/utils/transformers/getEncodedText.ts
+++ b/packages/core/src/utils/transformers/getEncodedText.ts
@@ -1,3 +1,0 @@
-export function getEncodedText(text?: string): string {
-  return text ? text.replaceAll('`', '\\`') : ''
-}

--- a/packages/core/src/utils/transformers/index.ts
+++ b/packages/core/src/utils/transformers/index.ts
@@ -1,3 +1,3 @@
-export * from './getEncodedText.ts'
+export * from './escape.ts'
 export * from './transformReservedWord.ts'
 export * from './combineCodes.ts'

--- a/packages/swagger-zod/src/generators/ZodGenerator.ts
+++ b/packages/swagger-zod/src/generators/ZodGenerator.ts
@@ -1,4 +1,4 @@
-import { getUniqueName, SchemaGenerator } from '@kubb/core'
+import { getUniqueName, SchemaGenerator, jsStringEscape } from '@kubb/core'
 import { isReference } from '@kubb/swagger'
 
 import { zodKeywords, zodParser } from '../parsers/index.ts'
@@ -99,7 +99,7 @@ export class ZodGenerator extends SchemaGenerator<Options, OpenAPIV3.SchemaObjec
           const isStartWithSlash = matches.startsWith('/')
           const isEndWithSlash = matches.endsWith('/')
 
-          const regexp = `new RegExp('${escape(matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined))}')`
+          const regexp = `new RegExp('${jsStringEscape(matches.slice(isStartWithSlash ? 1 : 0, isEndWithSlash ? -1 : undefined))}')`
 
           validationFunctions.push({ keyword: zodKeywords.matches, args: regexp })
         }

--- a/packages/swagger-zodios/src/generators/OperationGenerator.ts
+++ b/packages/swagger-zodios/src/generators/OperationGenerator.ts
@@ -1,4 +1,4 @@
-import { getEncodedText, getRelativePath, URLPath } from '@kubb/core'
+import { escape, getRelativePath, URLPath } from '@kubb/core'
 import { OperationGenerator as Generator } from '@kubb/swagger'
 import { pluginName as swaggerZodPluginName } from '@kubb/swagger-zod'
 
@@ -183,7 +183,7 @@ export class OperationGenerator extends Generator<Options> {
         parameters.push(`
           {
             name: "${schemas.pathParams.name}",
-            description: \`${getEncodedText(schemas.pathParams.description)}\`,
+            description: \`${escape(schemas.pathParams.description)}\`,
             type: "Path",
             schema: ${pathParams.name}
           }
@@ -201,7 +201,7 @@ export class OperationGenerator extends Generator<Options> {
         parameters.push(`
           {
             name: "${schemas.queryParams.name}",
-            description: \`${getEncodedText(schemas.queryParams.description)}\`,
+            description: \`${escape(schemas.queryParams.description)}\`,
             type: "Query",
             schema: ${queryParams.name}
           }
@@ -224,7 +224,7 @@ export class OperationGenerator extends Generator<Options> {
             errors.push(`
               {
                 status: ${errorOperationSchema.statusCode},
-                description: \`${getEncodedText(errorOperationSchema.description)}\`,
+                description: \`${escape(errorOperationSchema.description)}\`,
                 schema: ${name}
               }
             `)
@@ -236,7 +236,7 @@ export class OperationGenerator extends Generator<Options> {
         {
           method: "${operation.method}",
           path: "${new URLPath(operation.path).URL}",
-          description: \`${getEncodedText(operation.getDescription())}\`,
+          description: \`${escape(operation.getDescription())}\`,
           requestFormat: "json",
           parameters: [
               ${parameters.join(',')}


### PR DESCRIPTION
Schema
```yaml
Pet:
  log:
    type: string
    maxLength: 42
    minLength: 2
    pattern: >-
      ^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_.
      \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$
    example: my_log_destination
```

### Before with `globalThis.escape`
```typescript
export const petSchema = z.object({
  log: z.string().min(2).max(42).regex(new RegExp('%5E%5BA-Za-z0-9%28%29%5C%5B%5C%5D%27%22%5D%5B-A-Za-z0-9_.%20%5C/%28%29%5C%5B%5C%5D%5D%7B0%2C40%7D%5BA-Za-z0-9%28%29%5C%5B%5C%5D%27%22%5D%24')).optional()
})

expect(new RegExp('%5E%5BA-Za-z0-9%28%29%5C%5B%5C%5D%27%22%5D%5B-A-Za-z0-9_.%20%5C/%28%29%5C%5B%5C%5D%5D%7B0%2C40%7D%5BA-Za-z0-9%28%29%5C%5B%5C%5D%27%22%5D%24')).test('my_log_destination')).toBeTruthy()
// ^? false
```

### Without `globalThis.escape`
```typescript
export const petSchema = z.object({
  log: z.string().min(2).max(42).regex(new RegExp('^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$')).optional()
})

expect(new RegExp('^[A-Za-z0-9()\[\]'"][-A-Za-z0-9_. \/()\[\]]{0,40}[A-Za-z0-9()\[\]'"]$').test('my_log_destination')).toBeTruthy()
// ^? false + invalid js
```

### After with `jsStringEscape`
```typescript
export const petSchema = z.object({
  log: z.string().min(2).max(42).regex(new RegExp('^[A-Za-z0-9()\\[\\]\'"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]\'"]$')).optional()
})

expect(new RegExp('^[A-Za-z0-9()\\[\\]\'"][-A-Za-z0-9_. \\/()\\[\\]]{0,40}[A-Za-z0-9()\\[\\]\'"]$').test('my_log_destination')).toBeTruthy()
// ^? true
```
