### PR TITLE
fix: initialPageParam with type unknown to support string, number, ...

### DIFF
--- a/.changeset/ten-windows-joke.md
+++ b/.changeset/ten-windows-joke.md
@@ -1,0 +1,5 @@
+---
+"@kubb/swagger-tanstack-query": patch
+---
+
+initialPageParam with type unknown to support string, number, ...

--- a/docs/plugins/swagger-tanstack-query/index.md
+++ b/docs/plugins/swagger-tanstack-query/index.md
@@ -489,7 +489,7 @@ type Infinite = {
    * The initial value, the value of the first page.
    * @default `0`
    */
-  initialPageParam: number
+  initialPageParam: unknown
 }
 ```
 

--- a/packages/swagger-tanstack-query/src/types.ts
+++ b/packages/swagger-tanstack-query/src/types.ts
@@ -30,7 +30,7 @@ export type Infinite = {
    * The initial value, the value of the first page.
    * @default `0`
    */
-  initialPageParam: number
+  initialPageParam: unknown
 }
 
 export type Options = {


### PR DESCRIPTION
Infinite query page parameter is not always a number