### PR TITLE
Fix: Missing options in parse call method.

### DIFF
--- a/.changeset/heavy-baboons-show.md
+++ b/.changeset/heavy-baboons-show.md
@@ -1,0 +1,5 @@
+---
+"@kubb/oas": patch
+---
+
+Fix issue with not initialized oasClass

--- a/packages/oas/src/utils.ts
+++ b/packages/oas/src/utils.ts
@@ -89,7 +89,7 @@ export async function parse(
     const config = await loadConfig()
     const bundleResults = await bundle({ ref: pathOrApi, config, base: pathOrApi })
 
-    return parse(bundleResults.bundle.parsed as string)
+    return parse(bundleResults.bundle.parsed as string, {oasClass, canBundle, enablePaths })
   }
 
   const oasNormalize = new OASNormalize(pathOrApi, {


### PR DESCRIPTION
Fix issue with initializing custom oasClass

probably this fix also can fix that issue https://github.com/kubb-labs/kubb/issues/2156 for me this look like missing initializing custom oas.