### PR TITLE
fix(react-query): add TContext generic to mutationOptions

### DIFF
--- a/.changeset/hip-chicken-clean.md
+++ b/.changeset/hip-chicken-clean.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-react-query": major
+---
+
+Add TContext generic to mutationOptions for proper onMutate context typing

--- a/packages/plugin-react-query/src/components/MutationOptions.tsx
+++ b/packages/plugin-react-query/src/components/MutationOptions.tsx
@@ -95,10 +95,10 @@ export function MutationOptions({ name, clientName, dataReturnType, typeSchemas,
 
   return (
     <File.Source name={name} isExportable isIndexable>
-      <Function name={name} export params={params.toConstructor()}>
+      <Function name={name} export params={params.toConstructor()} generics={['TContext = unknown']}>
         {`
       const mutationKey = ${mutationKeyName}(${mutationKeyParams.toCall()})
-      return mutationOptions<${TData}, ResponseErrorConfig<${TError}>, ${TRequest ? `{${TRequest}}` : 'void'}, typeof mutationKey>({
+      return mutationOptions<${TData}, ResponseErrorConfig<${TError}>, ${TRequest ? `{${TRequest}}` : 'void'}, TContext>({
         mutationKey,
         mutationFn: async(${dataParams.toConstructor()}) => {
           return ${clientName}(${clientParams.toCall()})

--- a/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/clientPostImportPath.ts
@@ -35,13 +35,15 @@ export async function updatePetWithForm(
   return updatePetWithFormMutationResponse.parse(res.data)
 }
 
-export function updatePetWithFormMutationOptions(config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {}) {
+export function updatePetWithFormMutationOptions<TContext = unknown>(
+  config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
+) {
   const mutationKey = updatePetWithFormMutationKey()
   return mutationOptions<
     UpdatePetWithFormMutationResponse,
     ResponseErrorConfig<UpdatePetWithForm405>,
     { petId: UpdatePetWithFormPathParams['petId']; data?: UpdatePetWithFormMutationRequest; params?: UpdatePetWithFormQueryParams },
-    typeof mutationKey
+    TContext
   >({
     mutationKey,
     mutationFn: async ({ petId, data, params }) => {

--- a/packages/plugin-react-query/src/generators/__snapshots__/updatePetById.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/updatePetById.ts
@@ -35,13 +35,15 @@ export async function updatePetWithForm(
   return updatePetWithFormMutationResponse.parse(res.data)
 }
 
-export function updatePetWithFormMutationOptions(config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {}) {
+export function updatePetWithFormMutationOptions<TContext = unknown>(
+  config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
+) {
   const mutationKey = updatePetWithFormMutationKey()
   return mutationOptions<
     UpdatePetWithFormMutationResponse,
     ResponseErrorConfig<UpdatePetWithForm405>,
     { petId: UpdatePetWithFormPathParams['petId']; data?: UpdatePetWithFormMutationRequest; params?: UpdatePetWithFormQueryParams },
-    typeof mutationKey
+    TContext
   >({
     mutationKey,
     mutationFn: async ({ petId, data, params }) => {

--- a/packages/plugin-react-query/src/generators/__snapshots__/updatePetByIdPathParamsObject.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/updatePetByIdPathParamsObject.ts
@@ -35,13 +35,15 @@ export async function updatePetWithForm(
   return updatePetWithFormMutationResponse.parse(res.data)
 }
 
-export function updatePetWithFormMutationOptions(config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {}) {
+export function updatePetWithFormMutationOptions<TContext = unknown>(
+  config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
+) {
   const mutationKey = updatePetWithFormMutationKey()
   return mutationOptions<
     UpdatePetWithFormMutationResponse,
     ResponseErrorConfig<UpdatePetWithForm405>,
     { petId: UpdatePetWithFormPathParams['petId']; data?: UpdatePetWithFormMutationRequest; params?: UpdatePetWithFormQueryParams },
-    typeof mutationKey
+    TContext
   >({
     mutationKey,
     mutationFn: async ({ petId, data, params }) => {

--- a/packages/plugin-react-query/src/generators/__snapshots__/updatePetByIdWithCustomOptions.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/updatePetByIdWithCustomOptions.ts
@@ -36,13 +36,15 @@ export async function updatePetWithForm(
   return updatePetWithFormMutationResponse.parse(res.data)
 }
 
-export function updatePetWithFormMutationOptions(config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {}) {
+export function updatePetWithFormMutationOptions<TContext = unknown>(
+  config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: typeof fetch } = {},
+) {
   const mutationKey = updatePetWithFormMutationKey()
   return mutationOptions<
     UpdatePetWithFormMutationResponse,
     ResponseErrorConfig<UpdatePetWithForm405>,
     { petId: UpdatePetWithFormPathParams['petId']; data?: UpdatePetWithFormMutationRequest; params?: UpdatePetWithFormQueryParams },
-    typeof mutationKey
+    TContext
   >({
     mutationKey,
     mutationFn: async ({ petId, data, params }) => {


### PR DESCRIPTION
## 🎯 Changes

The generated `mutationOptions` function was using `typeof mutationKey` as the 4th generic parameter (TContext), making it impossible to properly type the context returned by `onMutate` when spreading the options into `useMutation`.
This PR adds a `TContext = unknown` generic to `mutationOptions`, consistent with how the generated `useXxxMutation` hooks already handle it.

### Before
```typescript
export function updatePetMutationOptions(config = {}) {
  return mutationOptions<TData, TError, TRequest, typeof mutationKey>({ ... })
}
```
### After
```typescript
export function updatePetMutationOptions<TContext = unknown>(config = {}) {
  return mutationOptions<TData, TError, TRequest, TContext>({ ... })
}
```

This allows proper typing when using custom onMutate context:
```typescript
useMutation({
  ...updatePetMutationOptions(),
  onMutate: async () => {
    const previousPet = queryClient.getQueryData(queryKey);
    return { previousPet }; 
  },
  onSuccess(data, variables, onMutateResult, context) {
    onMutateResult.previousPet; // ✅ properly typed
  },
});
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

