### PR TITLE
fix: update argument types for vue-query; update argument unwrapping

### DIFF
--- a/.changeset/sweet-jars-itch.md
+++ b/.changeset/sweet-jars-itch.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-vue-query": patch
+---
+
+use MaybeRefOrGetter as argument type; use toValue for unwrapping arguments

--- a/packages/plugin-vue-query/src/components/InfiniteQuery.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQuery.tsx
@@ -46,25 +46,25 @@ function getParams({ paramsType, paramsCasing, pathParamsType, dataReturnType, t
             override(item) {
               return {
                 ...item,
-                type: `MaybeRef<${item.type}>`,
+                type: `MaybeRefOrGetter<${item.type}>`,
               }
             },
           }),
           data: typeSchemas.request?.name
             ? {
-                type: `MaybeRef<${typeSchemas.request?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
                 optional: isOptional(typeSchemas.request?.schema),
               }
             : undefined,
           params: typeSchemas.queryParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.queryParams?.schema),
               }
             : undefined,
           headers: typeSchemas.headerParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
                 optional: isOptional(typeSchemas.headerParams?.schema),
               }
             : undefined,
@@ -92,26 +92,26 @@ function getParams({ paramsType, paramsCasing, pathParamsType, dataReturnType, t
         override(item) {
           return {
             ...item,
-            type: `MaybeRef<${item.type}>`,
+            type: `MaybeRefOrGetter<${item.type}>`,
           }
         },
       }),
     },
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -42,25 +42,25 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
             override(item) {
               return {
                 ...item,
-                type: `MaybeRef<${item.type}>`,
+                type: `MaybeRefOrGetter<${item.type}>`,
               }
             },
           }),
           data: typeSchemas.request?.name
             ? {
-                type: `MaybeRef<${typeSchemas.request?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
                 optional: isOptional(typeSchemas.request?.schema),
               }
             : undefined,
           params: typeSchemas.queryParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.queryParams?.schema),
               }
             : undefined,
           headers: typeSchemas.headerParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.headerParams?.schema),
               }
             : undefined,
@@ -85,26 +85,26 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
         override(item) {
           return {
             ...item,
-            type: `MaybeRef<${item.type}>`,
+            type: `MaybeRefOrGetter<${item.type}>`,
           }
         },
       }),
     },
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,

--- a/packages/plugin-vue-query/src/components/Mutation.tsx
+++ b/packages/plugin-vue-query/src/components/Mutation.tsx
@@ -43,25 +43,25 @@ function getParams({ paramsCasing, dataReturnType, typeSchemas }: GetParamsProps
       override(item) {
         return {
           ...item,
-          type: `MaybeRef<${item.type}>`,
+          type: `MaybeRefOrGetter<${item.type}>`,
         }
       },
     }),
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,

--- a/packages/plugin-vue-query/src/components/Query.tsx
+++ b/packages/plugin-vue-query/src/components/Query.tsx
@@ -46,25 +46,25 @@ function getParams({ paramsCasing, paramsType, pathParamsType, dataReturnType, t
             override(item) {
               return {
                 ...item,
-                type: `MaybeRef<${item.type}>`,
+                type: `MaybeRefOrGetter<${item.type}>`,
               }
             },
           }),
           data: typeSchemas.request?.name
             ? {
-                type: `MaybeRef<${typeSchemas.request?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
                 optional: isOptional(typeSchemas.request?.schema),
               }
             : undefined,
           params: typeSchemas.queryParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.queryParams?.schema),
               }
             : undefined,
           headers: typeSchemas.headerParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
                 optional: isOptional(typeSchemas.headerParams?.schema),
               }
             : undefined,
@@ -92,26 +92,26 @@ function getParams({ paramsCasing, paramsType, pathParamsType, dataReturnType, t
         override(item) {
           return {
             ...item,
-            type: `MaybeRef<${item.type}>`,
+            type: `MaybeRefOrGetter<${item.type}>`,
           }
         },
       }),
     },
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.headerParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.headerParams?.name}>`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,

--- a/packages/plugin-vue-query/src/components/QueryKey.tsx
+++ b/packages/plugin-vue-query/src/components/QueryKey.tsx
@@ -33,20 +33,20 @@ function getParams({ pathParamsType, paramsCasing, typeSchemas }: GetParamsProps
         override(item) {
           return {
             ...item,
-            type: `MaybeRef<${item.type}>`,
+            type: `MaybeRefOrGetter<${item.type}>`,
           }
         },
       }),
     },
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,

--- a/packages/plugin-vue-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/QueryOptions.tsx
@@ -39,25 +39,25 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
             override(item) {
               return {
                 ...item,
-                type: `MaybeRef<${item.type}>`,
+                type: `MaybeRefOrGetter<${item.type}>`,
               }
             },
           }),
           data: typeSchemas.request?.name
             ? {
-                type: `MaybeRef<${typeSchemas.request?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
                 optional: isOptional(typeSchemas.request?.schema),
               }
             : undefined,
           params: typeSchemas.queryParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.queryParams?.schema),
               }
             : undefined,
           headers: typeSchemas.headerParams?.name
             ? {
-                type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+                type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
                 optional: isOptional(typeSchemas.headerParams?.schema),
               }
             : undefined,
@@ -82,26 +82,26 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
         override(item) {
           return {
             ...item,
-            type: `MaybeRef<${item.type}>`,
+            type: `MaybeRefOrGetter<${item.type}>`,
           }
         },
       }),
     },
     data: typeSchemas.request?.name
       ? {
-          type: `MaybeRef<${typeSchemas.request?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.request?.name}>`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: `MaybeRef<${typeSchemas.queryParams?.name}>`,
+          type: `MaybeRefOrGetter<${typeSchemas.queryParams?.name}>`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,
@@ -151,7 +151,7 @@ export function QueryOptions({ name, clientName, dataReturnType, typeSchemas, pa
           config.signal = signal
           return ${clientName}(${clientParams.toCall({
             transformName(name) {
-              return `unref(${name})`
+              return `toValue(${name})`
             },
           })})
        },

--- a/packages/plugin-vue-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
@@ -5,11 +5,12 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig, ResponseConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -36,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -50,7 +51,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -65,8 +66,8 @@ export function useFindPetsByTags<
   TQueryData = ResponseConfig<FindPetsByTagsQueryResponse>,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<ResponseConfig<FindPetsByTagsQueryResponse>, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/clientGetImportPath.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/clientGetImportPath.ts
@@ -5,11 +5,12 @@
 import fetch from 'axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { RequestConfig, ResponseErrorConfig } from 'axios'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -36,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -45,7 +46,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -60,8 +61,8 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/clientPostImportPath.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/clientPostImportPath.ts
@@ -5,7 +5,7 @@
 import fetch from 'axios'
 import type { MutationObserverOptions, QueryClient } from '@tanstack/vue-query'
 import type { RequestConfig, ResponseErrorConfig } from 'axios'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { useMutation } from '@tanstack/vue-query'
 
 export const updatePetWithFormMutationKey = () => [{ url: '/pet/{petId}' }] as const
@@ -45,9 +45,9 @@ export function useUpdatePetWithForm<TContext>(
       UpdatePetWithFormMutationResponse,
       ResponseErrorConfig<UpdatePetWithForm405>,
       {
-        petId: MaybeRef<UpdatePetWithFormPathParams['petId']>
-        data?: MaybeRef<UpdatePetWithFormMutationRequest>
-        params?: MaybeRef<UpdatePetWithFormQueryParams>
+        petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>
+        data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>
+        params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>
       },
       TContext
     > & { client?: QueryClient }

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTags.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTags.ts
@@ -5,11 +5,12 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -36,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -45,7 +46,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -60,8 +61,8 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsObject.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsObject.ts
@@ -5,11 +5,12 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -35,7 +36,7 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  { headers, params }: { headers: MaybeRef<FindPetsByTagsQueryParams>; params?: MaybeRef<FindPetsByTagsQueryParams> },
+  { headers, params }: { headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>; params?: MaybeRefOrGetter<FindPetsByTagsQueryParams> },
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -43,7 +44,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref({ headers: unref(headers), params: unref(params) }), unref(config))
+      return findPetsByTags(toValue({ headers: toValue(headers), params: toValue(params) }), toValue(config))
     },
   })
 }
@@ -58,7 +59,7 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  { headers, params }: { headers: MaybeRef<FindPetsByTagsHeaderParams>; params?: MaybeRef<FindPetsByTagsQueryParams> },
+  { headers, params }: { headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>; params?: MaybeRefOrGetter<FindPetsByTagsQueryParams> },
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
@@ -5,11 +5,12 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -36,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -45,7 +46,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -60,8 +61,8 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
@@ -5,11 +5,11 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) =>
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
   ['test', { url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
@@ -37,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -46,7 +46,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -61,8 +61,8 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithZod.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithZod.ts
@@ -5,11 +5,12 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
-export const findPetsByTagsQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) => [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
+export const findPetsByTagsQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
+  [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsQueryKey = ReturnType<typeof findPetsByTagsQueryKey>
 
@@ -36,8 +37,8 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: MaybeRef<FindPetsByTagsQueryParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsQueryKey(params)
@@ -45,7 +46,7 @@ export function findPetsByTagsQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return findPetsByTags(unref(headers), unref(params), unref(config))
+      return findPetsByTags(toValue(headers), toValue(params), toValue(config))
     },
   })
 }
@@ -60,8 +61,8 @@ export function useFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTags.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTags.ts
@@ -5,10 +5,10 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { InfiniteData, QueryKey, QueryClient, InfiniteQueryObserverOptions, UseInfiniteQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
 
-export const findPetsByTagsInfiniteQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) =>
+export const findPetsByTagsInfiniteQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
   [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsInfiniteQueryKey = ReturnType<typeof findPetsByTagsInfiniteQueryKey>
@@ -36,8 +36,8 @@ export async function findPetsByTagsInfinite(
 }
 
 export function findPetsByTagsInfiniteQueryOptions(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsInfiniteQueryKey(params)
@@ -67,8 +67,8 @@ export function useFindPetsByTagsInfinite<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsInfiniteQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<InfiniteQueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTagsCursor.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTagsCursor.ts
@@ -5,10 +5,10 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { InfiniteData, QueryKey, QueryClient, InfiniteQueryObserverOptions, UseInfiniteQueryReturnType } from '@tanstack/react-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
 
-export const findPetsByTagsInfiniteQueryKey = (params?: MaybeRef<FindPetsByTagsQueryParams>) =>
+export const findPetsByTagsInfiniteQueryKey = (params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>) =>
   [{ url: '/pet/findByTags' }, ...(params ? [params] : [])] as const
 
 export type FindPetsByTagsInfiniteQueryKey = ReturnType<typeof findPetsByTagsInfiniteQueryKey>
@@ -36,8 +36,8 @@ export async function findPetsByTagsInfinite(
 }
 
 export function findPetsByTagsInfiniteQueryOptions(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: typeof fetch } = {},
 ) {
   const queryKey = findPetsByTagsInfiniteQueryKey(params)
@@ -67,8 +67,8 @@ export function useFindPetsByTagsInfinite<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsInfiniteQueryKey,
 >(
-  headers: MaybeRef<FindPetsByTagsHeaderParams>,
-  params?: MaybeRef<FindPetsByTagsQueryParams>,
+  headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
+  params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   options: {
     query?: Partial<InfiniteQueryObserverOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
@@ -5,14 +5,14 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryReturnType } from 'custom-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from 'custom-query'
-import { unref } from 'vue'
+import { toValue } from 'vue'
 
 export const updatePetWithFormQueryKey = (
-  petId: MaybeRef<UpdatePetWithFormPathParams['petId']>,
-  data?: MaybeRef<UpdatePetWithFormMutationRequest>,
-  params?: MaybeRef<UpdatePetWithFormQueryParams>,
+  petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>,
+  data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>,
+  params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>,
 ) => [{ url: '/pet/:petId', params: { petId: petId } }, ...(params ? [params] : []), ...(data ? [data] : [])] as const
 
 export type UpdatePetWithFormQueryKey = ReturnType<typeof updatePetWithFormQueryKey>
@@ -41,9 +41,9 @@ export async function updatePetWithForm(
 }
 
 export function updatePetWithFormQueryOptions(
-  petId: MaybeRef<UpdatePetWithFormPathParams['petId']>,
-  data?: MaybeRef<UpdatePetWithFormMutationRequest>,
-  params?: MaybeRef<UpdatePetWithFormQueryParams>,
+  petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>,
+  data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>,
+  params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>,
   config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
 ) {
   const queryKey = updatePetWithFormQueryKey(petId, data, params)
@@ -52,7 +52,7 @@ export function updatePetWithFormQueryOptions(
     queryKey,
     queryFn: async ({ signal }) => {
       config.signal = signal
-      return updatePetWithForm(unref(petId), unref(data), unref(params), unref(config))
+      return updatePetWithForm(toValue(petId), toValue(data), toValue(params), toValue(config))
     },
   })
 }
@@ -66,9 +66,9 @@ export function useUpdatePetWithForm<
   TQueryData = UpdatePetWithFormMutationResponse,
   TQueryKey extends QueryKey = UpdatePetWithFormQueryKey,
 >(
-  petId: MaybeRef<UpdatePetWithFormPathParams['petId']>,
-  data?: MaybeRef<UpdatePetWithFormMutationRequest>,
-  params?: MaybeRef<UpdatePetWithFormQueryParams>,
+  petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>,
+  data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>,
+  params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>,
   options: {
     query?: Partial<QueryObserverOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient

--- a/packages/plugin-vue-query/src/generators/__snapshots__/updatePetById.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/updatePetById.ts
@@ -5,7 +5,7 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { MutationObserverOptions, QueryClient } from '@tanstack/vue-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { useMutation } from '@tanstack/vue-query'
 
 export const updatePetWithFormMutationKey = () => [{ url: '/pet/{petId}' }] as const
@@ -45,9 +45,9 @@ export function useUpdatePetWithForm<TContext>(
       UpdatePetWithFormMutationResponse,
       ResponseErrorConfig<UpdatePetWithForm405>,
       {
-        petId: MaybeRef<UpdatePetWithFormPathParams['petId']>
-        data?: MaybeRef<UpdatePetWithFormMutationRequest>
-        params?: MaybeRef<UpdatePetWithFormQueryParams>
+        petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>
+        data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>
+        params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>
       },
       TContext
     > & { client?: QueryClient }

--- a/packages/plugin-vue-query/src/generators/__snapshots__/updatePetByIdPathParamsObject.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/updatePetByIdPathParamsObject.ts
@@ -5,7 +5,7 @@
 import fetch from '@kubb/plugin-client/clients/axios'
 import type { RequestConfig, ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { MutationObserverOptions, QueryClient } from '@tanstack/vue-query'
-import type { MaybeRef } from 'vue'
+import type { MaybeRefOrGetter } from 'vue'
 import { useMutation } from '@tanstack/vue-query'
 
 export const updatePetWithFormMutationKey = () => [{ url: '/pet/{petId}' }] as const
@@ -45,9 +45,9 @@ export function useUpdatePetWithForm<TContext>(
       UpdatePetWithFormMutationResponse,
       ResponseErrorConfig<UpdatePetWithForm405>,
       {
-        petId: MaybeRef<UpdatePetWithFormPathParams['petId']>
-        data?: MaybeRef<UpdatePetWithFormMutationRequest>
-        params?: MaybeRef<UpdatePetWithFormQueryParams>
+        petId: MaybeRefOrGetter<UpdatePetWithFormPathParams['petId']>
+        data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>
+        params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>
       },
       TContext
     > & { client?: QueryClient }

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -84,8 +84,8 @@ export const infiniteQueryGenerator = createReactGenerator<PluginVueQuery>({
         {options.parser === 'zod' && (
           <File.Import name={[zod.schemas.response.name, zod.schemas.request?.name].filter(Boolean)} root={query.file.path} path={zod.file.path} />
         )}
-        <File.Import name={['unref']} path="vue" />
-        <File.Import name={['MaybeRef']} path="vue" isTypeOnly />
+        <File.Import name={['toValue']} path="vue" />
+        <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
         <File.Import name={'fetch'} path={options.client.importPath} />
         {hasClientPlugin && <File.Import name={[client.name]} root={query.file.path} path={client.file.path} />}
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -79,7 +79,7 @@ export const mutationGenerator = createReactGenerator<PluginVueQuery>({
         {options.parser === 'zod' && (
           <File.Import name={[zod.schemas.response.name, zod.schemas.request?.name].filter(Boolean)} root={mutation.file.path} path={zod.file.path} />
         )}
-        <File.Import name={['MaybeRef']} path="vue" isTypeOnly />
+        <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
         <File.Import name={'fetch'} path={options.client.importPath} />
         {!!hasClientPlugin && <File.Import name={[client.name]} root={mutation.file.path} path={client.file.path} />}
         <File.Import name={['RequestConfig', 'ResponseConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -82,8 +82,8 @@ export const queryGenerator = createReactGenerator<PluginVueQuery>({
         {options.parser === 'zod' && (
           <File.Import name={[zod.schemas.response.name, zod.schemas.request?.name].filter(Boolean)} root={query.file.path} path={zod.file.path} />
         )}
-        <File.Import name={['unref']} path="vue" />
-        <File.Import name={['MaybeRef']} path="vue" isTypeOnly />
+        <File.Import name={['toValue']} path="vue" />
+        <File.Import name={['MaybeRefOrGetter']} path="vue" isTypeOnly />
         <File.Import name={'fetch'} path={options.client.importPath} />
         {!!hasClientPlugin && <File.Import name={[client.name]} root={query.file.path} path={client.file.path} />}
         <File.Import name={['RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />


### PR DESCRIPTION
This will update the types for vue-query so it is possible to pass getters as property keys.

For example (pseudo code):
```
const queryReturn = useGetPetDetails({ id: () => pet.id })
```
Whereas pet is a reactive.
The usage above is at the moment not possible. Using plain pet.id would currently never update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Functions now support both Vue refs and getter functions as input parameters, offering greater flexibility when passing reactive or computed values.

* **Refactor**
  * Updated type annotations and internal value extraction to support a broader range of input types, ensuring compatibility with both refs and getter functions.
  * Public function signatures have been updated to reflect the new supported input types.

* **Style**
  * Improved consistency in handling reactive and computed values throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->