### PR TITLE
fix: remove unused fetch import when client plugin is active

### DIFF
--- a/.changeset/icy-clouds-sin.md
+++ b/.changeset/icy-clouds-sin.md
@@ -1,0 +1,9 @@
+---
+"@kubb/plugin-svelte-query": minor
+"@kubb/plugin-react-query": minor
+"@kubb/plugin-solid-query": minor
+"@kubb/plugin-vue-query": minor
+"@kubb/plugin-swr": minor
+---
+
+Remove unused fetch import when client plugin is active

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -104,13 +104,15 @@ export const infiniteQueryGenerator = createReactGenerator<PluginReactQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-react-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/mutationGenerator.tsx
@@ -91,13 +91,15 @@ export const mutationGenerator = createReactGenerator<PluginReactQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={mutation.file.path}

--- a/packages/plugin-react-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/queryGenerator.tsx
@@ -96,13 +96,15 @@ export const queryGenerator = createReactGenerator<PluginReactQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseInfiniteQueryGenerator.tsx
@@ -92,13 +92,15 @@ export const suspenseInfiniteQueryGenerator = createReactGenerator<PluginReactQu
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/suspenseQueryGenerator.tsx
@@ -108,13 +108,15 @@ export const suspenseQueryGenerator = createReactGenerator<PluginReactQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-solid-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-solid-query/src/generators/mutationGenerator.tsx
@@ -86,13 +86,15 @@ export const mutationGenerator = createReactGenerator<PluginSolidQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={mutation.file.path}

--- a/packages/plugin-solid-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-solid-query/src/generators/queryGenerator.tsx
@@ -92,13 +92,15 @@ export const queryGenerator = createReactGenerator<PluginSolidQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-svelte-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-svelte-query/src/generators/mutationGenerator.tsx
@@ -86,13 +86,15 @@ export const mutationGenerator = createReactGenerator<PluginSvelteQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={mutation.file.path}

--- a/packages/plugin-svelte-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-svelte-query/src/generators/queryGenerator.tsx
@@ -94,13 +94,15 @@ export const queryGenerator = createReactGenerator<PluginSvelteQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-swr/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-swr/src/generators/mutationGenerator.tsx
@@ -86,13 +86,15 @@ export const mutationGenerator = createReactGenerator<PluginSwr>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={mutation.file.path}

--- a/packages/plugin-swr/src/generators/queryGenerator.tsx
+++ b/packages/plugin-swr/src/generators/queryGenerator.tsx
@@ -93,13 +93,15 @@ export const queryGenerator = createReactGenerator<PluginSwr>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -106,13 +106,15 @@ export const infiniteQueryGenerator = createReactGenerator<PluginVueQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}

--- a/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/mutationGenerator.tsx
@@ -86,13 +86,15 @@ export const mutationGenerator = createReactGenerator<PluginVueQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={mutation.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={mutation.file.path}

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -94,13 +94,15 @@ export const queryGenerator = createReactGenerator<PluginVueQuery>({
         )}
         {options.client.importPath ? (
           <>
-            <File.Import name={'fetch'} path={options.client.importPath} />
+            {!shouldUseClientPlugin && <File.Import name={'fetch'} path={options.client.importPath} />}
             <File.Import name={['Client', 'RequestConfig', 'ResponseErrorConfig']} path={options.client.importPath} isTypeOnly />
             {options.client.dataReturnType === 'full' && <File.Import name={['ResponseConfig']} path={options.client.importPath} isTypeOnly />}
           </>
         ) : (
           <>
-            <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            {!shouldUseClientPlugin && (
+              <File.Import name={['fetch']} root={query.file.path} path={path.resolve(config.root, config.output.path, '.kubb/fetch.ts')} />
+            )}
             <File.Import
               name={['Client', 'RequestConfig', 'ResponseErrorConfig']}
               root={query.file.path}


### PR DESCRIPTION
## 🎯 Changes

When `pluginClient` is active (`shouldUseClientPlugin === true`), the query/mutation files import the named client function (e.g. `equipmentList`) from the generated client module, `fetch` is never called directly in these files.

However, `<File.Import name={'fetch'} />` is emitted unconditionally, resulting in a dead import in every generated hook/queryOptions file.

This was introduced in [76322c11d](https://github.com/kubb-labs/kubb/commit/76322c11d64e2be7d1b9d3dbf351f1f7cb322f48#diff-1d91fc05d6463ad8a3f774ffe41eb7a54f47e95e4ddd59cadfc81a181d4ee017) (Jan 24, 2025) which removed the `!hasClientPlugin` guard that existed in [021ba9616](https://github.com/kubb-labs/kubb/commit/021ba9616109876b737245b86db2204b128ffe52#diff-1d91fc05d6463ad8a3f774ffe41eb7a54f47e95e4ddd59cadfc81a181d4ee017) (Jan 21, 2025). 

**Fix:** Guard the `fetch` import with `!shouldUseClientPlugin` in both the `importPath` and `.kubb/fetch.ts` branches.

**Affected plugins (14 files):**
- `plugin-react-query`: queryGenerator, suspenseQueryGenerator, infiniteQueryGenerator, suspenseInfiniteQueryGenerator, mutationGenerator
- `plugin-vue-query`: queryGenerator, infiniteQueryGenerator, mutationGenerator
- `plugin-svelte-query`: queryGenerator, mutationGenerator
- `plugin-solid-query`: queryGenerator, mutationGenerator
- `plugin-swr`: queryGenerator, mutationGenerator

> `plugin-mcp` is **not** affected — `<Client>` is always rendered inline, so `fetch` is always consumed.


## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).