### PR TITLE
Skip coercion for email, url, uuid with zod 4

### DIFF
--- a/packages/plugin-zod/src/parser.test.ts
+++ b/packages/plugin-zod/src/parser.test.ts
@@ -14,10 +14,10 @@ describe('zod parse', () => {
   })
 
   describe('coercion with version 4', () => {
-    test('uuid with coercion=true and version=4 should use z.coerce.uuid()', () => {
+    test('uuid with coercion=true and version=4 should skip coercion', () => {
       const schema = { keyword: schemaKeywords.uuid, args: undefined }
       const text = parserZod.parse({ name: 'test', schema: {}, parent: undefined, current: schema, siblings: [schema] }, { version: '4', coercion: true })
-      expect(text).toBe('z.coerce.uuid()')
+      expect(text).toBe('z.uuid()')
     })
 
     test('uuid with coercion=true and version=3 should use z.coerce.string().uuid()', () => {
@@ -26,10 +26,10 @@ describe('zod parse', () => {
       expect(text).toBe('z.coerce.string().uuid()')
     })
 
-    test('url with coercion=true and version=4 should use z.coerce.url()', () => {
+    test('url with coercion=true and version=4 should skip coercion', () => {
       const schema = { keyword: schemaKeywords.url, args: undefined }
       const text = parserZod.parse({ name: 'test', schema: {}, parent: undefined, current: schema, siblings: [schema] }, { version: '4', coercion: true })
-      expect(text).toBe('z.coerce.url()')
+      expect(text).toBe('z.url()')
     })
 
     test('url with coercion=true and version=3 should use z.coerce.string().url()', () => {
@@ -38,10 +38,10 @@ describe('zod parse', () => {
       expect(text).toBe('z.coerce.string().url()')
     })
 
-    test('email with coercion=true and version=4 should use z.coerce.email()', () => {
+    test('email with coercion=true and version=4 should skip coercion', () => {
       const schema = { keyword: schemaKeywords.email, args: undefined }
       const text = parserZod.parse({ name: 'test', schema: {}, parent: undefined, current: schema, siblings: [schema] }, { version: '4', coercion: true })
-      expect(text).toBe('z.coerce.email()')
+      expect(text).toBe('z.email()')
     })
 
     test('email with coercion=true and version=3 should use z.coerce.string().email()', () => {

--- a/packages/plugin-zod/src/parser.ts
+++ b/packages/plugin-zod/src/parser.ts
@@ -142,7 +142,7 @@ const zodKeywordMapper = {
   },
   uuid: (coercion?: boolean, version: '3' | '4' = '3', min?: number, max?: number) => {
     return [
-      coercion ? (version === '4' ? 'z.coerce.uuid()' : 'z.coerce.string().uuid()') : version === '4' ? 'z.uuid()' : 'z.string().uuid()',
+      coercion ? (version === '4' ? 'z.uuid()' : 'z.coerce.string().uuid()') : version === '4' ? 'z.uuid()' : 'z.string().uuid()',
       min !== undefined ? `.min(${min})` : undefined,
       max !== undefined ? `.max(${max})` : undefined,
     ]
@@ -151,7 +151,7 @@ const zodKeywordMapper = {
   },
   url: (coercion?: boolean, version: '3' | '4' = '3', min?: number, max?: number) => {
     return [
-      coercion ? (version === '4' ? 'z.coerce.url()' : 'z.coerce.string().url()') : version === '4' ? 'z.url()' : 'z.string().url()',
+      coercion ? (version === '4' ? 'z.url()' : 'z.coerce.string().url()') : version === '4' ? 'z.url()' : 'z.string().url()',
       min !== undefined ? `.min(${min})` : undefined,
       max !== undefined ? `.max(${max})` : undefined,
     ]
@@ -177,7 +177,7 @@ const zodKeywordMapper = {
   matches: (value = '', coercion?: boolean) => (coercion ? `z.coerce.string().regex(${value})` : `z.string().regex(${value})`),
   email: (coercion?: boolean, version: '3' | '4' = '3', min?: number, max?: number) => {
     return [
-      coercion ? (version === '4' ? 'z.coerce.email()' : 'z.coerce.string().email()') : version === '4' ? 'z.email()' : 'z.string().email()',
+      coercion ? (version === '4' ? 'z.email()' : 'z.coerce.string().email()') : version === '4' ? 'z.email()' : 'z.string().email()',
       min !== undefined ? `.min(${min})` : undefined,
       max !== undefined ? `.max(${max})` : undefined,
     ]


### PR DESCRIPTION
- In Zod 4 coerce does not support `z.uuid()`, `z.email()` or `z.url()` and coercion does not really make sense with the specific string subtypes. You could coerce a number to string, but you can't coerce to non-string to a valid uuid, url or email.
- Related to https://github.com/kubb-labs/kubb/issues/2057