### PR TITLE
Investigate oas package schema ordering issue

### DIFF
--- a/packages/plugin-oas/src/utils/__snapshots__/getSchemas.test.ts.snap
+++ b/packages/plugin-oas/src/utils/__snapshots__/getSchemas.test.ts.snap
@@ -45,6 +45,67 @@ exports[`getSchemas > should include schemas from responses when enabled 1`] = `
 }
 `;
 
+exports[`getSchemas > should order schemas with oneOf circular dependencies correctly 1`] = `
+{
+  "ObjectSchema": {
+    "properties": {
+      "type": {
+        "enum": [
+          "object",
+        ],
+        "type": "string",
+      },
+      "value": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/TypeSchema",
+        },
+        "type": "object",
+      },
+    },
+    "required": [
+      "type",
+      "value",
+    ],
+    "type": "object",
+  },
+  "StringSchema": {
+    "properties": {
+      "type": {
+        "enum": [
+          "string",
+        ],
+        "type": "string",
+      },
+      "value": {
+        "type": "string",
+      },
+    },
+    "required": [
+      "type",
+      "value",
+    ],
+    "type": "object",
+  },
+  "TypeSchema": {
+    "discriminator": {
+      "mapping": {
+        "object": "#/components/schemas/ObjectSchema",
+        "string": "#/components/schemas/StringSchema",
+      },
+      "propertyName": "type",
+    },
+    "oneOf": [
+      {
+        "$ref": "#/components/schemas/ObjectSchema",
+      },
+      {
+        "$ref": "#/components/schemas/StringSchema",
+      },
+    ],
+  },
+}
+`;
+
 exports[`getSchemas > should respect custom contentType when multiple exist 1`] = `
 {
   "TestResponse": {


### PR DESCRIPTION
Fixes schema ordering for `oneOf`/`anyOf` schemas with circular dependencies to prevent "used before declaration" errors.

The previous topological sorting in `getSchemas.ts` did not correctly prioritize schemas referenced within `oneOf`/`anyOf` when circular dependencies were present. This resulted in union schemas being defined before their members, causing build failures. The updated `sortSchemas` function now explicitly tracks and prioritizes `oneOf`/`anyOf` dependencies, ensuring that referenced schemas are defined first, even in circular scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-debd40d1-3f55-49e0-ae2c-3c3b3bb4dc22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-debd40d1-3f55-49e0-ae2c-3c3b3bb4dc22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

