### PR TITLE
fix(plugin-ts): prevent AST crash on negative literal enum values

### DIFF
--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -481,7 +481,13 @@ export function createEnumDeclaration({
           enums
             .map(([_key, value]) => {
               if (isNumber(value)) {
-                return factory.createLiteralTypeNode(factory.createNumericLiteral(value?.toString()))
+                if (value < 0) {
+                  return factory.createLiteralTypeNode(
+                    factory.createPrefixUnaryExpression(ts.SyntaxKind.MinusToken, factory.createNumericLiteral(Math.abs(value).toString()))
+                  )
+                } else {
+                  return factory.createLiteralTypeNode(factory.createNumericLiteral(value?.toString()))
+                }
               }
 
               if (typeof value === 'boolean') {


### PR DESCRIPTION
## Summary
Fixes an issue where `@kubb/plugin-ts` crashes when generating literal enums that contain negative numeric values.

## Problem
Fixes #2734.
When `enumType: 'literal'` or `'inlineLiteral'` is used and an enum contains a negative number (e.g. `enum: [-1, 0, 5]`),  invokes `factory.createNumericLiteral(value?.toString())`. Passing a negative string (like `"-1"`) to `createNumericLiteral` is an invalid AST construct in the TypeScript compiler API, causing the build to crash or output malformed code.

## Solution
Updated `factory.ts` to wrap negative numeric values inside a `PrefixUnaryExpression` using `ts.SyntaxKind.MinusToken` and the absolute value, ensuring a valid and compilable TypeScript AST.