### PR TITLE
Review pr and add test case

### DIFF
--- a/e2e/schemas/vehicle.yaml
+++ b/e2e/schemas/vehicle.yaml
@@ -1,0 +1,28 @@
+openapi: 3.1.0
+info:
+  title: Vehicle API
+  version: 1.0.0
+
+paths: {}
+
+components:
+  schemas:
+    Vehicle:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          car: '#/components/schemas/Car'
+      oneOf:
+        - $ref: '#/components/schemas/Car'
+    
+    Car:
+      type: object
+      properties:
+        doors:
+          type: integer
+      required: [type]

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -636,7 +636,11 @@ export class SchemaGenerator<
       }
 
       if (discriminator) {
-        if (this.context) return [this.#addDiscriminatorToSchema({ schemaObject: schemaWithoutOneOf, schema: union, discriminator }), ...baseItems]
+        // In 'inherit' mode, the discriminator property is already added to child schemas by Oas.getDiscriminator()
+        // so we should NOT add it at the union level
+        if (this.context && this.context.oas.options.discriminator !== 'inherit') {
+          return [this.#addDiscriminatorToSchema({ schemaObject: schemaWithoutOneOf, schema: union, discriminator }), ...baseItems]
+        }
       }
 
       if (schemaWithoutOneOf.properties) {


### PR DESCRIPTION
Fixes discriminator 'inherit' mode to correctly add the discriminator property to child schemas.

In 'inherit' mode, `SchemaGenerator.ts` was incorrectly adding the discriminator at the union level, overriding the intended behavior where `Oas.getDiscriminator()` should add it directly to child schemas. This PR ensures `#addDiscriminatorToSchema` is skipped for 'inherit' mode, allowing child schemas to properly inherit the discriminator.

---
<a href="https://cursor.com/background-agent?bcId=bc-e489bd3e-e21d-44b8-a0fe-0b6d15e83838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e489bd3e-e21d-44b8-a0fe-0b6d15e83838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

