### PR TITLE
`format` attribute overrules `type` attribute in certain cases

### DIFF
--- a/packages/swagger-ts/mocks/type_assertions.yaml
+++ b/packages/swagger-ts/mocks/type_assertions.yaml
@@ -1,0 +1,51 @@
+components:
+  schemas:
+    Body_upload_file_api_assets_post:
+      properties:
+        file:
+          format: binary
+          title: File
+          type: string
+      required:
+      - file
+      title: Body_upload_file_api_assets_post
+      type: object
+      $comment: |
+        export type BodyUploadFileApiAssetsPost = {
+            /**
+            * @type string binary
+            */
+            file: Blob;
+        };
+    Plain_file:
+      format: binary
+      title: File
+      type: string
+      $comment: export type PlainFile = Blob;
+    Plain_date:
+      format: date
+      title: Date
+      type: string
+      $comment: export type PlainDate = Date;
+    Plain_time:
+      format: time
+      title: Time
+      type: number
+      $comment: export type PlainTime = number;
+    Plain_date_time:
+      format: date-time
+      title: Datetime
+      type: string
+      $comment: 
+    Plain_email:
+      format: email
+      title: Email
+      type: string
+    Plain_uuid:
+      format: uuid
+      title: UUID
+      type: string
+info:
+  title: Type Assertions
+openapi: 3.1.0
+paths: {}

--- a/packages/swagger-ts/src/TypeGenerator.test.ts
+++ b/packages/swagger-ts/src/TypeGenerator.test.ts
@@ -439,3 +439,77 @@ describe('TypeGenerator enums', async () => {
     expect(await format(output)).toMatchSnapshot()
   })
 })
+
+describe('TypeGenerator type assertions', async ()=> {
+  const schemaPath = path.resolve(__dirname, '../mocks/type_assertions.yaml')
+  const oas = await new OasManager().parse(schemaPath)
+  const generator = new TypeGenerator({
+    usedEnumNames: {},
+    enumType: 'asConst',
+    dateType: 'string',
+    optionalType: 'questionToken',
+    transformers: {},
+    oasType: false,
+  }, {
+    oas,
+    pluginManager: mockedPluginManager,
+  })
+
+
+  const schemas = oas.getDefinition().components?.schemas
+
+  test('generates file property with `File` type', async () => {
+    const node = generator.build({ schema: schemas?.Body_upload_file_api_assets_post as OasTypes.SchemaObject, baseName: 'Body_upload_file_api_assets_post' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates Plain_File types correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_file as OasTypes.SchemaObject, baseName: 'Plain_file' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+  
+  test('generates Date type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_date as OasTypes.SchemaObject, baseName: 'Plain_date' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+  
+  test('generates Time type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_time as OasTypes.SchemaObject, baseName: 'Plain_time' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates Email type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_email as OasTypes.SchemaObject, baseName: 'Plain_email' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates UUID type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_uuid as OasTypes.SchemaObject, baseName: 'Plain_uuid' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+})

--- a/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
+++ b/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
@@ -221,3 +221,38 @@ exports[`TypeGenerator petStoreRef > generate type for Pets 1`] = `
 "export type Pets = Pet[]
 "
 `;
+
+exports[`TypeGenerator type assertions > generates Date type correctly 1`] = `
+"export type PlainDate = Date;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Email type correctly 1`] = `
+"export type PlainEmail = string;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Plain_File types correctly 1`] = `
+"export type PlainFile = Blob;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Time type correctly 1`] = `
+"export type PlainTime = number;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates UUID type correctly 1`] = `
+"export type PlainUuid = string;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates file property with \`File\` type 1`] = `
+"export type BodyUploadFileApiAssetsPost = {
+    /**
+     * @type string binary
+    */
+    file: Blob;
+};
+"
+`;


### PR DESCRIPTION
This originated in the observation that  a plain file upload leads to a 

```yaml
    Plain_file:
      format: binary
      title: File
      type: string
```

```
export type PlainFile = string;
```
although a "Blob" would be more helpful in my case.