### PR TITLE
fix: exit with code 1 on generate error

### DIFF
--- a/.changeset/fifty-parks-wave.md
+++ b/.changeset/fifty-parks-wave.md
@@ -1,0 +1,5 @@
+---
+"@kubb/cli": patch
+---
+
+Ensure the CLI exits with code 1 on generation errors, improving error detection.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -146,6 +146,7 @@ const command = defineCommand({
       await events.emit('lifecycle:end')
     } catch (error) {
       await events.emit('error', error as Error)
+      process.exit(1)
     }
   },
 })


### PR DESCRIPTION
## 🎯 Changes

This PR ensures the Kubb CLI exits with code 1 when any generation error occurs. This makes failures easier to detect, might improve CI reliability in any automatic CI runs and prevents false positives when generation fails due to misconfiguration or dependency issues. Investigating logs on every kubb generate is error-prone!

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
