### PR TITLE
feat(cli): add oxfmt formatter support

### DIFF
--- a/.changeset/cool-monkeys-enter.md
+++ b/.changeset/cool-monkeys-enter.md
@@ -1,0 +1,6 @@
+---
+"@kubb/core": minor
+"@kubb/cli": minor
+---
+
+Add oxfmt as a new formatter option

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -285,7 +285,8 @@ Added `'auto'` option for both `output.format` and `output.lint` configurations.
 
 When `format: 'auto'` is set, Kubb checks for formatters in this order:
 1. **biome** (first choice)
-2. **prettier** (second choice)
+2. **oxfmt** (second choice)
+3. **prettier** (third choice)
 
 ::: code-group
 
@@ -304,7 +305,7 @@ export default defineConfig({
   input: { path: './petStore.yaml' },
   output: {
     path: './src/gen',
-    format: 'auto', // Automatically detects biome or prettier
+    format: 'auto', // Automatically detects biome or oxfmt or prettier
   },
 })
 ```

--- a/docs/getting-started/configure.md
+++ b/docs/getting-started/configure.md
@@ -208,9 +208,10 @@ Code formatter to use on generated files.
 | Required: | `false`                                     |
 |  Default: | `'prettier'`                                |
 
-- `'auto'` - Automatically detect and use available formatter (checks for biome, then prettier)
+- `'auto'` - Automatically detect and use available formatter (checks for biome, oxfmt then prettier)
 - `'prettier'` - Format with [Prettier](https://prettier.io/) (default, included since v3.17.1)
 - `'biome'` - Format with [Biome](https://biomejs.dev/)
+- `'oxfmt'` - Format with [Oxfmt](https://oxc.rs/docs/guide/usage/formatter)
 - `false` - Skip formatting
 
 > [!NOTE]

--- a/packages/cli/src/utils/detectFormatter.ts
+++ b/packages/cli/src/utils/detectFormatter.ts
@@ -1,16 +1,16 @@
 import { execaCommand } from 'execa'
 
-type Formatter = 'biome' | 'prettier'
+type Formatter = 'biome' | 'prettier' | 'oxfmt'
 
 /**
  * Check if a formatter command is available in the system.
  *
- * @param formatter - The formatter to check ('biome' or 'prettier')
+ * @param formatter - The formatter to check ('biome', 'prettier', or 'oxfmt')
  * @returns Promise that resolves to true if the formatter is available, false otherwise
  *
  * @remarks
  * This function checks availability by running `<formatter> --version` command.
- * All supported formatters (biome, prettier) implement the --version flag.
+ * All supported formatters (biome, prettier, oxfmt) implement the --version flag.
  */
 async function isFormatterAvailable(formatter: Formatter): Promise<boolean> {
   try {
@@ -28,7 +28,7 @@ async function isFormatterAvailable(formatter: Formatter): Promise<boolean> {
  * @returns Promise that resolves to the first available formatter or undefined if none are found
  *
  * @remarks
- * Checks in order of preference: biome, prettier.
+ * Checks in order of preference: biome, oxfmt, prettier.
  * Uses the `--version` flag to detect if each formatter command is available.
  * This is a reliable method as all supported formatters implement this flag.
  *
@@ -43,7 +43,7 @@ async function isFormatterAvailable(formatter: Formatter): Promise<boolean> {
  * ```
  */
 export async function detectFormatter(): Promise<Formatter | undefined> {
-  const formatters: Formatter[] = ['biome', 'prettier']
+  const formatters: Formatter[] = ['biome', 'oxfmt', 'prettier']
 
   for (const formatter of formatters) {
     if (await isFormatterAvailable(formatter)) {

--- a/packages/cli/src/utils/formatters.ts
+++ b/packages/cli/src/utils/formatters.ts
@@ -1,0 +1,17 @@
+export const formatters = {
+  prettier: {
+    command: 'prettier',
+    args: (outputPath: string) => ['--ignore-unknown', '--write', outputPath],
+    errorMessage: 'Prettier not found',
+  },
+  biome: {
+    command: 'biome',
+    args: (outputPath: string) => ['format', '--write', outputPath],
+    errorMessage: 'Biome not found',
+  },
+  oxfmt: {
+    command: 'oxfmt',
+    args: (outputPath: string) => [outputPath],
+    errorMessage: 'Oxfmt not found',
+  },
+} as const

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -93,7 +93,7 @@ export type Config<TInput = Input> = {
      * - 'biome': Uses Biome for code formatting.
      *
      */
-    format?: 'auto' | 'prettier' | 'biome' | false
+    format?: 'auto' | 'prettier' | 'biome' | 'oxfmt' | false
     /**
      * Specifies the linter that should be used to analyze the code.
      * The accepted values indicate different linting tools.


### PR DESCRIPTION
## 🎯 Changes

Add [oxfmt](https://github.com/user/oxfmt) as a new formatter option for generated files.

### What's included:
- Add oxfmt to formatters config (`packages/cli/src/utils/formatters.ts`)
- Update `detectFormatter` to detect oxfmt with priority: biome > oxfmt > prettier
- Update types to include `'oxfmt'` option in `format` config
- Update documentation

### Usage:
```ts
// kubb.config.ts
export default defineConfig({
  output: {
    format: 'oxfmt', // or 'auto' to auto-detect
  },
})
```

### Why oxfmt?
Oxfmt is a fast Rust-based formatter (part of the oxc toolchain, like oxlint which is already supported). Adding it provides consistency for users already using oxlint for linting.

## ✅ Checklist
- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact
- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

## 💡 Follow-up
I noticed the linter section uses the same pattern (repeated if-blocks for eslint/biome/oxlint). Happy to submit a follow-up PR to refactor both formatters and linters into a unified declarative config if you're interested !