### PR TITLE
fix(parser-ts): update prettier to be a peer dependency

### DIFF
--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -63,14 +63,17 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "prettier": "^3.6.2",
     "remeda": "catalog:",
     "typescript": "5.8.3"
   },
   "devDependencies": {
     "@kubb/config-ts": "workspace:*",
     "@kubb/config-tsup": "workspace:*",
+    "prettier": "^3.6.2",
     "tsup": "^8.5.0"
+  },
+  "peerDependencies": {
+    "prettier": "^3"
   },
   "engines": {
     "node": ">=20"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1346,9 +1346,6 @@ importers:
 
   packages/parser-ts:
     dependencies:
-      prettier:
-        specifier: ^3.6.2
-        version: 3.6.2
       remeda:
         specifier: 'catalog:'
         version: 2.26.0
@@ -1362,6 +1359,9 @@ importers:
       '@kubb/config-tsup':
         specifier: workspace:*
         version: link:../config-tsup
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
       tsup:
         specifier: ^8.5.0
         version: 8.5.0(@microsoft/api-extractor@7.52.8(@types/node@20.19.8))(jiti@2.4.2)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.7.1)


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management for Prettier, moving it to development and peer dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Nitpick from CodeRabbit

75-77: Consider clarifying whether the peer dependency is optional
If @kubb/parser-ts can be used without runtime access to prettier (e.g., only when specific APIs are invoked), add:
```json
"peerDependenciesMeta": {
  "prettier": {
    "optional": true
  }
}
```
Marking it optional prevents npm from emitting warnings for consumers that don’t need Prettier, while still expressing the expected major range.