### PR TITLE
Fixed typo in `plugin-ts` docs

### DIFF
--- a/docs/plugins/plugin-ts/index.md
+++ b/docs/plugins/plugin-ts/index.md
@@ -374,7 +374,7 @@ export default defineConfig({
       ],
       group: {
         type: 'tag',
-        name: ({ group }) => `'${group}Controller`
+        name: ({ group }) => `${group}Controller`
       },
       enumType: "asConst",
       enumSuffix: 'Enum',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the TypeScript plugin configuration example to change the formatting of generated group names, removing single quotes from the default group name output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->