### PR TITLE
Create pr for solid plugin issue

### DIFF
--- a/packages/plugin-solid-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-solid-query/src/components/QueryOptions.tsx
@@ -27,26 +27,34 @@ type GetParamsProps = {
 
 function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: GetParamsProps) {
   if (paramsType === 'object') {
+    // Wrap pathParams in accessor functions for Solid reactivity
+    const pathParamsChildren = typeSchemas.pathParams 
+      ? Object.fromEntries(
+          Object.entries(getPathParams(typeSchemas.pathParams, { typed: true, casing: paramsCasing }))
+            .map(([key, value]) => [key, value ? { ...value, type: `() => ${value.type}` } : value])
+        )
+      : {}
+    
     return FunctionParams.factory({
       data: {
         mode: 'object',
         children: {
-          ...getPathParams(typeSchemas.pathParams, { typed: true, casing: paramsCasing }),
+          ...pathParamsChildren,
           data: typeSchemas.request?.name
             ? {
-                type: typeSchemas.request?.name,
+                type: `() => ${typeSchemas.request?.name}`,
                 optional: isOptional(typeSchemas.request?.schema),
               }
             : undefined,
           params: typeSchemas.queryParams?.name
             ? {
-                type: typeSchemas.queryParams?.name,
+                type: `() => ${typeSchemas.queryParams?.name}`,
                 optional: isOptional(typeSchemas.queryParams?.schema),
               }
             : undefined,
           headers: typeSchemas.headerParams?.name
             ? {
-                type: typeSchemas.headerParams?.name,
+                type: `() => ${typeSchemas.headerParams?.name}`,
                 optional: isOptional(typeSchemas.headerParams?.schema),
               }
             : undefined,
@@ -54,9 +62,9 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
       },
       config: {
         type: typeSchemas.request?.name
-          ? `Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }`
-          : 'Partial<RequestConfig> & { client?: typeof fetch }',
-        default: '{}',
+          ? `() => Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }`
+          : '() => Partial<RequestConfig> & { client?: typeof fetch }',
+        default: '() => ({})',
       },
     })
   }
@@ -71,27 +79,27 @@ function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas }: Ge
       : undefined,
     data: typeSchemas.request?.name
       ? {
-          type: typeSchemas.request?.name,
+          type: `() => ${typeSchemas.request?.name}`,
           optional: isOptional(typeSchemas.request?.schema),
         }
       : undefined,
     params: typeSchemas.queryParams?.name
       ? {
-          type: typeSchemas.queryParams?.name,
+          type: `() => ${typeSchemas.queryParams?.name}`,
           optional: isOptional(typeSchemas.queryParams?.schema),
         }
       : undefined,
     headers: typeSchemas.headerParams?.name
       ? {
-          type: typeSchemas.headerParams?.name,
+          type: `() => ${typeSchemas.headerParams?.name}`,
           optional: isOptional(typeSchemas.headerParams?.schema),
         }
       : undefined,
     config: {
       type: typeSchemas.request?.name
-        ? `Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }`
-        : 'Partial<RequestConfig> & { client?: typeof fetch }',
-      default: '{}',
+        ? `() => Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }`
+        : '() => Partial<RequestConfig> & { client?: typeof fetch }',
+      default: '() => ({})',
     },
   })
 }
@@ -114,8 +122,29 @@ export function QueryOptions({ name, clientName, typeSchemas, paramsCasing, para
     typeSchemas,
   })
 
+  // Build the unwrapped parameter calls using transformName to call accessor functions
+  const unwrappedQueryKeyCall = queryKeyParams.toCall({
+    transformName(name) {
+      const param = params.flatParams[name]
+      if (param && param.type?.startsWith('() =>')) {
+        return `${name}?.()`
+      }
+      return name
+    },
+  })
+  
+  const unwrappedClientCall = clientParams.toCall({
+    transformName(name) {
+      const param = params.flatParams[name]
+      if (param && param.type?.startsWith('() =>')) {
+        return `${name}?.()`
+      }
+      return name
+    },
+  })
+
   const enabled = Object.entries(queryKeyParams.flatParams)
-    .map(([key, item]) => (item && !item.optional ? key : undefined))
+    .map(([key, item]) => (item && !item.optional ? `${key}?.()` : undefined))
     .filter(Boolean)
     .join('&& ')
 
@@ -125,13 +154,14 @@ export function QueryOptions({ name, clientName, typeSchemas, paramsCasing, para
     <File.Source name={name} isExportable isIndexable>
       <Function name={name} export params={params.toConstructor()}>
         {`
-      const queryKey = ${queryKeyName}(${queryKeyParams.toCall()})
+      const queryKey = ${queryKeyName}(${unwrappedQueryKeyCall})
       return queryOptions<${TData}, ${TError}, ${TData}, typeof queryKey>({
       ${enabledText}
        queryKey,
        queryFn: async ({ signal }) => {
-          config.signal = signal
-          return ${clientName}(${clientParams.toCall()})
+          const unwrappedConfig = config?.() ?? {}
+          unwrappedConfig.signal = signal
+          return ${clientName}(${unwrappedClientCall})
        },
       })
 `}

--- a/packages/plugin-solid-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
@@ -34,11 +34,11 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<
     ResponseConfig<FindPetsByTagsQueryResponse>,
     ResponseErrorConfig<FindPetsByTags400>,
@@ -47,8 +47,9 @@ export function findPetsByTagsQueryOptions(
   >({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -63,22 +64,22 @@ export function createFindPetsByTags<
   TQueryData = ResponseConfig<FindPetsByTagsQueryResponse>,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<ResponseConfig<FindPetsByTagsQueryResponse>, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/clientGetImportPath.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/clientGetImportPath.ts
@@ -34,16 +34,17 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -58,22 +59,22 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/findByTags.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/findByTags.ts
@@ -34,16 +34,17 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -58,22 +59,22 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsObject.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsObject.ts
@@ -33,15 +33,16 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  { headers, params }: { headers: FindPetsByTagsHeaderParams; params?: FindPetsByTagsQueryParams },
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  { headers, params }: { headers: () => FindPetsByTagsHeaderParams; params?: () => FindPetsByTagsQueryParams },
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags({ headers, params }, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags({ headers: headers?.(), params: params?.() }, config?.())
     },
   })
 }
@@ -56,21 +57,21 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  { headers, params }: { headers: FindPetsByTagsHeaderParams; params?: FindPetsByTagsQueryParams },
-  options: {
+  { headers, params }: { headers: () => FindPetsByTagsHeaderParams; params?: () => FindPetsByTagsQueryParams },
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions({ headers, params }, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions({ headers: headers?.(), params: params?.() }, config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
@@ -34,16 +34,17 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -58,22 +59,22 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
@@ -34,16 +34,17 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -58,22 +59,22 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsWithZod.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/findByTagsWithZod.ts
@@ -34,16 +34,17 @@ export async function findPetsByTags(
 }
 
 export function findPetsByTagsQueryOptions(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  config: Partial<RequestConfig> & { client?: typeof fetch } = {},
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  config: () => Partial<RequestConfig> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = findPetsByTagsQueryKey(params)
+  const queryKey = findPetsByTagsQueryKey(params?.())
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return findPetsByTags(headers, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return findPetsByTags(headers?.(), params?.(), config?.())
     },
   })
 }
@@ -58,22 +59,22 @@ export function createFindPetsByTags<
   TQueryData = FindPetsByTagsQueryResponse,
   TQueryKey extends QueryKey = FindPetsByTagsQueryKey,
 >(
-  headers: FindPetsByTagsHeaderParams,
-  params?: FindPetsByTagsQueryParams,
-  options: {
+  headers: () => FindPetsByTagsHeaderParams,
+  params?: () => FindPetsByTagsQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params)
+  const queryKey = queryOptions?.queryKey ?? findPetsByTagsQueryKey(params?.())
 
   const query = useQuery(
     () => ({
-      ...(findPetsByTagsQueryOptions(headers, params, config) as unknown as UseBaseQueryOptions),
+      ...(findPetsByTagsQueryOptions(headers?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),

--- a/packages/plugin-solid-query/src/generators/__snapshots__/postAsQuery.ts
+++ b/packages/plugin-solid-query/src/generators/__snapshots__/postAsQuery.ts
@@ -41,17 +41,18 @@ export async function updatePetWithForm(
 
 export function updatePetWithFormQueryOptions(
   petId: UpdatePetWithFormPathParams['petId'],
-  data?: UpdatePetWithFormMutationRequest,
-  params?: UpdatePetWithFormQueryParams,
-  config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
+  data?: () => UpdatePetWithFormMutationRequest,
+  params?: () => UpdatePetWithFormQueryParams,
+  config: () => Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = () => ({}),
 ) {
-  const queryKey = updatePetWithFormQueryKey(petId, data, params)
+  const queryKey = updatePetWithFormQueryKey(petId, data?.(), params?.())
   return queryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, UpdatePetWithFormMutationResponse, typeof queryKey>({
-    enabled: !!petId,
+    enabled: !!petId?.(),
     queryKey,
     queryFn: async ({ signal }) => {
-      config.signal = signal
-      return updatePetWithForm(petId, data, params, config)
+      const unwrappedConfig = config?.() ?? {}
+      unwrappedConfig.signal = signal
+      return updatePetWithForm(petId, data?.(), params?.(), config?.())
     },
   })
 }
@@ -66,22 +67,22 @@ export function createUpdatePetWithForm<
   TQueryKey extends QueryKey = UpdatePetWithFormQueryKey,
 >(
   petId: UpdatePetWithFormPathParams['petId'],
-  data?: UpdatePetWithFormMutationRequest,
-  params?: UpdatePetWithFormQueryParams,
-  options: {
+  data?: () => UpdatePetWithFormMutationRequest,
+  params?: () => UpdatePetWithFormQueryParams,
+  options: () => {
     query?: Partial<UseBaseQueryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, TData, TQueryData, TQueryKey>> & {
       client?: QueryClient
     }
     client?: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch }
-  } = {},
+  } = () => ({}),
 ) {
-  const { query: queryConfig = {}, client: config = {} } = options ?? {}
+  const { query: queryConfig = {}, client: config = {} } = options?.() ?? {}
   const { client: queryClient, ...queryOptions } = queryConfig
-  const queryKey = queryOptions?.queryKey ?? updatePetWithFormQueryKey(petId, data, params)
+  const queryKey = queryOptions?.queryKey ?? updatePetWithFormQueryKey(petId, data?.(), params?.())
 
   const query = useQuery(
     () => ({
-      ...(updatePetWithFormQueryOptions(petId, data, params, config) as unknown as UseBaseQueryOptions),
+      ...(updatePetWithFormQueryOptions(petId, data?.(), params?.(), config) as unknown as UseBaseQueryOptions),
       queryKey,
       initialData: null,
       ...(queryOptions as unknown as Omit<UseBaseQueryOptions, 'queryKey'>),


### PR DESCRIPTION
Accept accessor functions for params and options in Solid Query plugin to enable reactive tracking.

The generated hooks now accept parameters and options as accessor functions (`() => Type`) instead of direct values. This allows Solid Query to automatically track changes to reactive primitives (like signals) passed as parameters, enabling automatic refetching without requiring manual `createMemo` wrappers or other workarounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-5338ed31-6ad8-4735-b4af-c53264ec64da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5338ed31-6ad8-4735-b4af-c53264ec64da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

