### PR TITLE
chore(swagger-zod): add newline into generated zod schema

### DIFF
--- a/packages/swagger-zod/src/zodParser.ts
+++ b/packages/swagger-zod/src/zodParser.ts
@@ -171,7 +171,7 @@ function zodKeywordSorter(a: ZodMeta, b: ZodMeta): 1 | -1 | 0 {
   return 0
 }
 
-export function parseZodMeta(item: ZodMeta, mapper: Record<ZodKeyword, string> = zodKeywordMapper): string {
+export function parseZodMeta(item: ZodMeta, mapper: Record<ZodKeyword, string> = zodKeywordMapper, indentLevel = 1): string {
   // eslint-disable-next-line prefer-const
   let { keyword, args = '' } = (item || {}) as ZodMetaBase<unknown>
   const value = mapper[keyword]
@@ -217,6 +217,8 @@ export function parseZodMeta(item: ZodMeta, mapper: Record<ZodKeyword, string> =
     if (!args) {
       args = '{}'
     }
+
+    const indent = '    '
     const argsObject = Object.entries(args as ZodMeta)
       .filter((item) => {
         const schema = item[1] as ZodMeta[]
@@ -225,16 +227,16 @@ export function parseZodMeta(item: ZodMeta, mapper: Record<ZodKeyword, string> =
       .map((item) => {
         const name = item[0]
         const schema = item[1] as ZodMeta[]
-        return `"${name}": ${
+        return `${indent.repeat(indentLevel)}"${name}": ${
           schema
             .sort(zodKeywordSorter)
-            .map((item) => parseZodMeta(item, mapper))
+            .map((item) => parseZodMeta(item, mapper, indentLevel + 1))
             .join('')
         }`
       })
-      .join(',')
+      .join(',\n')
 
-    args = `{${argsObject}}`
+    args = `{\n${argsObject}\n${indent.repeat(indentLevel - 1)}}`
   }
 
   // custom type


### PR DESCRIPTION
There are many times when I need to refer to the zod schema, but the existing generated code was written in one line and was not good. So, I added a newline to improve readability.

Before:

```ts
export const componentCreateProjectRequestSchema = z.object({"email": z.string(),"project": z.object({"channel": z.string().optional(),"member_ids": z.array(z.string()).optional(),"department": z.string(),"description": z.string().optional(),"name": z.string(),"type": z.string().optional()})});
```

After:

```ts
export const createProjectRequestSchema = z.object({
    "email": z.string(),
    "project": z.object({
        "channel": z.string().optional(),
        "member_ids": z.array(z.string()).optional(),
        "department": z.string(),
        "description": z.string().optional(),
        "name": z.string(),
        "type": z.string().optional()
    })
});
```