### PR TITLE
fix: update logger to reference linter instead of formatter

### DIFF
--- a/packages/cli/src/runners/generate.ts
+++ b/packages/cli/src/runners/generate.ts
@@ -198,7 +198,7 @@ export async function generate({ input, config, progressCache, args }: GenerateP
 
   // linting
   if (config.output.lint === 'eslint') {
-    logger?.emit('start', `Linting with ${config.output.format}`)
+    logger?.emit('start', `Linting with ${config.output.lint}`)
 
     try {
       await execa('eslint', [path.resolve(definedConfig.root, definedConfig.output.path), '--fix'])
@@ -207,11 +207,11 @@ export async function generate({ input, config, progressCache, args }: GenerateP
       logger.consola?.error(e)
     }
 
-    logger?.emit('success', `Linted with ${config.output.format}`)
+    logger?.emit('success', `Linted with ${config.output.lint}`)
   }
 
   if (config.output.lint === 'biome') {
-    logger?.emit('start', `Linting with ${config.output.format}`)
+    logger?.emit('start', `Linting with ${config.output.lint}`)
 
     try {
       await execa('biome', ['lint', '--fix', path.resolve(definedConfig.root, definedConfig.output.path)])
@@ -220,11 +220,11 @@ export async function generate({ input, config, progressCache, args }: GenerateP
       logger.consola?.error(e)
     }
 
-    logger?.emit('success', `Linted with ${config.output.format}`)
+    logger?.emit('success', `Linted with ${config.output.lint}`)
   }
 
   if (config.output.lint === 'oxlint') {
-    logger?.emit('start', `Linting with ${config.output.format}`)
+    logger?.emit('start', `Linting with ${config.output.lint}`)
 
     try {
       await execa('oxlint', ['--fix', path.resolve(definedConfig.root, definedConfig.output.path)])
@@ -233,7 +233,7 @@ export async function generate({ input, config, progressCache, args }: GenerateP
       logger.consola?.error(e)
     }
 
-    logger?.emit('success', `Linted with ${config.output.format}`)
+    logger?.emit('success', `Linted with ${config.output.lint}`)
   }
 
   if (config.hooks) {


### PR DESCRIPTION
This pull request updates the linting log messages in the `generate` runner to correctly reference the configured linter rather than the formatter. This ensures that the logs accurately reflect which linter is being used during the generation process.

Logging improvements for linting:

* Changed logger messages to use `config.output.lint` instead of `config.output.format` for all supported linters (`eslint`, `biome`, `oxlint`) in `packages/cli/src/runners/generate.ts`. This makes the start and success log messages accurately state which linter is being run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected linting operation log messages to display the correct lint type instead of format information. Messages now show accurate information during linting initiation and completion for ESLint, Biome, and Oxlint operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->