### PR TITLE
fix: accept UserGroup in ResolverContext and apply default name in defaultResolvePath

### DIFF
--- a/.changeset/remove-user-group-type.md
+++ b/.changeset/remove-user-group-type.md
@@ -1,0 +1,9 @@
+---
+"@kubb/core": minor
+---
+
+Remove `UserGroup` type and make `Group.name` optional.
+
+`UserGroup` and `Group` were structurally identical after making `name` optional on `Group`, so `UserGroup` has been removed. Use `Group` everywhere.
+
+`defaultResolvePath` now supplies built-in defaults when `name` is omitted: `${camelCase(tag)}Controller` for tag groups and the first path segment for path groups.

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -218,7 +218,10 @@ export function defaultResolvePath({ baseName, pathMode, tag, path: groupPath }:
 
   if (group && (groupPath || tag)) {
     const groupValue = group.type === 'path' ? groupPath! : tag!
-    const defaultName = group.type === 'tag' ? ({ group: g }: { group: string }) => `${camelCase(g)}Controller` : ({ group: g }: { group: string }) => g.split('/').filter(Boolean)[0] ?? g
+    const defaultName =
+      group.type === 'tag'
+        ? ({ group: g }: { group: string }) => `${camelCase(g)}Controller`
+        : ({ group: g }: { group: string }) => g.split('/').filter(Boolean)[0] ?? g
     const resolveName = group.name ?? defaultName
     return path.resolve(root, output.path, resolveName({ group: groupValue }), baseName)
   }

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -217,7 +217,10 @@ export function defaultResolvePath({ baseName, pathMode, tag, path: groupPath }:
   }
 
   if (group && (groupPath || tag)) {
-    return path.resolve(root, output.path, group.name({ group: group.type === 'path' ? groupPath! : tag! }), baseName)
+    const groupValue = group.type === 'path' ? groupPath! : tag!
+    const defaultName = group.type === 'tag' ? ({ group: g }: { group: string }) => `${camelCase(g)}Controller` : ({ group: g }: { group: string }) => g.split('/').filter(Boolean)[0] ?? g
+    const resolveName = group.name ?? defaultName
+    return path.resolve(root, output.path, resolveName({ group: groupValue }), baseName)
   }
 
   return path.resolve(root, output.path, baseName)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -804,7 +804,7 @@ export type ResolverPathParams = {
 export type ResolverContext = {
   root: string
   output: Output
-  group?: Group
+  group?: UserGroup
   /**
    * Plugin name used to populate `meta.pluginName` on the resolved file.
    */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -593,8 +593,9 @@ export type Group = {
   type: 'tag' | 'path'
   /**
    * Returns the subdirectory name for a given group value.
+   * Defaults to `${camelCase(group)}Controller` for tags and the first path segment for paths.
    */
-  name: (context: { group: string }) => string
+  name?: (context: { group: string }) => string
 }
 
 export type LoggerOptions = {
@@ -804,7 +805,7 @@ export type ResolverPathParams = {
 export type ResolverContext = {
   root: string
   output: Output
-  group?: UserGroup
+  group?: Group
   /**
    * Plugin name used to populate `meta.pluginName` on the resolved file.
    */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -570,20 +570,6 @@ export type Output<_TOptions = unknown> = {
   override?: boolean
 }
 
-export type UserGroup = {
-  /**
-   * Determines how files are grouped into subdirectories.
-   * - `'tag'` groups files by OpenAPI tags.
-   * - `'path'` groups files by OpenAPI paths.
-   */
-  type: 'tag' | 'path'
-  /**
-   * Returns the subdirectory name for a given group value.
-   * Defaults to `${camelCase(group)}Controller` for tags and the first path segment for paths.
-   */
-  name?: (context: { group: string }) => string
-}
-
 export type Group = {
   /**
    * Determines how files are grouped into subdirectories.


### PR DESCRIPTION
UserGroup.name is optional (user-facing API), but Group.name is required.
Plugin generators assign UserGroup directly to ResolverContext.group, causing
TS2322 errors across plugin-client, plugin-faker, plugin-msw, plugin-cypress,
plugin-mcp, plugin-react-query, and plugin-vue-query.

Change ResolverContext.group from Group to UserGroup so plugins can pass the
user config directly. Update defaultResolvePath to supply the documented
defaults when name is absent: camelCase(tag)Controller for tag groups and the
first path segment for path groups.

https://claude.ai/code/session_01VGDZBMWdLGBZjfpD3e1yMG