### PR TITLE
docs: escape curly braces

### DIFF
--- a/docs/plugins/swagger-client/index.md
+++ b/docs/plugins/swagger-client/index.md
@@ -50,18 +50,26 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped clients.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `clients/\{\{tag\}\}Controller` => `clients/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `clients/{{tag}}Controller` => `clients/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+::: v-pre
+Name to be used for the `export * as {{exportAs}} from './`
+:::
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}Service"`
+Default: `"{{tag}}Service"`
+:::
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.

--- a/docs/plugins/swagger-client/index.md
+++ b/docs/plugins/swagger-client/index.md
@@ -12,19 +12,19 @@ With the Swagger client plugin you can create [Axios](https://axios-http.com/doc
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-client
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-client
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-client
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-client
 ```
 
@@ -51,17 +51,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped clients.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `clients/{{tag}}Controller` => `clients/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `clients/\{\{tag\}\}Controller` => `clients/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}Service"`
+Default: `"\{\{tag\}\}Service"`
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.

--- a/docs/plugins/swagger-faker.md
+++ b/docs/plugins/swagger-faker.md
@@ -51,18 +51,24 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped Faker mocks.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `mocks/\{\{tag\}\}Controller` => `mocks/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `mocks/{{tag}}Controller` => `mocks/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+Name to be used for the `export * as {{exportAs}} from './`
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}Mocks"`
+Default: `"{{tag}}Mocks"`
+:::
 
 ### skipBy
 Array containing skipBy paramaters to exclude/skip tags/operations/methods/paths.

--- a/docs/plugins/swagger-faker.md
+++ b/docs/plugins/swagger-faker.md
@@ -12,19 +12,19 @@ With the Swagger Faker plugin you can use [Faker](https://fakerjs.dev/) to creat
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-faker
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-faker
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-faker
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-faker
 ```
 
@@ -52,17 +52,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped Faker mocks.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `mocks/{{tag}}Controller` => `mocks/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `mocks/\{\{tag\}\}Controller` => `mocks/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}Mocks"`
+Default: `"\{\{tag\}\}Mocks"`
 
 ### skipBy
 Array containing skipBy paramaters to exclude/skip tags/operations/methods/paths.

--- a/docs/plugins/swagger-msw.md
+++ b/docs/plugins/swagger-msw.md
@@ -51,18 +51,24 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped MSW mocks.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `mocks/\{\{tag\}\}Controller` => `mocks/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `mocks/{{tag}}Controller` => `mocks/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+Name to be used for the `export * as {{exportAs}} from './`
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}Handlers"`
+Default: `"{{tag}}Handlers"`
+:::
 
 ### skipBy
 Array containing skipBy paramaters to exclude/skip tags/operations/methods/paths.

--- a/docs/plugins/swagger-msw.md
+++ b/docs/plugins/swagger-msw.md
@@ -12,19 +12,19 @@ With the MSW plugin you can use [MSW](https://mswjs.io/) to create API mocks bas
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-msw
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-msw
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-msw
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-msw
 ```
 
@@ -52,17 +52,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped MSW mocks.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `mocks/{{tag}}Controller` => `mocks/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `mocks/\{\{tag\}\}Controller` => `mocks/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}Handlers"`
+Default: `"\{\{tag\}\}Handlers"`
 
 ### skipBy
 Array containing skipBy paramaters to exclude/skip tags/operations/methods/paths.

--- a/docs/plugins/swagger-swr.md
+++ b/docs/plugins/swagger-swr.md
@@ -12,19 +12,19 @@ With the Swagger SWR plugin you can create [SWR hooks](https://swr.vercel.app/) 
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-swr
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-swr
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-swr
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-swr
 ```
 
@@ -50,17 +50,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped SWR hooks.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `hooks/{{tag}}Controller` => `hooks/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `hooks/\{\{tag\}\}Controller` => `hooks/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}SWRHooks"`
+Default: `"\{\{tag\}\}SWRHooks"`
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.

--- a/docs/plugins/swagger-swr.md
+++ b/docs/plugins/swagger-swr.md
@@ -49,18 +49,26 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped SWR hooks.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `hooks/\{\{tag\}\}Controller` => `hooks/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `hooks/{{tag}}Controller` => `hooks/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+::: v-pre
+Name to be used for the `export * as {{exportAs}} from './`
+:::
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}SWRHooks"`
+Default: `"{{tag}}SWRHooks"`
+:::
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.

--- a/docs/plugins/swagger-tanstack-query.md
+++ b/docs/plugins/swagger-tanstack-query.md
@@ -55,18 +55,26 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped @tanstack/query hooks.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `hooks/\{\{tag\}\}Controller` => `hooks/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `hooks/{{tag}}Controller` => `hooks/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+::: v-pre
+Name to be used for the `export * as {{exportAs}} from './`
+:::
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}Hooks"`
+Default: `"{{tag}}Hooks"`
+:::
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.

--- a/docs/plugins/swagger-tanstack-query.md
+++ b/docs/plugins/swagger-tanstack-query.md
@@ -8,7 +8,7 @@ outline: deep
 
 # @kubb/swagger-tanstack-query
 
-With the Swagger Tanstack Query plugin you can create: 
+With the Swagger Tanstack Query plugin you can create:
 - [react-query](https://tanstack.com/query/latest/docs/react) hooks based on an operation in the Swagger file.
 - [solid-query](https://tanstack.com/query/latest/docs/solid) primitives based on an operation in the Swagger file.
 - [svelte-query](https://tanstack.com/query/latest/docs/svelte) primitives based on an operation in the Swagger file.
@@ -18,19 +18,19 @@ With the Swagger Tanstack Query plugin you can create:
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-tanstack-query
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-tanstack-query
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-tanstack-query
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-tanstack-query
 ```
 
@@ -56,17 +56,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped @tanstack/query hooks.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `hooks/{{tag}}Controller` => `hooks/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `hooks/\{\{tag\}\}Controller` => `hooks/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}Hooks"`
+Default: `"\{\{tag\}\}Hooks"`
 
 ### client <Badge type="danger" text="deprecated" />
 Path to the client that will be used to do the API calls.
@@ -102,7 +102,7 @@ Type: `'react' | 'solid' | 'svelte' | 'vue'` <br/>
 Default: `"react"`
 
 ### infinite
-When set, an infiniteQuery is getting created, example: 
+When set, an infiniteQuery is getting created, example:
 ```typescript
 {
     output: './clients/hooks',

--- a/docs/plugins/swagger-ts.md
+++ b/docs/plugins/swagger-ts.md
@@ -49,12 +49,16 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped TypeScript Types.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `models/\{\{tag\}\}Controller` => `models/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `models/{{tag}}Controller` => `models/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 ### enumType
 Choose to use `enum` or `as const` for enums. <br/>

--- a/docs/plugins/swagger-ts.md
+++ b/docs/plugins/swagger-ts.md
@@ -12,19 +12,19 @@ With the Swagger TypeScript plugin you can create [TypeScript](https://www.types
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-ts
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-ts
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-ts
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-ts
 ```
 
@@ -50,11 +50,11 @@ Required: `true`
 
 #### output
 Relative path to save the grouped TypeScript Types.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `models/{{tag}}Controller` => `models/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `models/\{\{tag\}\}Controller` => `models/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 ### enumType
 Choose to use `enum` or `as const` for enums. <br/>
@@ -74,7 +74,7 @@ date: string
 ```
 
 ```typescript ['date']
-date: Date 
+date: Date
 ```
 :::
 

--- a/docs/plugins/swagger-zod.md
+++ b/docs/plugins/swagger-zod.md
@@ -12,19 +12,19 @@ With the Swagger Zod plugin you can use [Zod](https://zod.dev/) to validate your
 
 ::: code-group
 
-```shell [bun <img src="/feature/bun.svg"/>] 
+```shell [bun <img src="/feature/bun.svg"/>]
 bun add @kubb/swagger-zod
 ```
 
-```shell [pnpm <img src="/feature/pnpm.svg"/>] 
+```shell [pnpm <img src="/feature/pnpm.svg"/>]
 pnpm add @kubb/swagger-zod
 ```
 
-```shell [npm <img src="/feature/npm.svg"/>] 
+```shell [npm <img src="/feature/npm.svg"/>]
 npm install @kubb/swagger-zod
 ```
 
-```shell [yarn <img src="/feature/yarn.svg"/>] 
+```shell [yarn <img src="/feature/yarn.svg"/>]
 yarn add @kubb/swagger-zod
 ```
 
@@ -51,17 +51,17 @@ Required: `true`
 
 #### output
 Relative path to save the grouped Zod schemas.
-`{{tag}}` will be replaced by the current tagName.
+`\{\{tag\}\}` will be replaced by the current tagName.
 
 Type: `string` <br/>
-Example: `zod/{{tag}}Controller` => `zod/PetController` <br/>
-Default: `${output}/{{tag}}Controller`
+Example: `zod/\{\{tag\}\}Controller` => `zod/PetController` <br/>
+Default: `${output}/\{\{tag\}\}Controller`
 
 #### exportAs
-Name to be used for the `export * as {{exportAs}} from './`
+Name to be used for the `export * as \{\{exportAs\}\} from './`
 
 Type: `string` <br/>
-Default: `"{{tag}}Schemas"`
+Default: `"\{\{tag\}\}Schemas"`
 
 
 ### skipBy

--- a/docs/plugins/swagger-zod.md
+++ b/docs/plugins/swagger-zod.md
@@ -50,19 +50,26 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### output
+::: v-pre
 Relative path to save the grouped Zod schemas.
-`\{\{tag\}\}` will be replaced by the current tagName.
+`{{tag}}` will be replaced by the current tagName.
+:::
 
+::: v-pre
 Type: `string` <br/>
-Example: `zod/\{\{tag\}\}Controller` => `zod/PetController` <br/>
-Default: `${output}/\{\{tag\}\}Controller`
+Example: `zod/{{tag}}Controller` => `zod/PetController` <br/>
+Default: `${output}/{{tag}}Controller`
+:::
 
 #### exportAs
-Name to be used for the `export * as \{\{exportAs\}\} from './`
+::: v-pre
+Name to be used for the `export * as {{exportAs}} from './`
+:::
 
+::: v-pre
 Type: `string` <br/>
-Default: `"\{\{tag\}\}Schemas"`
-
+Default: `"{{tag}}Schemas"`
+:::
 
 ### skipBy
 Array containing skipBy paramaters to exclude/skip tags/operations/methods/paths.


### PR DESCRIPTION
noticed that some curly braces were causing blank text in the docs. i haven't tested this (apologies), but i assume escaping them should fix