### PR TITLE
feat: add support nullable to faker

### DIFF
--- a/packages/swagger-faker/src/parsers/fakerParser.test.ts
+++ b/packages/swagger-faker/src/parsers/fakerParser.test.ts
@@ -136,15 +136,11 @@ const input = [
         address: [{ keyword: 'string' }, { keyword: 'null' }],
       },
     }),
-    expected: '{"firstName": faker.string.alpha({"min":2}),"address": faker.string.alpha()null}',
+    expected: '{"firstName": faker.string.alpha({"min":2}),"address": faker.helpers.arrayElement([faker.string.alpha(),null])}',
   },
 ]
 
-describe('parseZod', () => {
-  // test.each(input)('.add($a, $b)', ({ input, expected }) => {
-  //   expect(input).toBe(expected)
-  // })
-
+describe('parseFaker', () => {
   test('parsing each input', () => {
     // TODO replace by test.each when Bun has support for test.each
     input.forEach((item) => {

--- a/packages/swagger-faker/src/parsers/fakerParser.ts
+++ b/packages/swagger-faker/src/parsers/fakerParser.ts
@@ -146,6 +146,17 @@ function fakerKeywordSorter(a: FakerMeta, b: FakerMeta) {
   return 0
 }
 
+function joinItems(items: string[]): string {
+  switch (items.length) {
+    case 0:
+      return 'undefined';
+    case 1:
+      return items[0]!;
+    default:
+      return `${fakerKeywordMapper.union}([${items.join(',')}])`
+  }
+}
+
 export function parseFakerMeta(item: FakerMeta, mapper: Record<FakerKeyword, string> = fakerKeywordMapper): string {
   // eslint-disable-next-line prefer-const
   let { keyword, args } = (item || {}) as FakerMetaBase<unknown>
@@ -184,10 +195,11 @@ export function parseFakerMeta(item: FakerMeta, mapper: Record<FakerKeyword, str
         const name = item[0]
         const schema = item[1] as FakerMeta[]
         return `"${name}": ${
-          schema
-            .sort(fakerKeywordSorter)
-            .map((item) => parseFakerMeta(item, mapper))
-            .join('')
+          joinItems(
+            schema
+              .sort(fakerKeywordSorter)
+              .map((item) => parseFakerMeta(item, mapper))
+          )
         }`
       })
       .join(',')
@@ -213,17 +225,13 @@ export function parseFakerMeta(item: FakerMeta, mapper: Record<FakerKeyword, str
 }
 
 export function fakerParser(items: FakerMeta[], options: { mapper?: Record<FakerKeyword, string>; name: string; typeName?: string | null }): string {
-  if (!items.length) {
-    return `
-export function ${options.name}()${options.typeName ? `: NonNullable<${options.typeName}>` : ''} {
-  return undefined;
-}
-`
-  }
-
   return `
 export function ${options.name}()${options.typeName ? `: NonNullable<${options.typeName}>` : ''} {
-  return ${items.map((item) => parseFakerMeta(item, { ...fakerKeywordMapper, ...options.mapper })).join('')};
+  return ${
+    joinItems(
+      items.map((item) => parseFakerMeta(item, { ...fakerKeywordMapper, ...options.mapper }))
+    )
+  };
 }
   `
 }


### PR DESCRIPTION
OpenAPI schema with "nullable: true" generates incorrect js code like faker.string.alpha()null with @kubb/swagger-faker
It change it to something like faker.helpers.arrayElement([faker.string.alpha(),null])