### PR TITLE
fix: support for bun

### DIFF
--- a/.changeset/little-walls-drop.md
+++ b/.changeset/little-walls-drop.md
@@ -1,0 +1,6 @@
+---
+"@kubb/core": patch
+"@kubb/cli": patch
+---
+
+full support for Bun v1.1.0

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -31,9 +31,16 @@ yarn add @kubb/cli
 
 ## Usage
 
-```sh
+::: code-group
+
+```shell [bun <img src="/feature/bun.svg"/>]
+kubb --bun --config kubb.config.js
+bkubb --config kubb.config.js
+```
+```sh [node]
 kubb --config kubb.config.js
 ```
+:::
 
 ```mdx
 kubb/2.0.0
@@ -73,6 +80,7 @@ Options:
   -l, --log-level <type>  Info, silent or debug
   -w, --watch             Watch mode based on the input file
   -h, --help              Display this message
+  -b, --bun               Run Kubb with Bun
 ```
 
 Path of the input file(overrides the one in `kubb.config.js`)

--- a/docs/plugins/cli/index.md
+++ b/docs/plugins/cli/index.md
@@ -31,9 +31,16 @@ yarn add @kubb/cli
 
 ## Usage
 
-```sh
+::: code-group
+
+```shell [bun <img src="/feature/bun.svg"/>]
+kubb --bun --config kubb.config.js
+bkubb --config kubb.config.js
+```
+```sh [node]
 kubb --config kubb.config.js
 ```
+:::
 
 ```mdx
 kubb/1.2.1
@@ -73,6 +80,7 @@ Options:
   -l, --log-level <type>  Info, silent or debug
   -w, --watch             Watch mode based on the input file
   -h, --help              Display this message
+  -b, --bun               Run Kubb with Bun
 ```
 
 Path of the input file(overrides the one in `kubb.config.js`)

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -15,7 +15,7 @@
     "build": "tsup",
     "clean": "npx rimraf ./dist",
     "generate": "kubb generate",
-    "generate:bun": "bun ./node_modules/@kubb/cli/bin/kubb.js generate --config .kubbrc.js",
+    "generate:bun": "kubb generate --bun",
     "generate:js": "kubb generate --config .kubbrc.js",
     "generate:json": "kubb generate --config kubb.json",
     "generate:ts": "kubb generate --config configs/kubb.config.ts",

--- a/packages/cli/bin/bkubb.cjs
+++ b/packages/cli/bin/bkubb.cjs
@@ -1,19 +1,4 @@
 #!/usr/bin/env bun
-try {
-  const cachedSourceMaps = new Map()
-
-  // @ts-ignore
-  if (!process.isBun) {
-    require('source-map-support').install({
-      retrieveSourceMap(source) {
-        if (cachedSourceMaps.has(source)) {
-          return cachedSourceMaps.get(source)
-        }
-        return null
-      },
-    })
-  }
-} catch (err) {}
 
 import('../dist/index.js').then(({ run }) => {
   process.title = 'Kubb'

--- a/packages/cli/bin/bkubb.cjs
+++ b/packages/cli/bin/bkubb.cjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 try {
   const cachedSourceMaps = new Map()
 

--- a/packages/cli/bin/kubb.cjs
+++ b/packages/cli/bin/kubb.cjs
@@ -2,17 +2,14 @@
 try {
   const cachedSourceMaps = new Map()
 
-  // @ts-ignore
-  if (!process.isBun) {
-    require('source-map-support').install({
-      retrieveSourceMap(source) {
-        if (cachedSourceMaps.has(source)) {
-          return cachedSourceMaps.get(source)
-        }
-        return null
-      },
-    })
-  }
+  require('source-map-support').install({
+    retrieveSourceMap(source) {
+      if (cachedSourceMaps.has(source)) {
+        return cachedSourceMaps.get(source)
+      }
+      return null
+    },
+  })
 } catch (err) {}
 
 import('../dist/index.js').then(({ run }) => {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,7 +23,8 @@
     }
   },
   "bin": {
-    "kubb": "bin/kubb.cjs"
+    "kubb": "bin/kubb.cjs",
+    "bkubb": "bin/bkubb.cjs"
   },
   "files": ["src", "dist", "bin", "!/**/**.test.**", "!/**/__tests__/**"],
   "scripts": {
@@ -40,6 +41,7 @@
   "dependencies": {
     "@kubb/core": "workspace:*",
     "bundle-require": "^4.0.2",
+    "js-runtime": "^0.0.7",
     "cac": "^6.7.14",
     "chokidar": "^3.6.0",
     "cosmiconfig": "^9.0.0",

--- a/packages/cli/src/generate.ts
+++ b/packages/cli/src/generate.ts
@@ -1,17 +1,16 @@
-import { safeBuild } from '@kubb/core'
 import { LogLevel, createLogger, randomCliColour } from '@kubb/core/logger'
 
 import { execa } from 'execa'
+import { get } from 'js-runtime'
 import { parseArgsStringToArgv } from 'string-argv'
 import c from 'tinyrainbow'
 
 import { OraWritable } from './utils/OraWritable.ts'
-import { getSummary } from './utils/getSummary.ts'
 import { spinner } from './utils/spinner.ts'
 
 import type { Writable } from 'node:stream'
-import type { CLIOptions, Config } from '@kubb/core'
-import type { ExecaReturnValue } from 'execa'
+import { type CLIOptions, type Config, safeBuild } from '@kubb/core'
+import { getSummary } from './utils/getSummary.ts'
 
 type GenerateProps = {
   input?: string
@@ -22,11 +21,6 @@ type GenerateProps = {
 type ExecutingHooksProps = {
   hooks: Config['hooks']
   logLevel: LogLevel
-}
-
-type Executer = {
-  subProcess: ExecaReturnValue<string>
-  abort: AbortController['abort']
 }
 
 async function executeHooks({ hooks, logLevel }: ExecutingHooksProps): Promise<void> {
@@ -109,7 +103,7 @@ export async function generate({ input, config, CLIOptions }: GenerateProps): Pr
   const logLevel = logger.logLevel
   const inputPath = input ?? ('path' in userConfig.input ? userConfig.input.path : undefined)
 
-  spinner.start(`🚀 Building ${logLevel !== 'silent' ? c.dim(inputPath) : ''}`)
+  spinner.start(`🚀 Building with ${get()} ${logLevel !== 'silent' ? c.dim(inputPath) : ''}`)
 
   const definedConfig: Config = {
     root: process.cwd(),
@@ -150,7 +144,7 @@ export async function generate({ input, config, CLIOptions }: GenerateProps): Pr
   await executeHooks({ hooks: config.hooks, logLevel })
 
   spinner.suffixText = ''
-  spinner.succeed(`🚀 Build completed ${logLevel !== 'silent' ? c.dim(inputPath) : ''}`)
+  spinner.succeed(`🚀 Build completed with ${get()} ${logLevel !== 'silent' ? c.dim(inputPath) : ''}`)
 
   console.log(summary.join(''))
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,8 @@ import { spinner } from './utils/spinner.ts'
 import { startWatcher } from './utils/watcher.ts'
 
 import type { CLIOptions } from '@kubb/core'
+import { execa } from 'execa'
+import { OraWritable } from './utils/OraWritable.ts'
 
 const moduleName = 'kubb'
 
@@ -31,6 +33,13 @@ function programCatcher(e: unknown, CLIOptions: CLIOptions): void {
 }
 
 async function generateAction(input: string, CLIOptions: CLIOptions) {
+  if (CLIOptions.bun) {
+    const command = process.argv.splice(2).filter((item) => item !== '--bun')
+
+    await execa('bkubb', command, { stdout: process.stdout, stderr: process.stderr })
+    return
+  }
+
   spinner.start('🔍 Loading config')
   const result = await getCosmiConfig(moduleName, CLIOptions.config)
   spinner.succeed(`🔍 Config loaded(${c.dim(path.relative(process.cwd(), result.filepath))})`)
@@ -71,6 +80,7 @@ export async function run(argv?: string[]): Promise<void> {
     .option('-c, --config <path>', 'Path to the Kubb config')
     .option('-l, --log-level <type>', 'Info, silent or debug')
     .option('-w, --watch', 'Watch mode based on the input file')
+    .option('-b, --bun', 'Run Kubb with Bun')
     .action(generateAction)
 
   program
@@ -78,6 +88,7 @@ export async function run(argv?: string[]): Promise<void> {
     .option('-c, --config <path>', 'Path to the Kubb config')
     .option('-l, --log-level <type>', 'Info, silent or debug')
     .option('-w, --watch', 'Watch mode based on the input file')
+    .option('-b, --bun', 'Run Kubb with Bun')
     .action(generateAction)
 
   program.command('init', 'Init Kubb').action(async () => {

--- a/packages/cli/src/utils/getSummary.ts
+++ b/packages/cli/src/utils/getSummary.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import { LogLevel, randomCliColour } from '@kubb/core/logger'
+import { randomCliColour } from '@kubb/core/logger'
 
 import c from 'tinyrainbow'
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,6 +117,10 @@ export type CLIOptions = {
    * @default `silent`
    */
   logLevel?: LogLevel
+  /**
+   * Run Kubb with Bun
+   */
+  bun?: boolean
 }
 
 // plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,6 +996,9 @@ importers:
       execa:
         specifier: ^8.0.1
         version: 8.0.1
+      js-runtime:
+        specifier: ^0.0.7
+        version: 0.0.7
       ora:
         specifier: ^8.0.1
         version: 8.0.1


### PR DESCRIPTION
Kubb can be used with `Bun` but as explained here(https://bun.sh/docs/cli/bunx#shebangs) you need to set the _**shebang**_ to Bun. Because we want to support Node and Bun we cannot change this. So another bin has been added: `bkubb` that fully uses Bun.

Previously, to use `Kubb` with `bun` you need to use the following command:
```bash
bun node_modules/@kubb/cli/bin/kubb.js generate
```
That is of course not easy for an end user so we added a new CLI flag `--bun` that will call `bkubb` in the background so you can use the full power of `Bun`.
```bash
kubb --bun generate
```





Issue: https://github.com/oven-sh/bun/issues/5362