### PR TITLE
[plugin-zod] Fix duplicate ToZod import

### DIFF
--- a/.changeset/olive-llamas-perform.md
+++ b/.changeset/olive-llamas-perform.md
@@ -1,0 +1,5 @@
+---
+'@kubb/plugin-zod': patch
+---
+
+Prevent `typed: true` Zod generation from emitting duplicate `ToZod` imports in generated files.

--- a/packages/plugin-zod/src/generators/__snapshots__/optionalPetTyped.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/optionalPetTyped.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import * as z from 'zod'
-import { ToZod } from './test/.kubb/ToZod'
+import type { ToZod } from './test/.kubb/ToZod'
 
 export const optionalPet = z.object({
   id: z.optional(z.number().int()),

--- a/packages/plugin-zod/src/generators/__snapshots__/pets.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/pets.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import * as z from 'zod'
-import { ToZod } from './test/.kubb/ToZod'
+import type { ToZod } from './test/.kubb/ToZod'
 
 export const pets = z.array(
   z.object({

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -374,6 +374,71 @@ describe('zodGenerator schema', async () => {
 
     await matchFiles(fabric.files)
   })
+
+  test('typed schemas add ToZod once as a type-only import', async () => {
+    const oas = await parse(path.resolve(__dirname, '../../mocks/petStore.yaml'))
+
+    const options: PluginZod['resolvedOptions'] = {
+      dateType: 'date',
+      transformers: {},
+      inferred: false,
+      typed: true,
+      unknownType: 'any',
+      integerType: 'number',
+      mapper: {},
+      importPath: 'zod',
+      coercion: false,
+      operations: false,
+      override: [],
+      output: {
+        path: '.',
+      },
+      group: undefined,
+      wrapOutput: undefined,
+      version: '3',
+      guidType: 'uuid',
+      emptySchemaType: 'unknown',
+      mini: false,
+    }
+    const plugin = { options } as Plugin<PluginZod>
+    const mockedPluginManager = createMockedPluginManager('Pets')
+    const generator = new SchemaGenerator(options, {
+      fabric,
+      oas,
+      pluginManager: mockedPluginManager,
+      plugin,
+      contentType: 'application/json',
+      include: undefined,
+      override: undefined,
+      mode: 'split',
+      output: './gen',
+    })
+
+    const { schemas } = getSchemas({ oas })
+    const schema = schemas.Pets as SchemaObject
+    const tree = generator.parse({ schema, name: 'Pets', parentName: null })
+
+    await buildSchema(
+      {
+        name: 'Pets',
+        tree,
+        value: schema,
+      },
+      {
+        config: { root: '.', output: { path: 'test' } } as Config,
+        fabric,
+        generator,
+        Component: zodGenerator.Schema,
+        plugin,
+      },
+    )
+
+    const file = fabric.files.at(0)
+    const toZodImports = file?.imports?.filter((item) => item.path.endsWith('.kubb/ToZod.ts'))
+
+    expect(toZodImports).toHaveLength(1)
+    expect(toZodImports?.[0]?.isTypeOnly).toBe(true)
+  })
 })
 
 describe('zodGenerator operation', async () => {
@@ -500,6 +565,61 @@ describe('zodGenerator operation', async () => {
     })
 
     await matchFiles(fabric.files)
+  })
+
+  test('typed operations add ToZod once per generated file', async () => {
+    const oas = await parse(path.resolve(__dirname, '../../mocks/petStore.yaml'))
+
+    const options: PluginZod['resolvedOptions'] = {
+      dateType: 'date',
+      transformers: {},
+      typed: true,
+      inferred: false,
+      unknownType: 'any',
+      mapper: {},
+      importPath: 'zod',
+      coercion: false,
+      integerType: 'number',
+      operations: false,
+      override: [],
+      output: {
+        path: '.',
+      },
+      group: undefined,
+      wrapOutput: undefined,
+      version: '3',
+      guidType: 'uuid',
+      emptySchemaType: 'unknown',
+      mini: false,
+    }
+    const plugin = { options } as Plugin<PluginZod>
+    const mockedPluginManager = createMockedPluginManager('createPets')
+    const generator = new OperationGenerator(options, {
+      fabric,
+      oas,
+      include: undefined,
+      pluginManager: mockedPluginManager,
+      plugin,
+      contentType: undefined,
+      override: undefined,
+      mode: 'split',
+      exclude: [],
+    })
+    const operation = oas.operation('/pets', 'post')
+
+    await buildOperation(operation, {
+      config: { root: '.', output: { path: 'test' } } as Config,
+      fabric,
+      generator,
+      Component: zodGenerator.Operation,
+      plugin,
+    })
+
+    const file = fabric.files.at(0)
+    const toZodImports = file?.imports?.filter((item) => item.path.endsWith('.kubb/ToZod.ts'))
+
+    expect(toZodImports).toHaveLength(1)
+    expect(toZodImports?.[0]?.isTypeOnly).toBe(true)
   })
 
   describe('wrapOutput', () => {

--- a/packages/plugin-zod/src/generators/zodGenerator.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.tsx
@@ -39,6 +39,7 @@ export const zodGenerator = createReactGenerator<PluginZod>({
     const operationSchemas = [schemas.pathParams, schemas.queryParams, schemas.headerParams, schemas.statusCodes, schemas.request, schemas.response]
       .flat()
       .filter(Boolean)
+    const toZodPath = path.resolve(config.root, config.output.path, '.kubb/ToZod.ts')
 
     const mapOperationSchema = ({ name, schema: schemaOriginal, description, keysToOmit: keysToOmitOriginal, ...options }: OperationSchemaType) => {
       let schemaObject = schemaOriginal
@@ -102,9 +103,6 @@ export const zodGenerator = createReactGenerator<PluginZod>({
       return (
         <>
           {typed && <File.Import isTypeOnly root={file.path} path={type.file.path} name={[type.name]} />}
-          {typed && version === '3' && (
-            <File.Import name={['ToZod']} isTypeOnly root={file.path} path={path.resolve(config.root, config.output.path, '.kubb/ToZod.ts')} />
-          )}
           {imports.map((imp) => (
             <File.Import key={[imp.path, imp.name, imp.isTypeOnly].join('-')} root={file.path} path={imp.path} name={imp.name} />
           ))}
@@ -139,6 +137,7 @@ export const zodGenerator = createReactGenerator<PluginZod>({
         footer={getFooter({ oas, output: plugin.options.output })}
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={plugin.options.importPath} isNameSpace={isZodImport} />
+        {typed && version === '3' && <File.Import name={['ToZod']} isTypeOnly root={file.path} path={toZodPath} />}
         {operationSchemas.map(mapOperationSchema)}
       </File>
     )
@@ -165,6 +164,7 @@ export const zodGenerator = createReactGenerator<PluginZod>({
     }
 
     const isZodImport = importPath === 'zod' || importPath === 'zod/mini'
+    const toZodPath = path.resolve(config.root, config.output.path, '.kubb/ToZod.ts')
 
     return (
       <File
@@ -176,9 +176,7 @@ export const zodGenerator = createReactGenerator<PluginZod>({
       >
         <File.Import name={isZodImport ? 'z' : ['z']} path={importPath} isNameSpace={isZodImport} />
         {typed && <File.Import isTypeOnly root={zod.file.path} path={type.file.path} name={[type.name]} />}
-        {typed && version === '3' && (
-          <File.Import name={['ToZod']} root={zod.file.path} path={path.resolve(config.root, config.output.path, '.kubb/ToZod.ts')} />
-        )}
+        {typed && version === '3' && <File.Import name={['ToZod']} isTypeOnly root={zod.file.path} path={toZodPath} />}
         {imports.map((imp) => (
           <File.Import key={[imp.path, imp.name, imp.isTypeOnly].join('-')} root={zod.file.path} path={imp.path} name={imp.name} />
         ))}


### PR DESCRIPTION
## Summary
- prevent plugin-zod from emitting duplicate ToZod imports when typed: true is used
- move the ToZod import to the file level for operation generation and make it type-only consistently
- add regression coverage and a patch changeset

## Testing
- env COREPACK_HOME=/tmp/corepack corepack pnpm --filter @kubb/core --filter @kubb/oas --filter @kubb/plugin-oas --filter @kubb/plugin-ts build
- env COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config ./configs/vitest.config.ts packages/plugin-zod/src/parser.test.ts packages/plugin-zod/src/generators/operationsGenerator.test.tsx packages/plugin-zod/src/generators/zodGenerator.test.tsx
- env COREPACK_HOME=/tmp/corepack corepack pnpm --filter @kubb/plugin-zod typecheck
- env COREPACK_HOME=/tmp/corepack corepack pnpm exec biome check packages/plugin-zod/src/generators/zodGenerator.tsx packages/plugin-zod/src/generators/zodGenerator.test.tsx packages/plugin-zod/src/generators/__snapshots__/pets.ts packages/plugin-zod/src/generators/__snapshots__/optionalPetTyped.ts