### PR TITLE
Give format precendence over type property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ test.json
 docs/.vitepress/cache/**
 docs/.vitepress/dist/**
 !__snapshots__
+.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # editors
 #.vscode
 .idea/
+*.iml
 
 # dependencies
 node_modules

--- a/packages/core/mocks/hellowWorld.js
+++ b/packages/core/mocks/hellowWorld.js
@@ -1,1 +1,0 @@
-export const hallo = 'world'

--- a/packages/swagger-ts/mocks/type_assertions.yaml
+++ b/packages/swagger-ts/mocks/type_assertions.yaml
@@ -1,0 +1,51 @@
+components:
+  schemas:
+    Body_upload_file_api_assets_post:
+      properties:
+        file:
+          format: binary
+          title: File
+          type: string
+      required:
+      - file
+      title: Body_upload_file_api_assets_post
+      type: object
+      $comment: |
+        export type BodyUploadFileApiAssetsPost = {
+            /**
+            * @type string binary
+            */
+            file: Blob;
+        };
+    Plain_file:
+      format: binary
+      title: File
+      type: string
+      $comment: export type PlainFile = Blob;
+    Plain_date:
+      format: date
+      title: Date
+      type: string
+      $comment: export type PlainDate = Date;
+    Plain_time:
+      format: time
+      title: Time
+      type: number
+      $comment: export type PlainTime = number;
+    Plain_date_time:
+      format: date-time
+      title: Datetime
+      type: string
+      $comment: 
+    Plain_email:
+      format: email
+      title: Email
+      type: string
+    Plain_uuid:
+      format: uuid
+      title: UUID
+      type: string
+info:
+  title: Type Assertions
+openapi: 3.1.0
+paths: {}

--- a/packages/swagger-ts/src/TypeGenerator.test.ts
+++ b/packages/swagger-ts/src/TypeGenerator.test.ts
@@ -458,7 +458,7 @@ describe('TypeGenerator enums', async () => {
   })
 })
 
-describe('TypeGenerator type assertions', async ()=> {
+describe('TypeGenerator type assertions', async () => {
   const schemaPath = path.resolve(__dirname, '../mocks/type_assertions.yaml')
   const oas = await new OasManager().parse(schemaPath)
   const generator = new TypeGenerator({
@@ -472,7 +472,6 @@ describe('TypeGenerator type assertions', async ()=> {
     oas,
     pluginManager: mockedPluginManager,
   })
-
 
   const schemas = oas.getDefinition().components?.schemas
 
@@ -493,7 +492,7 @@ describe('TypeGenerator type assertions', async ()=> {
     expect(output).toBeDefined()
     expect(output).toMatchSnapshot()
   })
-  
+
   test('generates Date type correctly', async () => {
     const node = generator.build({ schema: schemas?.Plain_date as OasTypes.SchemaObject, baseName: 'Plain_date' })
 
@@ -502,7 +501,7 @@ describe('TypeGenerator type assertions', async ()=> {
     expect(output).toBeDefined()
     expect(output).toMatchSnapshot()
   })
-  
+
   test('generates Time type correctly', async () => {
     const node = generator.build({ schema: schemas?.Plain_time as OasTypes.SchemaObject, baseName: 'Plain_time' })
 
@@ -529,5 +528,4 @@ describe('TypeGenerator type assertions', async ()=> {
     expect(output).toBeDefined()
     expect(output).toMatchSnapshot()
   })
-
 })

--- a/packages/swagger-ts/src/TypeGenerator.test.ts
+++ b/packages/swagger-ts/src/TypeGenerator.test.ts
@@ -461,21 +461,22 @@ describe('TypeGenerator enums', async () => {
 describe('TypeGenerator type assertions', async () => {
   const schemaPath = path.resolve(__dirname, '../mocks/type_assertions.yaml')
   const oas = await new OasManager().parse(schemaPath)
-  const generator = new TypeGenerator({
-    usedEnumNames: {},
-    enumType: 'asConst',
-    dateType: 'string',
-    optionalType: 'questionToken',
-    transformers: {},
-    oasType: false,
-  }, {
-    oas,
-    pluginManager: mockedPluginManager,
-  })
 
   const schemas = oas.getDefinition().components?.schemas
 
   test('generates file property with `File` type', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
     const node = generator.build({ schema: schemas?.Body_upload_file_api_assets_post as OasTypes.SchemaObject, baseName: 'Body_upload_file_api_assets_post' })
 
     const output = print(node, undefined)
@@ -485,6 +486,18 @@ describe('TypeGenerator type assertions', async () => {
   })
 
   test('generates Plain_File types correctly', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
     const node = generator.build({ schema: schemas?.Plain_file as OasTypes.SchemaObject, baseName: 'Plain_file' })
 
     const output = print(node, undefined)
@@ -493,7 +506,42 @@ describe('TypeGenerator type assertions', async () => {
     expect(output).toMatchSnapshot()
   })
 
-  test('generates Date type correctly', async () => {
+  test('generates Date type correctly when dateType = date', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'date',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
+
+    const node = generator.build({ schema: schemas?.Plain_date as OasTypes.SchemaObject, baseName: 'Plain_date' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates Date type correctly when dateType = string', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
+
     const node = generator.build({ schema: schemas?.Plain_date as OasTypes.SchemaObject, baseName: 'Plain_date' })
 
     const output = print(node, undefined)
@@ -503,6 +551,19 @@ describe('TypeGenerator type assertions', async () => {
   })
 
   test('generates Time type correctly', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
+
     const node = generator.build({ schema: schemas?.Plain_time as OasTypes.SchemaObject, baseName: 'Plain_time' })
 
     const output = print(node, undefined)
@@ -512,6 +573,19 @@ describe('TypeGenerator type assertions', async () => {
   })
 
   test('generates Email type correctly', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
+
     const node = generator.build({ schema: schemas?.Plain_email as OasTypes.SchemaObject, baseName: 'Plain_email' })
 
     const output = print(node, undefined)
@@ -521,6 +595,19 @@ describe('TypeGenerator type assertions', async () => {
   })
 
   test('generates UUID type correctly', async () => {
+    const generator = new TypeGenerator({
+      usedEnumNames: {},
+      enumType: 'asConst',
+      dateType: 'string',
+      optionalType: 'questionToken',
+      transformers: {},
+      oasType: false,
+      unknownType: 'unknown',
+    }, {
+      oas,
+      pluginManager: mockedPluginManager,
+    })
+
     const node = generator.build({ schema: schemas?.Plain_uuid as OasTypes.SchemaObject, baseName: 'Plain_uuid' })
 
     const output = print(node, undefined)

--- a/packages/swagger-ts/src/TypeGenerator.test.ts
+++ b/packages/swagger-ts/src/TypeGenerator.test.ts
@@ -457,3 +457,77 @@ describe('TypeGenerator enums', async () => {
     expect(await format(output)).toMatchSnapshot()
   })
 })
+
+describe('TypeGenerator type assertions', async ()=> {
+  const schemaPath = path.resolve(__dirname, '../mocks/type_assertions.yaml')
+  const oas = await new OasManager().parse(schemaPath)
+  const generator = new TypeGenerator({
+    usedEnumNames: {},
+    enumType: 'asConst',
+    dateType: 'string',
+    optionalType: 'questionToken',
+    transformers: {},
+    oasType: false,
+  }, {
+    oas,
+    pluginManager: mockedPluginManager,
+  })
+
+
+  const schemas = oas.getDefinition().components?.schemas
+
+  test('generates file property with `File` type', async () => {
+    const node = generator.build({ schema: schemas?.Body_upload_file_api_assets_post as OasTypes.SchemaObject, baseName: 'Body_upload_file_api_assets_post' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates Plain_File types correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_file as OasTypes.SchemaObject, baseName: 'Plain_file' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+  
+  test('generates Date type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_date as OasTypes.SchemaObject, baseName: 'Plain_date' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+  
+  test('generates Time type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_time as OasTypes.SchemaObject, baseName: 'Plain_time' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates Email type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_email as OasTypes.SchemaObject, baseName: 'Plain_email' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+  test('generates UUID type correctly', async () => {
+    const node = generator.build({ schema: schemas?.Plain_uuid as OasTypes.SchemaObject, baseName: 'Plain_uuid' })
+
+    const output = print(node, undefined)
+
+    expect(output).toBeDefined()
+    expect(output).toMatchSnapshot()
+  })
+
+})

--- a/packages/swagger-ts/src/TypeGenerator.ts
+++ b/packages/swagger-ts/src/TypeGenerator.ts
@@ -1,17 +1,17 @@
-import { Generator } from '@kubb/core'
+import {Generator} from '@kubb/core'
 import transformers from '@kubb/core/transformers'
-import { getUniqueName } from '@kubb/core/utils'
+import {getUniqueName} from '@kubb/core/utils'
 import * as factory from '@kubb/parser/factory'
-import { keywordTypeNodes } from '@kubb/parser/factory'
-import { getSchemaFactory, isReference } from '@kubb/swagger/utils'
+import {keywordTypeNodes} from '@kubb/parser/factory'
+import {getSchemaFactory, isReference} from '@kubb/swagger/utils'
 
-import { pluginKey } from './plugin.ts'
+import {pluginKey} from './plugin.ts'
 
-import type { PluginManager } from '@kubb/core'
-import type { ts } from '@kubb/parser'
-import type { ImportMeta, Refs } from '@kubb/swagger'
-import type { Oas, OasTypes, OpenAPIV3, OpenAPIV3_1 } from '@kubb/swagger/oas'
-import type { PluginOptions } from './types.ts'
+import type {PluginManager} from '@kubb/core'
+import type {ts} from '@kubb/parser'
+import type {ImportMeta, Refs} from '@kubb/swagger'
+import type {Oas, OasTypes, OpenAPIV3, OpenAPIV3_1} from '@kubb/swagger/oas'
+import type {PluginOptions} from './types.ts'
 
 // based on https://github.com/cellular/oazapfts/blob/7ba226ebb15374e8483cc53e7532f1663179a22c/src/codegen/generate.ts#L398
 
@@ -19,6 +19,7 @@ type Context = {
   oas: Oas
   pluginManager: PluginManager
 }
+
 
 export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], Context> {
   refs: Refs = {}
@@ -32,12 +33,12 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
   #usedAliasNames: Record<string, number> = {}
 
   build({
-    schema,
-    optional,
-    baseName,
-    description,
-    keysToOmit,
-  }: {
+          schema,
+          optional,
+          baseName,
+          description,
+          keysToOmit,
+        }: {
     schema: OasTypes.SchemaObject
     baseName: string
     description?: string
@@ -52,13 +53,13 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     if (optional) {
-      type = factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.undefined] }) as ts.TypeNode
+      type = factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.undefined]}) as ts.TypeNode
     }
 
     const node = factory.createTypeAliasDeclaration({
       modifiers: [factory.modifiers.export],
-      name: this.context.pluginManager.resolveName({ name: baseName, pluginKey, type: 'type' }),
-      type: keysToOmit?.length ? factory.createOmitDeclaration({ keys: keysToOmit, type, nonNullable: true }) : type,
+      name: this.context.pluginManager.resolveName({name: baseName, pluginKey, type: 'type'}),
+      type: keysToOmit?.length ? factory.createOmitDeclaration({keys: keysToOmit, type, nonNullable: true}) : type,
     })
 
     if (description) {
@@ -99,14 +100,14 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       return type
     }
 
-    return factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.null] })
+    return factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.null]})
   }
 
   /**
    * Recursively creates a type literal with the given props.
    */
   #getTypeFromProperties(baseSchema?: OasTypes.SchemaObject, baseName?: string): ts.TypeNode | null {
-    const { optionalType } = this.options
+    const {optionalType} = this.options
     const properties = baseSchema?.properties || {}
     const required = baseSchema?.required
     const additionalProperties = baseSchema?.additionalProperties
@@ -115,14 +116,18 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       const schema = properties[name] as OasTypes.SchemaObject
 
       const isRequired = Array.isArray(required) ? required.includes(name) : !!required
-      let type = this.getTypeFromSchema(schema, this.context.pluginManager.resolveName({ name: `${baseName || ''} ${name}`, pluginKey, type: 'type' }))
+      let type = this.getTypeFromSchema(schema, this.context.pluginManager.resolveName({
+        name: `${baseName || ''} ${name}`,
+        pluginKey,
+        type: 'type'
+      }))
 
       if (!type) {
         return null
       }
 
       if (!isRequired && ['undefined', 'questionTokenAndUndefined'].includes(optionalType as string)) {
-        type = factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.undefined] })
+        type = factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.undefined]})
       }
       const propertySignature = factory.createPropertySignature({
         questionToken: ['questionToken', 'questionTokenAndUndefined'].includes(optionalType as string) && !isRequired,
@@ -157,7 +162,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
    * Create a type alias for the schema referenced by the given ReferenceObject
    */
   #getRefAlias(obj: OpenAPIV3.ReferenceObject, _baseName?: string) {
-    const { $ref } = obj
+    const {$ref} = obj
     let ref = this.refs[$ref]
 
     if (ref) {
@@ -165,15 +170,15 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     const originalName = getUniqueName($ref.replace(/.+\//, ''), this.#usedAliasNames)
-    const propertyName = this.context.pluginManager.resolveName({ name: originalName, pluginKey, type: 'type' })
+    const propertyName = this.context.pluginManager.resolveName({name: originalName, pluginKey, type: 'type'})
 
     ref = this.refs[$ref] = {
       propertyName,
       originalName,
     }
 
-    const fileName = this.context.pluginManager.resolveName({ name: originalName, pluginKey, type: 'file' })
-    const path = this.context.pluginManager.resolvePath({ baseName: fileName, pluginKey })
+    const fileName = this.context.pluginManager.resolveName({name: originalName, pluginKey, type: 'file'})
+    const path = this.context.pluginManager.resolvePath({baseName: fileName, pluginKey})
 
     this.imports.push({
       ref,
@@ -197,7 +202,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     _schema: OasTypes.SchemaObject | undefined,
     baseName?: string,
   ): ts.TypeNode | null {
-    const { schema, version } = this.#getParsedSchema(_schema)
+    const {schema, version} = this.#getParsedSchema(_schema)
 
     if (!schema) {
       return this.#unknownReturn
@@ -209,7 +214,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
 
     if (schema.oneOf) {
       // union
-      const schemaWithoutOneOf = { ...schema, oneOf: undefined } as OasTypes.SchemaObject
+      const schemaWithoutOneOf = {...schema, oneOf: undefined} as OasTypes.SchemaObject
 
       const union = factory.createUnionDeclaration({
         withParentheses: true,
@@ -232,7 +237,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     if (schema.anyOf) {
-      const schemaWithoutAnyOf = { ...schema, anyOf: undefined } as OasTypes.SchemaObject
+      const schemaWithoutAnyOf = {...schema, anyOf: undefined} as OasTypes.SchemaObject
 
       const union = factory.createUnionDeclaration({
         withParentheses: true,
@@ -255,7 +260,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
     if (schema.allOf) {
       // intersection/add
-      const schemaWithoutAllOf = { ...schema, allOf: undefined } as OasTypes.SchemaObject
+      const schemaWithoutAllOf = {...schema, allOf: undefined} as OasTypes.SchemaObject
 
       const and = factory.createIntersectionDeclaration({
         withParentheses: true,
@@ -298,12 +303,16 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       this.extraNodes.push(
         ...factory.createEnumDeclaration({
           name: transformers.camelCase(enumName),
-          typeName: this.context.pluginManager.resolveName({ name: enumName, pluginKey, type: 'type' }),
+          typeName: this.context.pluginManager.resolveName({name: enumName, pluginKey, type: 'type'}),
           enums,
           type: this.options.enumType,
         }),
       )
-      return factory.createTypeReferenceNode(this.context.pluginManager.resolveName({ name: enumName, pluginKey, type: 'type' }), undefined)
+      return factory.createTypeReferenceNode(this.context.pluginManager.resolveName({
+        name: enumName,
+        pluginKey,
+        type: 'type'
+      }), undefined)
     }
 
     if (schema.enum) {
@@ -386,18 +395,53 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
         })
       }
 
-      if (this.options.dateType === 'date' && ['date', 'date-time'].some((item) => item === schema.format)) {
-        return factory.createTypeReferenceNode(factory.createIdentifier('Date'))
+      /**
+       * > Structural validation alone may be insufficient to allow an application to correctly utilize certain values. The "format"
+       * > annotation keyword is defined to allow schema authors to convey semantic information for a fixed subset of values which are
+       * > accurately described by authoritative resources, be they RFCs or other external specifications.
+       *
+       * In other words: format is more specific than type alone, hence it should override the type value, if possible.
+       *
+       * see also https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.7
+       */
+      if (schema.format) {
+        switch (schema.format) {
+          case "binary":
+            if (schema.type === "string") {
+              return factory.createTypeReferenceNode('Blob', []);
+            }
+            break;
+          // 7.3.1. Dates, Times, and Duration
+          case "date-time":
+          case "date":
+          case "time":
+            if (this.options.dateType === 'date') {
+              return factory.createTypeReferenceNode(factory.createIdentifier('Date'))
+            }
+          case "uuid":
+            // TODO how to work with this? use https://www.npmjs.com/package/uuid for it?
+            break;
+          case "duration":
+          case "email":
+          case "idn-email":
+          case "hostname":
+          case "idn-hostname":
+          case "ipv4":
+          case "ipv6":
+          case "uri":
+          case "uri-reference":
+          case "json-pointer":
+          case "relative-json-pointer":
+          default:
+            // formats not yet implemented: ignore.
+            break;
+        }
       }
 
       // string, boolean, null, number
       if (schema.type in factory.keywordTypeNodes) {
         return factory.keywordTypeNodes[schema.type as keyof typeof factory.keywordTypeNodes]
       }
-    }
-
-    if (schema.format === 'binary') {
-      return factory.createTypeReferenceNode('Blob', [])
     }
 
     return this.#unknownReturn

--- a/packages/swagger-ts/src/TypeGenerator.ts
+++ b/packages/swagger-ts/src/TypeGenerator.ts
@@ -1,17 +1,17 @@
-import {Generator} from '@kubb/core'
+import { Generator } from '@kubb/core'
 import transformers from '@kubb/core/transformers'
-import {getUniqueName} from '@kubb/core/utils'
+import { getUniqueName } from '@kubb/core/utils'
 import * as factory from '@kubb/parser/factory'
-import {keywordTypeNodes} from '@kubb/parser/factory'
-import {getSchemaFactory, isReference} from '@kubb/swagger/utils'
+import { keywordTypeNodes } from '@kubb/parser/factory'
+import { getSchemaFactory, isReference } from '@kubb/swagger/utils'
 
-import {pluginKey} from './plugin.ts'
+import { pluginKey } from './plugin.ts'
 
-import type {PluginManager} from '@kubb/core'
-import type {ts} from '@kubb/parser'
-import type {ImportMeta, Refs} from '@kubb/swagger'
-import type {Oas, OasTypes, OpenAPIV3, OpenAPIV3_1} from '@kubb/swagger/oas'
-import type {PluginOptions} from './types.ts'
+import type { PluginManager } from '@kubb/core'
+import type { ts } from '@kubb/parser'
+import type { ImportMeta, Refs } from '@kubb/swagger'
+import type { Oas, OasTypes, OpenAPIV3, OpenAPIV3_1 } from '@kubb/swagger/oas'
+import type { PluginOptions } from './types.ts'
 
 // based on https://github.com/cellular/oazapfts/blob/7ba226ebb15374e8483cc53e7532f1663179a22c/src/codegen/generate.ts#L398
 
@@ -19,7 +19,6 @@ type Context = {
   oas: Oas
   pluginManager: PluginManager
 }
-
 
 export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], Context> {
   refs: Refs = {}
@@ -33,12 +32,12 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
   #usedAliasNames: Record<string, number> = {}
 
   build({
-          schema,
-          optional,
-          baseName,
-          description,
-          keysToOmit,
-        }: {
+    schema,
+    optional,
+    baseName,
+    description,
+    keysToOmit,
+  }: {
     schema: OasTypes.SchemaObject
     baseName: string
     description?: string
@@ -53,13 +52,13 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     if (optional) {
-      type = factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.undefined]}) as ts.TypeNode
+      type = factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.undefined] }) as ts.TypeNode
     }
 
     const node = factory.createTypeAliasDeclaration({
       modifiers: [factory.modifiers.export],
-      name: this.context.pluginManager.resolveName({name: baseName, pluginKey, type: 'type'}),
-      type: keysToOmit?.length ? factory.createOmitDeclaration({keys: keysToOmit, type, nonNullable: true}) : type,
+      name: this.context.pluginManager.resolveName({ name: baseName, pluginKey, type: 'type' }),
+      type: keysToOmit?.length ? factory.createOmitDeclaration({ keys: keysToOmit, type, nonNullable: true }) : type,
     })
 
     if (description) {
@@ -100,14 +99,14 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       return type
     }
 
-    return factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.null]})
+    return factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.null] })
   }
 
   /**
    * Recursively creates a type literal with the given props.
    */
   #getTypeFromProperties(baseSchema?: OasTypes.SchemaObject, baseName?: string): ts.TypeNode | null {
-    const {optionalType} = this.options
+    const { optionalType } = this.options
     const properties = baseSchema?.properties || {}
     const required = baseSchema?.required
     const additionalProperties = baseSchema?.additionalProperties
@@ -116,18 +115,21 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       const schema = properties[name] as OasTypes.SchemaObject
 
       const isRequired = Array.isArray(required) ? required.includes(name) : !!required
-      let type = this.getTypeFromSchema(schema, this.context.pluginManager.resolveName({
-        name: `${baseName || ''} ${name}`,
-        pluginKey,
-        type: 'type'
-      }))
+      let type = this.getTypeFromSchema(
+        schema,
+        this.context.pluginManager.resolveName({
+          name: `${baseName || ''} ${name}`,
+          pluginKey,
+          type: 'type',
+        }),
+      )
 
       if (!type) {
         return null
       }
 
       if (!isRequired && ['undefined', 'questionTokenAndUndefined'].includes(optionalType as string)) {
-        type = factory.createUnionDeclaration({nodes: [type, factory.keywordTypeNodes.undefined]})
+        type = factory.createUnionDeclaration({ nodes: [type, factory.keywordTypeNodes.undefined] })
       }
       const propertySignature = factory.createPropertySignature({
         questionToken: ['questionToken', 'questionTokenAndUndefined'].includes(optionalType as string) && !isRequired,
@@ -162,7 +164,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
    * Create a type alias for the schema referenced by the given ReferenceObject
    */
   #getRefAlias(obj: OpenAPIV3.ReferenceObject, _baseName?: string) {
-    const {$ref} = obj
+    const { $ref } = obj
     let ref = this.refs[$ref]
 
     if (ref) {
@@ -170,15 +172,15 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     const originalName = getUniqueName($ref.replace(/.+\//, ''), this.#usedAliasNames)
-    const propertyName = this.context.pluginManager.resolveName({name: originalName, pluginKey, type: 'type'})
+    const propertyName = this.context.pluginManager.resolveName({ name: originalName, pluginKey, type: 'type' })
 
     ref = this.refs[$ref] = {
       propertyName,
       originalName,
     }
 
-    const fileName = this.context.pluginManager.resolveName({name: originalName, pluginKey, type: 'file'})
-    const path = this.context.pluginManager.resolvePath({baseName: fileName, pluginKey})
+    const fileName = this.context.pluginManager.resolveName({ name: originalName, pluginKey, type: 'file' })
+    const path = this.context.pluginManager.resolvePath({ baseName: fileName, pluginKey })
 
     this.imports.push({
       ref,
@@ -202,7 +204,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     _schema: OasTypes.SchemaObject | undefined,
     baseName?: string,
   ): ts.TypeNode | null {
-    const {schema, version} = this.#getParsedSchema(_schema)
+    const { schema, version } = this.#getParsedSchema(_schema)
 
     if (!schema) {
       return this.#unknownReturn
@@ -214,7 +216,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
 
     if (schema.oneOf) {
       // union
-      const schemaWithoutOneOf = {...schema, oneOf: undefined} as OasTypes.SchemaObject
+      const schemaWithoutOneOf = { ...schema, oneOf: undefined } as OasTypes.SchemaObject
 
       const union = factory.createUnionDeclaration({
         withParentheses: true,
@@ -237,7 +239,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
 
     if (schema.anyOf) {
-      const schemaWithoutAnyOf = {...schema, anyOf: undefined} as OasTypes.SchemaObject
+      const schemaWithoutAnyOf = { ...schema, anyOf: undefined } as OasTypes.SchemaObject
 
       const union = factory.createUnionDeclaration({
         withParentheses: true,
@@ -260,7 +262,7 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
     }
     if (schema.allOf) {
       // intersection/add
-      const schemaWithoutAllOf = {...schema, allOf: undefined} as OasTypes.SchemaObject
+      const schemaWithoutAllOf = { ...schema, allOf: undefined } as OasTypes.SchemaObject
 
       const and = factory.createIntersectionDeclaration({
         withParentheses: true,
@@ -303,16 +305,19 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
       this.extraNodes.push(
         ...factory.createEnumDeclaration({
           name: transformers.camelCase(enumName),
-          typeName: this.context.pluginManager.resolveName({name: enumName, pluginKey, type: 'type'}),
+          typeName: this.context.pluginManager.resolveName({ name: enumName, pluginKey, type: 'type' }),
           enums,
           type: this.options.enumType,
         }),
       )
-      return factory.createTypeReferenceNode(this.context.pluginManager.resolveName({
-        name: enumName,
-        pluginKey,
-        type: 'type'
-      }), undefined)
+      return factory.createTypeReferenceNode(
+        this.context.pluginManager.resolveName({
+          name: enumName,
+          pluginKey,
+          type: 'type',
+        }),
+        undefined,
+      )
     }
 
     if (schema.enum) {
@@ -406,35 +411,35 @@ export class TypeGenerator extends Generator<PluginOptions['resolvedOptions'], C
        */
       if (schema.format) {
         switch (schema.format) {
-          case "binary":
-            if (schema.type === "string") {
-              return factory.createTypeReferenceNode('Blob', []);
+          case 'binary':
+            if (schema.type === 'string') {
+              return factory.createTypeReferenceNode('Blob', [])
             }
-            break;
+            break
           // 7.3.1. Dates, Times, and Duration
-          case "date-time":
-          case "date":
-          case "time":
+          case 'date-time':
+          case 'date':
+          case 'time':
             if (this.options.dateType === 'date') {
               return factory.createTypeReferenceNode(factory.createIdentifier('Date'))
             }
-          case "uuid":
+          case 'uuid':
             // TODO how to work with this? use https://www.npmjs.com/package/uuid for it?
-            break;
-          case "duration":
-          case "email":
-          case "idn-email":
-          case "hostname":
-          case "idn-hostname":
-          case "ipv4":
-          case "ipv6":
-          case "uri":
-          case "uri-reference":
-          case "json-pointer":
-          case "relative-json-pointer":
+            break
+          case 'duration':
+          case 'email':
+          case 'idn-email':
+          case 'hostname':
+          case 'idn-hostname':
+          case 'ipv4':
+          case 'ipv6':
+          case 'uri':
+          case 'uri-reference':
+          case 'json-pointer':
+          case 'relative-json-pointer':
           default:
             // formats not yet implemented: ignore.
-            break;
+            break
         }
       }
 

--- a/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
+++ b/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
@@ -222,8 +222,13 @@ exports[`TypeGenerator petStoreRef > generate type for Pets 1`] = `
 "
 `;
 
-exports[`TypeGenerator type assertions > generates Date type correctly 1`] = `
+exports[`TypeGenerator type assertions > generates Date type correctly when dateType = date 1`] = `
 "export type PlainDate = Date;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Date type correctly when dateType = string 1`] = `
+"export type PlainDate = string;
 "
 `;
 

--- a/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
+++ b/packages/swagger-ts/src/__snapshots__/TypeGenerator.test.ts.snap
@@ -221,3 +221,38 @@ exports[`TypeGenerator petStoreRef > generate type for Pets 1`] = `
 "export type Pets = Pet[]
 "
 `;
+
+exports[`TypeGenerator type assertions > generates Date type correctly 1`] = `
+"export type PlainDate = Date;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Email type correctly 1`] = `
+"export type PlainEmail = string;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Plain_File types correctly 1`] = `
+"export type PlainFile = Blob;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates Time type correctly 1`] = `
+"export type PlainTime = number;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates UUID type correctly 1`] = `
+"export type PlainUuid = string;
+"
+`;
+
+exports[`TypeGenerator type assertions > generates file property with \`File\` type 1`] = `
+"export type BodyUploadFileApiAssetsPost = {
+    /**
+     * @type string binary
+    */
+    file: Blob;
+};
+"
+`;


### PR DESCRIPTION
Equal to  #777 but rebased on current kubb main branch.

# Observation 

The JSON schema spec suggests that the `format` keyword has a higher specificity than the `type` keyword, since `format` it provides information about the contents of the schema at hand. 

Prior this PR, the `format` property would only be used by kubb iff the `type` property is not known. However, this prevents the `format` property to be used in most cases (except for `date`,  and `date-time`).

For example 
a plain file upload 

    Plain_file:
      format: binary
      title: File
      type: string

leads to a

    export type PlainFile = string;

although a `Blob` oder `FormData` would be more helpful in many cases.

# Goals

This PR enables `format` to "overrule" `type` and therefore generalizes the ad hoc approach that was begun `date` and `date-time` format parsing.


# Open questions:

However, some changes are still open for discussion, since they might involve inclusion of further dependencies (e.g. uuid validation).

* How to work with `format: uuid`?
* Should  the `format` only be used for `schema.type === "string"`, or shall it stay above those?
* is this a minor or a breaking change? Without activation flag, I would argue for breaking.
* Should this PR also trickle into downstream packages like zod or swr?  