### PR TITLE
fix: include `react` and `react-reconciler` in the bundle

### DIFF
--- a/packages/react-template/package.json
+++ b/packages/react-template/package.json
@@ -58,6 +58,7 @@
     "@kubb/core": "workspace:*",
     "@kubb/ts-codegen": "workspace:*",
     "auto-bind": "^4.0.0",
+    "react": "^18.2.0",
     "react-reconciler": "^0.29.0"
   },
   "devDependencies": {
@@ -68,22 +69,7 @@
     "@types/react": ">=18.2.27",
     "@types/react-reconciler": "^0.28.5",
     "eslint": "^8.51.0",
-    "react": "^18.2.0",
-    "react-devtools-core": "^4.28.4",
     "tsup": "^7.2.0"
-  },
-  "peerDependencies": {
-    "@types/react": ">=17.0.0",
-    "react": ">=17.0.0",
-    "react-devtools-core": "^4.19.1"
-  },
-  "peerDependenciesMeta": {
-    "@types/react": {
-      "optional": true
-    },
-    "react-devtools-core": {
-      "optional": true
-    }
   },
   "packageManager": "pnpm@8.3.0",
   "engines": {

--- a/packages/react-template/tsup.config.ts
+++ b/packages/react-template/tsup.config.ts
@@ -2,4 +2,7 @@ import { optionsCJS, optionsESM } from '@kubb/tsup-config'
 
 import { defineConfig } from 'tsup'
 
-export default defineConfig([optionsCJS, optionsESM])
+export default defineConfig([
+  { ...optionsCJS, noExternal: [/react-reconcile/, /react/, /react\/jsx-runtime/] },
+  { ...optionsESM, noExternal: [/react-reconcile/, /react/, /react\/jsx-runtime/] },
+])

--- a/packages/swagger-client/tsup.config.ts
+++ b/packages/swagger-client/tsup.config.ts
@@ -3,8 +3,8 @@ import { optionsCJS, optionsESM } from '@kubb/tsup-config'
 import { defineConfig } from 'tsup'
 
 export default defineConfig([
-  optionsCJS,
-  optionsESM,
+  { ...optionsCJS, noExternal: [/react-reconcile/, /react/, /react\/jsx-runtime/] },
+  { ...optionsESM, noExternal: [/react-reconcile/, /react/, /react\/jsx-runtime/] },
   {
     ...optionsCJS,
     entry: ['./client.ts'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -957,6 +957,9 @@ importers:
       auto-bind:
         specifier: ^4.0.0
         version: 4.0.0
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
       react-reconciler:
         specifier: ^0.29.0
         version: 0.29.0(react@18.2.0)
@@ -979,12 +982,6 @@ importers:
       eslint:
         specifier: ^8.51.0
         version: 8.51.0
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-devtools-core:
-        specifier: ^4.28.4
-        version: 4.28.4
       tsup:
         specifier: ^7.2.0
         version: 7.2.0(@swc/core@1.3.82)(ts-node@10.9.1)(typescript@5.2.2)
@@ -5864,6 +5861,7 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: false
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
@@ -6650,16 +6648,6 @@ packages:
       unpipe: 1.0.0
     dev: false
 
-  /react-devtools-core@4.28.4:
-    resolution: {integrity: sha512-IUZKLv3CimeM07G3vX4H4loxVpByrzq3HvfTX7v9migalwvLs9ZY5D3S3pKR33U+GguYfBBdMMZyToFhsSE/iQ==}
-    dependencies:
-      shell-quote: 1.8.1
-      ws: 7.5.9
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: true
-
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -6698,6 +6686,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
+    dev: false
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -6983,10 +6972,6 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-
-  /shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-    dev: true
 
   /shiki@0.14.4:
     resolution: {integrity: sha512-IXCRip2IQzKwxArNNq1S+On4KPML3Yyn8Zzs/xRgcgOWIr8ntIK3IKzjFPfjy/7kt9ZMjc+FItfqHRBg8b6tNQ==}
@@ -8205,19 +8190,6 @@ packages:
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  /ws@7.5.9:
-    resolution: {integrity: sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-    dev: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}


### PR DESCRIPTION
No impact on peerDependencies but increase in bundleSize