### PR TITLE
Fix `--ui` option code example

### DIFF
--- a/docs/helpers/cli.md
+++ b/docs/helpers/cli.md
@@ -116,7 +116,7 @@ kubb --watch
 
 Open Kubb's ui in the default browser
 ```shell [node]
-kubb --watch
+kubb --ui
 ```
 
 #### --version (-v)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the example command for opening the UI in the CLI documentation to use the appropriate `--ui` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->