### PR TITLE
fix: fix merging headers for clients/fetch

### DIFF
--- a/packages/plugin-client/src/clients/fetch.ts
+++ b/packages/plugin-client/src/clients/fetch.ts
@@ -47,8 +47,8 @@ export const client = async <TData, _TError = unknown, TVariables = unknown>(par
     ...globalConfig,
     ...paramsConfig,
     headers: {
-      ...globalConfig.headers,
-      ...paramsConfig.headers,
+      ...(Array.isArray(globalConfig.headers) ? Object.fromEntries(globalConfig.headers) : globalConfig.headers),
+      ...(Array.isArray(paramsConfig.headers) ? Object.fromEntries(paramsConfig.headers) : paramsConfig.headers),
     },
   }
 

--- a/packages/plugin-client/templates/clients/fetch.ts
+++ b/packages/plugin-client/templates/clients/fetch.ts
@@ -47,8 +47,8 @@ export const fetch = async <TData, _TError = unknown, TVariables = unknown>(para
     ...globalConfig,
     ...paramsConfig,
     headers: {
-      ...globalConfig.headers,
-      ...paramsConfig.headers,
+      ...(Array.isArray(globalConfig.headers) ? Object.fromEntries(globalConfig.headers) : globalConfig.headers),
+      ...(Array.isArray(paramsConfig.headers) ? Object.fromEntries(paramsConfig.headers) : paramsConfig.headers),
     },
   }
 


### PR DESCRIPTION
This pull request updates the way request configuration headers are merged to ensure that headers from both the global configuration and per-request configuration are combined correctly.

Configuration merging improvements:

* Updated the `client` function in `packages/plugin-client/src/clients/fetch.ts` to deeply merge the `headers` property from both `globalConfig` and `paramsConfig`, preventing header overrides and ensuring all headers are included.
* Made the same deep merging change for the `headers` property in the `fetch` function within `packages/plugin-client/templates/clients/fetch.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Request headers from global configuration and per-request settings are now merged correctly, so both sources are preserved and no longer unintentionally overwrite each other.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->