### PR TITLE
chore(swagger-zodios): export endpoints too

### DIFF
--- a/packages/swagger-zodios/src/components/Definitions.tsx
+++ b/packages/swagger-zodios/src/components/Definitions.tsx
@@ -27,7 +27,8 @@ function Template({
 }: TemplateProps): ReactNode {
   return (
     <>
-      {`const endpoints = makeApi([${definitions.join(',')}])`}
+      {`export const endpoints = makeApi([${definitions.join(',')}])`}
+      {`export const getAPI = (baseUrl: string) => new Zodios(baseUrl, endpoints)`}
       {baseURL && `export const ${name} = new Zodios('${baseURL}', endpoints)`}
       {!baseURL && `export const  ${name} = new Zodios(endpoints)`}
       {`export default ${name}`}


### PR DESCRIPTION
Sometimes it is necessary to use a dynamic baseUrl in a single build.

In this case, it is necessary to create a `Zodios` instance externally, as shown in the example code below, and therefore it is necessary to export the necessary endpoints.

```ts
import { Zodios } from "@zodios/core";
import { endpoints } from '@generated-api/zodios'

const API_SERVER_URL = process.env.API_SERVER_URL
const myAPI = new Zodios(API_SERVER_URL, endpoints)
```

I also added getAPI, which allows you to create an API instance without endpoints import.

```ts
import { getAPI } from '@generated-api/zodios'

const myAPI = getAPI(process.env.API_SERVER_URL)
```
