### PR TITLE
chore(swagger-client): copy client.ts only when the client options is provided

### DIFF
--- a/packages/swagger-client/src/builders/ClientBuilder.tsx
+++ b/packages/swagger-client/src/builders/ClientBuilder.tsx
@@ -106,7 +106,11 @@ export class ClientBuilder extends OasBuilder<Options> {
       const file = useResolve({ pluginName, type: 'file' })
       const fileType = useResolveType({ type: 'file' })
 
-      const resolvedClientPath = clientImportPath ? clientImportPath : clientPath ? getRelativePath(file.path, clientPath) : '@kubb/swagger-client/client'
+      const resolvedClientPath = clientImportPath
+        ? clientImportPath
+        : clientPath
+          ? getRelativePath(file.path, clientPath)
+          : '@kubb/swagger-client/client'
 
       return (
         <File baseName={file.baseName} path={file.path}>

--- a/packages/swagger-client/src/plugin.ts
+++ b/packages/swagger-client/src/plugin.ts
@@ -20,10 +20,12 @@ export const definePlugin = createPlugin<PluginOptions>((options) => {
     skipBy = [],
     overrideBy = [],
     transformers = {},
+    client,
     clientImportPath,
     dataReturnType = 'data',
     pathParamsType = 'inline',
   } = options
+
   const template = groupBy?.output ? groupBy.output : `${output}/{{tag}}Controller`
   let pluginsOptions: [SwaggerPluginOptions]
 
@@ -66,7 +68,7 @@ export const definePlugin = createPlugin<PluginOptions>((options) => {
 
       const oas = await swaggerPlugin.api.getOas()
       const root = pathParser.resolve(this.config.root, this.config.output.path)
-      const clientPath = pathParser.resolve(root, 'client.ts')
+      const clientPath = client ? pathParser.resolve(root, 'client.ts') : undefined
 
       const operationGenerator = new OperationGenerator(
         {
@@ -122,10 +124,9 @@ export const definePlugin = createPlugin<PluginOptions>((options) => {
         await this.addFile(...rootFiles)
       }
 
-      // copy `client.ts`
-      const clientPath = pathParser.resolve(root, 'client.ts')
-
-      if (clientPath) {
+      // Copy `client.ts` file only when the 'client' option is provided.
+      if (client) {
+        const clientPath = pathParser.resolve(root, 'client.ts')
         const originalClientPath: KubbFile.OptionalPath = options.client
           ? pathParser.resolve(this.config.root, options.client)
           : getLocation('@kubb/swagger-client/ts-client', process.cwd())


### PR DESCRIPTION
- With the `clientImportPath` option coming in, copying the client.ts file is only necessary when using the `client` option, so I modified the conditional statement.
- The existing clientPath was a string type, so the check was unnecessary.