### PR TITLE
feat(core): add virtual module support for plugin authors

### DIFF
--- a/packages/adapter-oas/CHANGELOG.md
+++ b/packages/adapter-oas/CHANGELOG.md
@@ -268,7 +268,6 @@
 ### Patch Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -280,7 +279,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -333,7 +331,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`
@@ -349,7 +346,6 @@
 ### Minor Changes
 
 - [#2821](https://github.com/kubb-labs/kubb/pull/2821) [`f4105fe`](https://github.com/kubb-labs/kubb/commit/f4105fe44e46ec2846e665fd6079290e6d6ce6c6) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - **`@kubb/plugin-ts`**: When `legacy: true`, the type generator now fully matches the v4 output:
-
   - Grouped parameter types: `<OperationId>PathParams`, `<OperationId>QueryParams`, `<OperationId>HeaderParams`
   - No `<OperationId>RequestConfig` type emitted
   - Wrapper types (`Mutation`/`Query`) use `{ Response, Request?, QueryParams?, Errors }` shape
@@ -359,7 +355,6 @@
   Six `@deprecated` resolver methods added to `ResolverTs` for grouped parameter naming (`resolvePathParamsName`, `resolveQueryParamsName`, `resolveHeaderParamsName` and typed variants). Implemented only in `resolverTsLegacy`; will be removed in v6.
 
   **`@kubb/adapter-oas`**: `collisionDetection` is now part of the public API with a default of `true`.
-
   - `collisionDetection: true` (default) → full-path enum names, e.g. `OrderParamsStatusEnum`
   - `collisionDetection: false` → immediate-parent enum names with numeric deduplication, e.g. `ParamsStatusEnum`, `ParamsStatusEnum2`
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -119,7 +119,6 @@
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`f7d19bb`](https://github.com/kubb-labs/kubb/commit/f7d19bb69177fbd1b54c855423b3b55c399678b0) Thanks [@pull](https://github.com/apps/pull)! - Decouple `@kubb/agent` from static plugin knowledge.
 
   Plugins are now resolved at runtime via dynamic `import()` instead of being hard-coded as dependencies. This means:
-
   - `@kubb/agent` no longer bundles or lists any `@kubb/plugin-*` packages as dependencies.
   - Any Kubb plugin (or third-party plugin) is supported — install whichever plugins you need alongside the agent.
   - Plugin factory resolution tries three strategies in order: camelCase named export (`pluginReactQuery`), `default` export, or first exported function.
@@ -219,7 +218,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -1745,7 +1743,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio

--- a/packages/ast/CHANGELOG.md
+++ b/packages/ast/CHANGELOG.md
@@ -43,7 +43,6 @@
   ### `@kubb/ast`
 
   New node types in `nodes/code.ts`:
-
   - `ConstNode` (`kind: 'Const'`) — mirrors the `Const` component
   - `TypeNode` (`kind: 'Type'`) — mirrors the `Type` component; a plain type alias declaration with `name`, `export`, `JSDoc`, and `nodes` fields
   - `FunctionNode` (`kind: 'Function'`) — mirrors the `Function` component
@@ -78,7 +77,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -91,13 +89,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -106,26 +102,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -134,26 +129,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -168,7 +162,6 @@
   Complete rewrite of `@kubb/plugin-zod` to the v5 AST-based architecture. The plugin no longer depends on `@kubb/plugin-oas` or `@kubb/oas`; it operates entirely on the `@kubb/ast` node graph.
 
   **Breaking changes:**
-
   - `mapper` option removed — no replacement (naming is now controlled via `resolvers`)
   - `version` option removed — Zod v3 is no longer supported; Kubb v5 always generates Zod v4 code
   - `contentType` option removed — moved to `adapterOas(...)`
@@ -182,21 +175,18 @@
   - Naming conventions (default preset): response status schemas are now named `<operationId>Status<code>Schema` instead of `<operationId><code>Schema`. Use `compatibilityPreset: 'kubbV4'` to keep the old names.
 
   **New options:**
-
   - `paramsCasing?: 'camelcase'` — apply camelCase to path/query/header parameter names in operation schemas
   - `compatibilityPreset?: 'default' | 'kubbV4'` — select naming conventions; `'kubbV4'` reproduces Kubb v4 names for a gradual migration
   - `resolvers?: Array<ResolverZod>` — provide custom resolver instances to override naming conventions
   - `transformers?: Array<Visitor>` — AST visitor array applied to each `SchemaNode` before printing (replaces the old `transformers.schema` callback)
 
   **New exports:**
-
   - `resolverZod` — default v5 resolver (camelCase + `Schema` suffix)
   - `resolverZodLegacy` — Kubb v4-compatible resolver (use with `compatibilityPreset: 'kubbV4'`)
   - `printerZod` — Zod v4 chainable-API printer factory (`definePrinter`)
   - `printerZodMini` — Zod v4 Mini functional-API printer factory
 
   ### `@kubb/ast`
-
   - `createSchema`, `createProperty`, `createOperation` factory functions now automatically infer and set the `primitive` field based on the node `type`, reducing boilerplate in tests and custom generators.
 
 ## 5.0.0-alpha.24
@@ -206,7 +196,6 @@
 ### Minor Changes
 
 - [#2931](https://github.com/kubb-labs/kubb/pull/2931) [`8cfa19a`](https://github.com/kubb-labs/kubb/commit/8cfa19adbe681d4466f0ff97a8c14ece8ba1e5d8) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Added `createOperationParams(node, options)` utility that converts an `OperationNode` into a `FunctionParametersNode`.
   - Added `reference` variant to `TypeNode` for plain type name strings (e.g. `'string'`, `'QueryParams'`), so all type annotations in the AST are always `TypeNode` — never raw strings.
   - Changed `FunctionParameterNode.type` from `string | TypeNode` to `TypeNode`.
@@ -215,7 +204,6 @@
   - Removed `typeToString` helper from `utils.ts`; `resolveType` now returns `TypeNode` directly.
 
   ### `@kubb/plugin-ts`
-
   - Updated `functionPrinter` to handle all three `TypeNode` variants (`member`, `struct`, `reference`) explicitly; removed all `typeof … === 'string'` checks.
 
 ## 5.0.0-alpha.22
@@ -237,7 +225,6 @@
 ### Minor Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -249,7 +236,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -262,17 +248,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -286,7 +269,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -69,7 +69,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -192,7 +191,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -525,7 +523,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -633,7 +630,6 @@
 - [#2607](https://github.com/kubb-labs/kubb/pull/2607) [`e244177`](https://github.com/kubb-labs/kubb/commit/e244177168a2e32a2818626a5efde990d1f1806f) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Add anonymous telemetry to the Kubb CLI to track usage data (command, plugins, version, duration, platform, Node.js version, and file count). No OpenAPI specs, file paths, plugin options, or secrets are ever collected.
 
   Telemetry can be disabled at any time by setting:
-
   - `DO_NOT_TRACK=1` – standard opt-out flag recognised by many developer tools ([consoledonottrack.com](https://consoledonottrack.com))
   - `KUBB_DISABLE_TELEMETRY=1` – Kubb-specific opt-out flag
 
@@ -767,7 +763,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio
@@ -903,7 +898,6 @@
 - [#2396](https://github.com/kubb-labs/kubb/pull/2396) [`b5c4fd9`](https://github.com/kubb-labs/kubb/commit/b5c4fd94711b1657cdffe9a629229cd0f708a4b1) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add new `init` command for interactive project setup
 
   The CLI now includes a new `kubb init` command that provides an interactive setup wizard to quickly scaffold a Kubb project:
-
   - **Interactive prompts**: Uses `@clack/prompts` for a beautiful CLI experience
   - **Package manager detection**: Automatically detects `npm`, `pnpm`, `yarn`, or `bun`
   - **Plugin selection**: Multi-select from all 13 available Kubb plugins
@@ -918,7 +912,6 @@
   ```
 
   The command will guide you through:
-
   1. Creating a `package.json` (if needed)
   2. Selecting your OpenAPI specification path
   3. Choosing which plugins to install
@@ -1094,13 +1087,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -48,10 +48,10 @@
 
   ```ts
   // before – always returned the base Resolver type
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // Resolver
+  const resolver = driver.getResolver('@kubb/plugin-ts') // Resolver
 
   // after – returns the plugin's typed resolver
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+  const resolver = driver.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
   ```
 
   ### `GeneratorContext.getResolver`
@@ -61,9 +61,9 @@
   ```ts
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, ctx) {
-      const tsResolver = ctx.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+      const tsResolver = ctx.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -89,17 +89,14 @@
 - [#3095](https://github.com/kubb-labs/kubb/pull/3095) [`96ac140`](https://github.com/kubb-labs/kubb/commit/96ac140638e1c10bbdf91840f0c8271c91124c03) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Remove legacy plugin infrastructure now that all plugins use `definePlugin`.
 
   ### Removed types
-
   - `NormalizedPlugin` — internal plugin state is no longer part of the public API. Use `Plugin` for all external-facing plugin references.
   - `PluginContext` — replaced by the standalone `GeneratorContext` type.
   - `SchemaHook`, `OperationHook`, `OperationsHook` — unused hook type aliases.
 
   ### Renamed types
-
   - The internal `InternalPlugin` type (never public) was renamed to `NormalizedPlugin` for clarity, but this type is marked `@internal` and should not be used by plugin authors.
 
   ### Improved types
-
   - `ResolveOptionsContext` — marked `@internal`.
   - `FileMetaBase` — marked `@internal`.
   - `FileProcessor` — marked `@internal`.
@@ -114,10 +111,10 @@
 
   ```ts
   // Before
-  import type { NormalizedPlugin, PluginContext } from "@kubb/core";
+  import type { NormalizedPlugin, PluginContext } from '@kubb/core'
 
   // After
-  import type { Plugin, GeneratorContext } from "@kubb/core";
+  import type { Plugin, GeneratorContext } from '@kubb/core'
   ```
 
 ### Patch Changes
@@ -193,19 +190,18 @@
   **Before:**
 
   ```ts
-  import { getMode } from "@kubb/core";
-  getMode("src/gen/types.ts"); // 'single'
+  import { getMode } from '@kubb/core'
+  getMode('src/gen/types.ts') // 'single'
   ```
 
   **After:**
 
   ```ts
-  import { PluginDriver } from "@kubb/core";
-  PluginDriver.getMode("src/gen/types.ts"); // 'single'
+  import { PluginDriver } from '@kubb/core'
+  PluginDriver.getMode('src/gen/types.ts') // 'single'
   ```
 
   The following utilities have also been removed from `@kubb/core`'s public API as they are internal post-processing helpers used only by CLI/agent tooling:
-
   - `formatters` — moved to `@internals/utils`
   - `linters` — moved to `@internals/utils`
   - `detectFormatter` — moved to `@internals/utils`
@@ -306,13 +302,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -343,7 +339,6 @@
 - [#2990](https://github.com/kubb-labs/kubb/pull/2990) [`3ac7d1f`](https://github.com/kubb-labs/kubb/commit/3ac7d1f9b75099bfe793e35152e5c322e65aa6ad) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Update `@kubb/react-fabric` and `@kubb/fabric-core` to v0.16.0
 
 - [#2994](https://github.com/kubb-labs/kubb/pull/2994) [`9e6a772`](https://github.com/kubb-labs/kubb/commit/9e6a772c7ca1ee54e931d2dbf0f2448f67707c0e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add `@kubb/renderer-jsx` — a lightweight JSX renderer for Kubb plugins.
-
   - New package `@kubb/renderer-jsx` with a custom JSX runtime (`jsx-runtime`, `jsx-dev-runtime`)
   - Provides `createRenderer` to render JSX trees into `FileNode` arrays without React
   - Built-in components: `File`, `Const`, `Function`, `Type`, `Root`
@@ -368,7 +363,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -377,19 +371,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.
@@ -410,14 +404,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -425,25 +419,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -451,7 +445,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -513,7 +507,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -526,13 +519,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -541,26 +532,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -569,26 +559,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -611,7 +600,6 @@
 - [#2940](https://github.com/kubb-labs/kubb/pull/2940) [`c1e9257`](https://github.com/kubb-labs/kubb/commit/c1e92572c04cf82ddb4df2e9e72e1551287a21fa) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
 
   Add three generic helper functions to `renderNode.tsx` that encapsulate the repeated react + core generator dispatch boilerplate:
-
   - `runGeneratorSchema(node, ctx)` — dispatches a single schema node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperation(node, ctx)` — dispatches a single operation node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperations(nodes, ctx)` — batch-dispatches a list of collected operation nodes to all generators using `plugin.options` directly (no per-node filtering).
@@ -716,17 +704,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -894,7 +879,6 @@
   Introduces a `storage` option in `output` that replaces direct filesystem writes with a pluggable storage layer, inspired by the Nitro/unstorage API.
 
   **New exports from `@kubb/core`:**
-
   - `defineStorage(builder)` — factory helper (same pattern as `definePlugin`/`defineLogger`/`defineAdapter`) that wraps a builder function and makes options optional
   - `fsStorage()` — built-in filesystem driver; the default when no `storage` is configured, preserving existing on-disk behavior
   - `memoryStorage()` — built-in in-memory driver; useful for testing and dry-run scenarios
@@ -903,43 +887,43 @@
   **`output.write` is now deprecated.** Setting `write: false` for dry-runs still works and continues to be supported.
 
   ```ts
-  import { defineConfig, defineStorage, fsStorage } from "@kubb/core";
+  import { defineConfig, defineStorage, fsStorage } from '@kubb/core'
 
   // default (no change needed for existing configs)
   export default defineConfig({
-    output: { path: "./src/gen" },
-  });
+    output: { path: './src/gen' },
+  })
 
   // explicit filesystem storage
   export default defineConfig({
-    output: { path: "./src/gen", storage: fsStorage() },
-  });
+    output: { path: './src/gen', storage: fsStorage() },
+  })
 
   // custom in-memory storage
   export const memoryStorage = defineStorage((_options) => {
-    const store = new Map<string, string>();
+    const store = new Map<string, string>()
     return {
-      name: "memory",
+      name: 'memory',
       async hasItem(key) {
-        return store.has(key);
+        return store.has(key)
       },
       async getItem(key) {
-        return store.get(key) ?? null;
+        return store.get(key) ?? null
       },
       async setItem(key, value) {
-        store.set(key, value);
+        store.set(key, value)
       },
       async removeItem(key) {
-        store.delete(key);
+        store.delete(key)
       },
       async getKeys() {
-        return [...store.keys()];
+        return [...store.keys()]
       },
       async clear() {
-        store.clear();
+        store.clear()
       },
-    };
-  });
+    }
+  })
   ```
 
 ### Patch Changes
@@ -982,7 +966,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -1173,12 +1156,10 @@
   Generated enums now support configurable key casing through the new `enumKeyCasing` option in `@kubb/plugin-ts`. This allows transforming enum keys into conventional casing formats instead of using raw values.
 
   **New transformers in @kubb/core:**
-
   - `screamingSnakeCase`: Converts to SCREAMING_SNAKE_CASE
   - `snakeCase`: Converts to snake_case
 
   **New option in @kubb/plugin-ts:**
-
   - `enumKeyCasing`: Choose from `'screamingSnakeCase'` | `'snakeCase'` | `'pascalCase'` | `'camelCase'` | `'none'` (default: `'none'`)
 
   **Example:**
@@ -1188,32 +1169,31 @@
   export default {
     plugins: [
       pluginTs({
-        enumKeyCasing: "screamingSnakeCase",
+        enumKeyCasing: 'screamingSnakeCase',
       }),
     ],
-  };
+  }
   ```
 
   Before:
 
   ```typescript
   export const enumStringEnum = {
-    "created at": "created at",
-    "FILE.UPLOADED": "FILE.UPLOADED",
-  } as const;
+    'created at': 'created at',
+    'FILE.UPLOADED': 'FILE.UPLOADED',
+  } as const
   ```
 
   After:
 
   ```typescript
   export const enumStringEnum = {
-    CREATED_AT: "created at",
-    FILE_UPLOADED: "FILE.UPLOADED",
-  } as const;
+    CREATED_AT: 'created at',
+    FILE_UPLOADED: 'FILE.UPLOADED',
+  } as const
   ```
 
   **Additional improvements:**
-
   - Enum member keys now use identifiers without quotes when the key is a valid JavaScript identifier, making the output cleaner and more idiomatic
   - Default value is `'none'` to preserve backward compatibility
 
@@ -1256,13 +1236,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ## 4.12.15

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,9 @@
     "*": {
       "mocks": [
         "./dist/mocks.d.ts"
+      ],
+      "virtual-modules": [
+        "./dist/virtual-modules.d.ts"
       ]
     }
   },
@@ -55,6 +58,15 @@
     "./mocks": {
       "import": "./dist/mocks.js",
       "require": "./dist/mocks.cjs"
+    },
+    "./register": {
+      "import": "./dist/register.js"
+    },
+    "./loader": {
+      "import": "./dist/loader.js"
+    },
+    "./virtual-modules": {
+      "types": "./dist/virtual-modules.d.ts"
     },
     "./package.json": "./package.json"
   },

--- a/packages/core/src/OutputRegistry.ts
+++ b/packages/core/src/OutputRegistry.ts
@@ -50,11 +50,7 @@ export class OutputRegistry {
    */
   resolve(query: { nodeId: string; nodeKind: 'schema' | 'operation'; plugin: string; kind?: string }): OutputEntry | undefined {
     return this.#entries.find(
-      (e) =>
-        e.nodeId === query.nodeId &&
-        e.nodeKind === query.nodeKind &&
-        e.plugin === query.plugin &&
-        (query.kind === undefined || e.kind === query.kind),
+      (e) => e.nodeId === query.nodeId && e.nodeKind === query.nodeKind && e.plugin === query.plugin && (query.kind === undefined || e.kind === query.kind),
     )
   }
 

--- a/packages/core/src/OutputRegistry.ts
+++ b/packages/core/src/OutputRegistry.ts
@@ -1,0 +1,62 @@
+import type { ExportNode, FileNode } from '@kubb/ast'
+
+export type OutputKind = string
+
+export type OutputEntry = {
+  nodeId: string
+  nodeKind: 'schema' | 'operation'
+  plugin: string
+  kind: OutputKind
+  file: string
+  exports: Array<string>
+}
+
+function extractExportNames(file: FileNode): Array<string> {
+  return file.exports.flatMap((e: ExportNode) => {
+    if (!e.name) return []
+    return Array.isArray(e.name) ? (e.name as string[]) : [e.name as string]
+  })
+}
+
+/**
+ * Tracks what each plugin produced for each schema/operation node.
+ * Populated automatically by PluginDriver when addFile/upsertFile is called
+ * inside a generator context that has a currentNode in AsyncLocalStorage.
+ *
+ * Plugins opt-in by tagging their files with `meta: { kind: 'type' | 'zod' | ... }`.
+ */
+export class OutputRegistry {
+  readonly #entries: Array<OutputEntry> = []
+
+  register(entry: OutputEntry): void {
+    this.#entries.push(entry)
+  }
+
+  /**
+   * Returns all entries matching the given filter (all fields optional).
+   */
+  query(filter: Partial<Pick<OutputEntry, 'nodeId' | 'nodeKind' | 'plugin' | 'kind'>>): Array<OutputEntry> {
+    return this.#entries.filter(
+      (e) =>
+        (filter.nodeId === undefined || e.nodeId === filter.nodeId) &&
+        (filter.nodeKind === undefined || e.nodeKind === filter.nodeKind) &&
+        (filter.plugin === undefined || e.plugin === filter.plugin) &&
+        (filter.kind === undefined || e.kind === filter.kind),
+    )
+  }
+
+  /**
+   * Returns the first entry matching the given node + plugin + optional kind.
+   */
+  resolve(query: { nodeId: string; nodeKind: 'schema' | 'operation'; plugin: string; kind?: string }): OutputEntry | undefined {
+    return this.#entries.find(
+      (e) =>
+        e.nodeId === query.nodeId &&
+        e.nodeKind === query.nodeKind &&
+        e.plugin === query.plugin &&
+        (query.kind === undefined || e.kind === query.kind),
+    )
+  }
+
+  static extractExportNames = extractExportNames
+}

--- a/packages/core/src/PluginDriver.ts
+++ b/packages/core/src/PluginDriver.ts
@@ -8,6 +8,8 @@ import type { Plugin } from './definePlugin.ts'
 import { defineResolver } from './defineResolver.ts'
 import { openInStudio as openInStudioFn } from './devtools.ts'
 import { FileManager } from './FileManager.ts'
+import { getContextStore } from './generatorContext.ts'
+import { OutputRegistry } from './OutputRegistry.ts'
 import { applyHookResult } from './renderNode.ts'
 
 import type {
@@ -62,6 +64,13 @@ export class PluginDriver {
    * add files; this property gives direct read/write access when needed.
    */
   readonly fileManager = new FileManager()
+
+  /**
+   * Tracks what each plugin produced for each schema/operation node.
+   * Plugins opt-in by tagging files with `meta: { kind: 'type' | 'zod' | ... }`.
+   * Queryable via the `kubb:outputs` virtual module.
+   */
+  readonly outputRegistry = new OutputRegistry()
 
   readonly plugins = new Map<string, NormalizedPlugin>()
 
@@ -348,9 +357,11 @@ export class PluginDriver {
       driver,
       addFile: async (...files: Array<FileNode>) => {
         driver.fileManager.add(...files)
+        driver.#autoRegister(plugin.name, files)
       },
       upsertFile: async (...files: Array<FileNode>) => {
         driver.fileManager.upsert(...files)
+        driver.#autoRegister(plugin.name, files)
       },
       get inputNode(): InputNode | undefined {
         return driver.inputNode
@@ -395,6 +406,40 @@ export class PluginDriver {
     } as unknown as GeneratorContext<TOptions>
 
     return baseContext
+  }
+
+  /**
+   * Automatically registers files into the OutputRegistry when called inside a
+   * generator context. Only registers files that carry a `meta.kind` tag.
+   */
+  #autoRegister(pluginName: string, files: Array<FileNode>): void {
+    let store: ReturnType<typeof getContextStore> | undefined
+    try {
+      store = getContextStore()
+    } catch {
+      return
+    }
+
+    const { currentNode } = store
+    if (!currentNode) return
+
+    const isOperation = currentNode.kind === 'Operation'
+    const nodeId = isOperation ? (currentNode as OperationNode).operationId : ((currentNode as SchemaNode).name ?? '')
+    const nodeKind = isOperation ? 'operation' : 'schema'
+
+    for (const file of files) {
+      const kind = (file.meta as { kind?: string } | undefined)?.kind
+      if (!kind) continue
+
+      this.outputRegistry.register({
+        nodeId,
+        nodeKind,
+        plugin: pluginName,
+        kind,
+        file: file.path,
+        exports: OutputRegistry.extractExportNames(file),
+      })
+    }
   }
 
   getPlugin<TName extends keyof Kubb.PluginRegistry>(pluginName: TName): Plugin<Kubb.PluginRegistry[TName]> | undefined

--- a/packages/core/src/composables.test.ts
+++ b/packages/core/src/composables.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { useDriver, useFiles } from './composables.ts'
+import { generatorContextStorage } from './generatorContext.ts'
+import type { GeneratorContext } from './types.ts'
+
+function makeMockContext(overrides: Partial<GeneratorContext> = {}): GeneratorContext {
+  return {
+    config: { root: '.', output: { path: './gen' } } as GeneratorContext['config'],
+    driver: {
+      fileManager: {
+        files: [{ path: 'a.ts', baseName: 'a.ts', name: 'a' } as any],
+      },
+    } as GeneratorContext['driver'],
+    inputNode: {
+      kind: 'Input',
+      schemas: [],
+      operations: [],
+    } as GeneratorContext['inputNode'],
+    resolver: {} as GeneratorContext['resolver'],
+    ...overrides,
+  } as GeneratorContext
+}
+
+describe('composables — inside a generator context', () => {
+  it('useFiles() returns current files from the FileManager', async () => {
+    const ctx = makeMockContext()
+    await generatorContextStorage.run(ctx, async () => {
+      const result = useFiles()
+      expect(result).toHaveLength(1)
+      expect(result[0]?.baseName).toBe('a.ts')
+    })
+  })
+
+  it('useDriver() returns the PluginDriver from the context', async () => {
+    const ctx = makeMockContext()
+    await generatorContextStorage.run(ctx, async () => {
+      expect(useDriver()).toBe(ctx.driver)
+    })
+  })
+
+  it('useFiles() returns live data — reflects FileManager mutations mid-run', async () => {
+    const files: any[] = []
+    const ctx = makeMockContext({
+      driver: { fileManager: { files } } as GeneratorContext['driver'],
+    })
+    await generatorContextStorage.run(ctx, async () => {
+      expect(useFiles()).toHaveLength(0)
+      files.push({ path: 'b.ts', baseName: 'b.ts', name: 'b' })
+      expect(useFiles()).toHaveLength(1)
+    })
+  })
+})
+
+describe('composables — outside a generator context', () => {
+  it('useFiles() throws a helpful error', () => {
+    expect(() => useFiles()).toThrow(/called outside a generator context/)
+  })
+
+  it('useDriver() throws a helpful error', () => {
+    expect(() => useDriver()).toThrow(/called outside a generator context/)
+  })
+})

--- a/packages/core/src/composables.test.ts
+++ b/packages/core/src/composables.test.ts
@@ -1,62 +1,146 @@
 import { describe, expect, it } from 'vitest'
-import { useDriver, useFiles } from './composables.ts'
+import { getCurrentNode, getOperation, getOperations, getOperationsByTag, getSchema, getSchemas, queryOutputs, resolveImport } from './composables.ts'
 import { generatorContextStorage } from './generatorContext.ts'
 import type { GeneratorContext } from './types.ts'
 
 function makeMockContext(overrides: Partial<GeneratorContext> = {}): GeneratorContext {
   return {
-    config: { root: '.', output: { path: './gen' } } as GeneratorContext['config'],
+    config: { root: '/project', output: { path: './gen' } } as GeneratorContext['config'],
     driver: {
-      fileManager: {
-        files: [{ path: 'a.ts', baseName: 'a.ts', name: 'a' } as any],
+      fileManager: { files: [] as any[] },
+      outputRegistry: {
+        query: () => [],
+        resolve: () => undefined,
       },
-    } as GeneratorContext['driver'],
+    } as unknown as GeneratorContext['driver'],
     inputNode: {
       kind: 'Input',
-      schemas: [],
-      operations: [],
+      schemas: [{ kind: 'Schema', name: 'Pet', type: 'object' } as any, { kind: 'Schema', name: 'Error', type: 'object' } as any],
+      operations: [
+        { kind: 'Operation', operationId: 'listPets', method: 'get', path: '/pets', tags: ['pets'] } as any,
+        { kind: 'Operation', operationId: 'createPet', method: 'post', path: '/pets', tags: ['pets'] } as any,
+        { kind: 'Operation', operationId: 'getUser', method: 'get', path: '/users', tags: ['users'] } as any,
+      ],
+      meta: { title: 'Petstore', version: '1.0.0' },
     } as GeneratorContext['inputNode'],
     resolver: {} as GeneratorContext['resolver'],
     ...overrides,
   } as GeneratorContext
 }
 
-describe('composables — inside a generator context', () => {
-  it('useFiles() returns current files from the FileManager', async () => {
-    const ctx = makeMockContext()
-    await generatorContextStorage.run(ctx, async () => {
-      const result = useFiles()
-      expect(result).toHaveLength(1)
-      expect(result[0]?.baseName).toBe('a.ts')
+const mockSchemaNode = { kind: 'Schema' as const, name: 'Pet', type: 'object' as any }
+const mockOperationNode = {
+  kind: 'Operation' as const,
+  operationId: 'listPets',
+  method: 'get' as any,
+  path: '/pets',
+  tags: ['pets'],
+  parameters: [],
+  responses: [],
+}
+
+describe('kubb:spec composables — inside a generator context', () => {
+  it('getSchemas() returns all schema nodes', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockSchemaNode }, async () => {
+      expect(getSchemas()).toHaveLength(2)
+      expect(getSchemas()[0]?.name).toBe('Pet')
     })
   })
 
-  it('useDriver() returns the PluginDriver from the context', async () => {
-    const ctx = makeMockContext()
-    await generatorContextStorage.run(ctx, async () => {
-      expect(useDriver()).toBe(ctx.driver)
+  it('getSchema() finds by name', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockSchemaNode }, async () => {
+      expect(getSchema('Pet')?.name).toBe('Pet')
+      expect(getSchema('Missing')).toBeUndefined()
     })
   })
 
-  it('useFiles() returns live data — reflects FileManager mutations mid-run', async () => {
-    const files: any[] = []
+  it('getOperations() returns all operations', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockOperationNode }, async () => {
+      expect(getOperations()).toHaveLength(3)
+    })
+  })
+
+  it('getOperation() finds by operationId', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockOperationNode }, async () => {
+      expect(getOperation('listPets')?.operationId).toBe('listPets')
+      expect(getOperation('missing')).toBeUndefined()
+    })
+  })
+
+  it('getOperationsByTag() filters by tag', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockOperationNode }, async () => {
+      expect(getOperationsByTag('pets')).toHaveLength(2)
+      expect(getOperationsByTag('users')).toHaveLength(1)
+      expect(getOperationsByTag('nope')).toHaveLength(0)
+    })
+  })
+
+  it('getCurrentNode() returns the node currently being processed', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockSchemaNode }, async () => {
+      expect(getCurrentNode()).toBe(mockSchemaNode)
+    })
+  })
+
+  it('getCurrentNode() returns null during the operations-batch call', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: null }, async () => {
+      expect(getCurrentNode()).toBeNull()
+    })
+  })
+})
+
+describe('kubb:outputs composables — inside a generator context', () => {
+  it('queryOutputs() delegates to the OutputRegistry', async () => {
+    const mockEntries = [{ nodeId: 'Pet', nodeKind: 'schema', plugin: 'plugin-ts', kind: 'type', file: '/gen/types/pet.ts', exports: ['Pet'] }]
     const ctx = makeMockContext({
-      driver: { fileManager: { files } } as GeneratorContext['driver'],
+      driver: {
+        fileManager: { files: [] as any[] },
+        outputRegistry: {
+          query: () => mockEntries,
+          resolve: () => undefined,
+        },
+      } as unknown as GeneratorContext['driver'],
     })
-    await generatorContextStorage.run(ctx, async () => {
-      expect(useFiles()).toHaveLength(0)
-      files.push({ path: 'b.ts', baseName: 'b.ts', name: 'b' })
-      expect(useFiles()).toHaveLength(1)
+    await generatorContextStorage.run({ ctx, currentNode: mockSchemaNode }, async () => {
+      expect(queryOutputs({ nodeId: 'Pet' })).toEqual(mockEntries)
+    })
+  })
+
+  it('resolveImport() returns null when no entry found', async () => {
+    await generatorContextStorage.run({ ctx: makeMockContext(), currentNode: mockSchemaNode }, async () => {
+      const imp = resolveImport({ schema: 'Pet', plugin: 'plugin-ts', kind: 'type', from: '/gen/client/pet.ts' })
+      expect(imp).toBeNull()
+    })
+  })
+
+  it('resolveImport() returns an ImportNode with a relative path when entry exists', async () => {
+    const ctx = makeMockContext({
+      driver: {
+        fileManager: { files: [] as any[] },
+        outputRegistry: {
+          query: () => [],
+          resolve: () => ({ nodeId: 'Pet', nodeKind: 'schema', plugin: 'plugin-ts', kind: 'type', file: '/gen/types/pet.ts', exports: ['Pet'] }),
+        },
+      } as unknown as GeneratorContext['driver'],
+    })
+    await generatorContextStorage.run({ ctx, currentNode: mockSchemaNode }, async () => {
+      const imp = resolveImport({ schema: 'Pet', plugin: 'plugin-ts', kind: 'type', from: '/gen/client/pet.ts' })
+      expect(imp).not.toBeNull()
+      expect(imp?.path).toBe('../types/pet.ts')
+      expect(imp?.isTypeOnly).toBe(true)
     })
   })
 })
 
 describe('composables — outside a generator context', () => {
-  it('useFiles() throws a helpful error', () => {
-    expect(() => useFiles()).toThrow(/called outside a generator context/)
+  it('getSchemas() throws a helpful error', () => {
+    expect(() => getSchemas()).toThrow(/called outside a generator context/)
   })
 
-  it('useDriver() throws a helpful error', () => {
-    expect(() => useDriver()).toThrow(/called outside a generator context/)
+  it('getOperations() throws a helpful error', () => {
+    expect(() => getOperations()).toThrow(/called outside a generator context/)
+  })
+
+  it('resolveImport() throws a helpful error', () => {
+    expect(() => resolveImport({ schema: 'Pet', plugin: 'plugin-ts', from: '/gen/client.ts' })).toThrow(/called outside a generator context/)
   })
 })

--- a/packages/core/src/composables.ts
+++ b/packages/core/src/composables.ts
@@ -1,11 +1,87 @@
-import type { FileNode } from '@kubb/ast'
-import { getGeneratorContext } from './generatorContext.ts'
-import type { PluginDriver } from './PluginDriver.ts'
+import { dirname, relative } from 'node:path'
+import type { ImportNode, OperationNode, SchemaNode } from '@kubb/ast'
+import { createImport } from '@kubb/ast'
+import { getContextStore } from './generatorContext.ts'
+import type { OutputEntry } from './OutputRegistry.ts'
 
-export function useFiles(): Array<FileNode> {
-  return getGeneratorContext().driver.fileManager.files
+// ─── kubb:spec ────────────────────────────────────────────────────────────────
+
+/** Returns all schema nodes from the parsed spec. */
+export function getSchemas(): Array<SchemaNode> {
+  return (getContextStore().ctx.inputNode?.schemas ?? []) as Array<SchemaNode>
 }
 
-export function useDriver(): PluginDriver {
-  return getGeneratorContext().driver
+/** Returns the schema node with the given name, or undefined. */
+export function getSchema(name: string): SchemaNode | undefined {
+  return getSchemas().find((s) => s.name === name)
+}
+
+/** Returns all operation nodes from the parsed spec. */
+export function getOperations(): Array<OperationNode> {
+  return (getContextStore().ctx.inputNode?.operations ?? []) as Array<OperationNode>
+}
+
+/** Returns the operation node with the given operationId, or undefined. */
+export function getOperation(operationId: string): OperationNode | undefined {
+  return getOperations().find((op) => op.operationId === operationId)
+}
+
+/** Returns all operations that carry the given tag. */
+export function getOperationsByTag(tag: string): Array<OperationNode> {
+  return getOperations().filter((op) => op.tags?.includes(tag))
+}
+
+/** Returns the node currently being processed (schema or operation), or null during the operations-batch call. */
+export function getCurrentNode(): SchemaNode | OperationNode | null {
+  return getContextStore().currentNode
+}
+
+/** Returns the InputNode metadata (title, version, baseURL, description). */
+export function getInputMeta() {
+  return getContextStore().ctx.inputNode?.meta
+}
+
+// ─── kubb:outputs ─────────────────────────────────────────────────────────────
+
+/**
+ * Queries the OutputRegistry and returns all matching entries.
+ * Entries are only present for plugins that tagged their files with `meta: { kind: '...' }`.
+ */
+export function queryOutputs(filter: Partial<Pick<OutputEntry, 'nodeId' | 'nodeKind' | 'plugin' | 'kind'>>): Array<OutputEntry> {
+  return getContextStore().ctx.driver.outputRegistry.query(filter)
+}
+
+/**
+ * Resolves a cross-plugin output to a ready-to-use `ImportNode`.
+ *
+ * @param query.schema    - Name of the schema node (exclusive with `operation`)
+ * @param query.operation - operationId of the operation (exclusive with `schema`)
+ * @param query.plugin    - The plugin that produced the output (e.g. `'plugin-ts'`)
+ * @param query.kind      - The semantic kind of the output (e.g. `'type'`, `'zod'`)
+ * @param query.from      - Absolute path of the file that will contain the import
+ *
+ * Returns an `ImportNode` ready to add to a `FileNode`, or `null` if no match.
+ */
+export function resolveImport(query: {
+  schema?: string
+  operation?: string
+  plugin: string
+  kind?: string
+  from: string
+}): ImportNode | null {
+  const registry = getContextStore().ctx.driver.outputRegistry
+  const nodeId = query.schema ?? query.operation ?? ''
+  const nodeKind: 'schema' | 'operation' = query.schema ? 'schema' : 'operation'
+
+  const entry = registry.resolve({ nodeId, nodeKind, plugin: query.plugin, kind: query.kind })
+  if (!entry || entry.exports.length === 0) return null
+
+  const rel = relative(dirname(query.from), entry.file)
+  const importPath = rel.startsWith('.') ? rel : `./${rel}`
+
+  return createImport({
+    name: entry.exports,
+    path: importPath,
+    isTypeOnly: entry.kind === 'type',
+  })
 }

--- a/packages/core/src/composables.ts
+++ b/packages/core/src/composables.ts
@@ -1,0 +1,11 @@
+import type { FileNode } from '@kubb/ast'
+import { getGeneratorContext } from './generatorContext.ts'
+import type { PluginDriver } from './PluginDriver.ts'
+
+export function useFiles(): Array<FileNode> {
+  return getGeneratorContext().driver.fileManager.files
+}
+
+export function useDriver(): PluginDriver {
+  return getGeneratorContext().driver
+}

--- a/packages/core/src/composables.ts
+++ b/packages/core/src/composables.ts
@@ -62,13 +62,7 @@ export function queryOutputs(filter: Partial<Pick<OutputEntry, 'nodeId' | 'nodeK
  *
  * Returns an `ImportNode` ready to add to a `FileNode`, or `null` if no match.
  */
-export function resolveImport(query: {
-  schema?: string
-  operation?: string
-  plugin: string
-  kind?: string
-  from: string
-}): ImportNode | null {
+export function resolveImport(query: { schema?: string; operation?: string; plugin: string; kind?: string; from: string }): ImportNode | null {
   const registry = getContextStore().ctx.driver.outputRegistry
   const nodeId = query.schema ?? query.operation ?? ''
   const nodeKind: 'schema' | 'operation' = query.schema ? 'schema' : 'operation'

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -1,4 +1,5 @@
 import { dirname, resolve } from 'node:path'
+import { generatorContextStorage } from './generatorContext.ts'
 import { AsyncEventEmitter, BuildError, exists, formatMs, getElapsedMs, getRelativePath, URLPath } from '@internals/utils'
 import type { ExportNode, FileNode, OperationNode } from '@kubb/ast'
 import { createExport, createFile, transform, walk } from '@kubb/ast'
@@ -211,13 +212,15 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
 
       const ctx = { ...generatorContext, options }
 
-      for (const gen of generators) {
-        if (!gen.schema) continue
-        const result = await gen.schema(transformedNode, ctx)
-        await applyHookResult(result, driver, resolveRenderer(gen))
-      }
+      await generatorContextStorage.run(ctx, async () => {
+        for (const gen of generators) {
+          if (!gen.schema) continue
+          const result = await gen.schema(transformedNode, ctx)
+          await applyHookResult(result, driver, resolveRenderer(gen))
+        }
 
-      await driver.hooks.emit('kubb:generate:schema', transformedNode, ctx)
+        await driver.hooks.emit('kubb:generate:schema', transformedNode, ctx)
+      })
     },
     async operation(node) {
       const transformedNode = plugin.transformer ? transform(node, plugin.transformer) : node
@@ -232,13 +235,15 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
 
         const ctx = { ...generatorContext, options }
 
-        for (const gen of generators) {
-          if (!gen.operation) continue
-          const result = await gen.operation(transformedNode, ctx)
-          await applyHookResult(result, driver, resolveRenderer(gen))
-        }
+        await generatorContextStorage.run(ctx, async () => {
+          for (const gen of generators) {
+            if (!gen.operation) continue
+            const result = await gen.operation(transformedNode, ctx)
+            await applyHookResult(result, driver, resolveRenderer(gen))
+          }
 
-        await driver.hooks.emit('kubb:generate:operation', transformedNode, ctx)
+          await driver.hooks.emit('kubb:generate:operation', transformedNode, ctx)
+        })
       }
     },
   })
@@ -246,13 +251,15 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
   if (collectedOperations.length > 0) {
     const ctx = { ...generatorContext, options: plugin.options }
 
-    for (const gen of generators) {
-      if (!gen.operations) continue
-      const result = await gen.operations(collectedOperations, ctx)
-      await applyHookResult(result, driver, resolveRenderer(gen))
-    }
+    await generatorContextStorage.run(ctx, async () => {
+      for (const gen of generators) {
+        if (!gen.operations) continue
+        const result = await gen.operations(collectedOperations, ctx)
+        await applyHookResult(result, driver, resolveRenderer(gen))
+      }
 
-    await driver.hooks.emit('kubb:generate:operations', collectedOperations, ctx)
+      await driver.hooks.emit('kubb:generate:operations', collectedOperations, ctx)
+    })
   }
 }
 

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -212,7 +212,7 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
 
       const ctx = { ...generatorContext, options }
 
-      await generatorContextStorage.run(ctx, async () => {
+      await generatorContextStorage.run({ ctx, currentNode: transformedNode }, async () => {
         for (const gen of generators) {
           if (!gen.schema) continue
           const result = await gen.schema(transformedNode, ctx)
@@ -235,7 +235,7 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
 
         const ctx = { ...generatorContext, options }
 
-        await generatorContextStorage.run(ctx, async () => {
+        await generatorContextStorage.run({ ctx, currentNode: transformedNode }, async () => {
           for (const gen of generators) {
             if (!gen.operation) continue
             const result = await gen.operation(transformedNode, ctx)
@@ -251,7 +251,7 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
   if (collectedOperations.length > 0) {
     const ctx = { ...generatorContext, options: plugin.options }
 
-    await generatorContextStorage.run(ctx, async () => {
+    await generatorContextStorage.run({ ctx, currentNode: null }, async () => {
       for (const gen of generators) {
         if (!gen.operations) continue
         const result = await gen.operations(collectedOperations, ctx)

--- a/packages/core/src/generatorContext.ts
+++ b/packages/core/src/generatorContext.ts
@@ -1,0 +1,23 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+import type { GeneratorContext } from './types.ts'
+
+/**
+ * Stores the active GeneratorContext for the current async execution tree.
+ * Populated by runPluginAstHooks() before each generator method call.
+ */
+export const generatorContextStorage = new AsyncLocalStorage<GeneratorContext>()
+
+/**
+ * Returns the GeneratorContext for the currently-executing generator method,
+ * or throws when called outside the generator execution tree.
+ */
+export function getGeneratorContext(): GeneratorContext {
+  const ctx = generatorContextStorage.getStore()
+  if (!ctx) {
+    throw new Error(
+      '[kubb] Virtual module accessor called outside a generator context. ' +
+        'Use kubb:files and kubb:driver only inside a schema(), operation(), or operations() method.',
+    )
+  }
+  return ctx
+}

--- a/packages/core/src/generatorContext.ts
+++ b/packages/core/src/generatorContext.ts
@@ -1,23 +1,28 @@
 import { AsyncLocalStorage } from 'node:async_hooks'
+import type { OperationNode, SchemaNode } from '@kubb/ast'
 import type { GeneratorContext } from './types.ts'
 
-/**
- * Stores the active GeneratorContext for the current async execution tree.
- * Populated by runPluginAstHooks() before each generator method call.
- */
-export const generatorContextStorage = new AsyncLocalStorage<GeneratorContext>()
+export type ContextStore = {
+  ctx: GeneratorContext
+  /** The schema or operation node currently being processed, or null for the operations-batch call. */
+  currentNode: SchemaNode | OperationNode | null
+}
 
 /**
- * Returns the GeneratorContext for the currently-executing generator method,
- * or throws when called outside the generator execution tree.
+ * Stores the active generator context for the current async execution tree.
+ * Populated by runPluginAstHooks() before each generator method call.
  */
-export function getGeneratorContext(): GeneratorContext {
-  const ctx = generatorContextStorage.getStore()
-  if (!ctx) {
+export const generatorContextStorage = new AsyncLocalStorage<ContextStore>()
+
+function getStore(): ContextStore {
+  const store = generatorContextStorage.getStore()
+  if (!store) {
     throw new Error(
       '[kubb] Virtual module accessor called outside a generator context. ' +
-        'Use kubb:files and kubb:driver only inside a schema(), operation(), or operations() method.',
+        'Use kubb:spec and kubb:outputs only inside a schema(), operation(), or operations() method.',
     )
   }
-  return ctx
+  return store
 }
+
+export { getStore as getContextStore }

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -30,11 +30,7 @@ export async function resolve(
   return nextResolve(specifier, context)
 }
 
-export async function load(
-  url: string,
-  context: LoadContext,
-  nextLoad: (u: string, c: LoadContext) => Promise<LoadResult>,
-): Promise<LoadResult> {
+export async function load(url: string, context: LoadContext, nextLoad: (u: string, c: LoadContext) => Promise<LoadResult>): Promise<LoadResult> {
   if (!url.startsWith('kubb-virtual:')) {
     return nextLoad(url, context)
   }

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -3,9 +3,9 @@
  *
  * Register via:  node --import @kubb/core/register
  *
- * Intercepts bare specifiers starting with 'kubb:' and returns
- * synthetic modules backed by the AsyncLocalStorage context set
- * by runPluginAstHooks() in createKubb.ts.
+ * Supported virtual modules:
+ *   kubb:spec    — query the parsed OpenAPI spec (schemas, operations, tags)
+ *   kubb:outputs — resolve cross-plugin outputs to ready-to-use ImportNodes
  */
 
 const COMPOSABLES_URL = new URL('./composables.js', import.meta.url).href
@@ -38,19 +38,25 @@ export async function load(url: string, context: LoadContext, nextLoad: (u: stri
   const name = url.slice('kubb-virtual:'.length)
 
   switch (name) {
-    case 'files':
+    case 'spec':
       return {
         format: 'module',
         shortCircuit: true,
-        source: `import { useFiles } from '${COMPOSABLES_URL}'; export const files = useFiles;`,
+        source: `
+import { getSchemas, getSchema, getOperations, getOperation, getOperationsByTag, getCurrentNode, getInputMeta } from '${COMPOSABLES_URL}';
+export { getSchemas, getSchema, getOperations, getOperation, getOperationsByTag, getCurrentNode, getInputMeta };
+        `.trim(),
       }
-    case 'driver':
+    case 'outputs':
       return {
         format: 'module',
         shortCircuit: true,
-        source: `import { useDriver } from '${COMPOSABLES_URL}'; export const driver = useDriver;`,
+        source: `
+import { queryOutputs, resolveImport } from '${COMPOSABLES_URL}';
+export { queryOutputs, resolveImport };
+        `.trim(),
       }
     default:
-      throw new Error(`[kubb] Unknown virtual module 'kubb:${name}'. Available: kubb:files, kubb:driver`)
+      throw new Error(`[kubb] Unknown virtual module 'kubb:${name}'. Available: kubb:spec, kubb:outputs`)
   }
 }

--- a/packages/core/src/loader.ts
+++ b/packages/core/src/loader.ts
@@ -1,0 +1,60 @@
+/**
+ * Node.js ESM module-hooks loader for Kubb virtual modules.
+ *
+ * Register via:  node --import @kubb/core/register
+ *
+ * Intercepts bare specifiers starting with 'kubb:' and returns
+ * synthetic modules backed by the AsyncLocalStorage context set
+ * by runPluginAstHooks() in createKubb.ts.
+ */
+
+const COMPOSABLES_URL = new URL('./composables.js', import.meta.url).href
+
+type ResolveContext = { parentURL: string | undefined }
+type ResolveResult = { url: string; format: string; shortCircuit: boolean }
+type LoadContext = { format: string }
+type LoadResult = { format: string; shortCircuit: boolean; source: string }
+
+export async function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: (s: string, c: ResolveContext) => Promise<ResolveResult>,
+): Promise<ResolveResult> {
+  if (specifier.startsWith('kubb:')) {
+    return {
+      url: `kubb-virtual:${specifier.slice(5)}`,
+      format: 'module',
+      shortCircuit: true,
+    }
+  }
+  return nextResolve(specifier, context)
+}
+
+export async function load(
+  url: string,
+  context: LoadContext,
+  nextLoad: (u: string, c: LoadContext) => Promise<LoadResult>,
+): Promise<LoadResult> {
+  if (!url.startsWith('kubb-virtual:')) {
+    return nextLoad(url, context)
+  }
+
+  const name = url.slice('kubb-virtual:'.length)
+
+  switch (name) {
+    case 'files':
+      return {
+        format: 'module',
+        shortCircuit: true,
+        source: `import { useFiles } from '${COMPOSABLES_URL}'; export const files = useFiles;`,
+      }
+    case 'driver':
+      return {
+        format: 'module',
+        shortCircuit: true,
+        source: `import { useDriver } from '${COMPOSABLES_URL}'; export const driver = useDriver;`,
+      }
+    default:
+      throw new Error(`[kubb] Unknown virtual module 'kubb:${name}'. Available: kubb:files, kubb:driver`)
+  }
+}

--- a/packages/core/src/register.ts
+++ b/packages/core/src/register.ts
@@ -1,0 +1,18 @@
+/**
+ * Registers the Kubb virtual-module loader for Node.js ESM.
+ *
+ * Usage (add to your build/test command):
+ *   node --import @kubb/core/register your-plugin.ts
+ *
+ * Or programmatically (must be the first import in your entry file):
+ *   import '@kubb/core/register'
+ *
+ * After registration, you can import Kubb virtual modules:
+ *   import { files } from 'kubb:files'
+ *   import { driver } from 'kubb:driver'
+ *
+ * Requires Node.js >= 22 (module.register is available since Node 18.19).
+ */
+import { register } from 'node:module'
+
+register('./loader.js', import.meta.url)

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -11,20 +11,59 @@
  *   node --import @kubb/core/register
  */
 
-declare module 'kubb:files' {
-  import type { FileNode } from '@kubb/ast'
+declare module 'kubb:spec' {
+  import type { OperationNode, SchemaNode } from '@kubb/ast'
+  import type { InputMeta } from '@kubb/ast'
+
+  /** Returns all schema nodes from the parsed OpenAPI spec. */
+  export function getSchemas(): Array<SchemaNode>
+
+  /** Returns the schema node with the given name, or undefined. */
+  export function getSchema(name: string): SchemaNode | undefined
+
+  /** Returns all operation nodes from the parsed spec. */
+  export function getOperations(): Array<OperationNode>
+
+  /** Returns the operation node with the given operationId, or undefined. */
+  export function getOperation(operationId: string): OperationNode | undefined
+
+  /** Returns all operations that carry the given tag. */
+  export function getOperationsByTag(tag: string): Array<OperationNode>
+
   /**
-   * Returns all files currently in the FileManager.
-   * Must be called inside a generator schema(), operation(), or operations() method.
+   * Returns the node currently being processed (schema or operation).
+   * Returns null during the operations-batch (operations()) call.
    */
-  export const files: () => Array<FileNode>
+  export function getCurrentNode(): SchemaNode | OperationNode | null
+
+  /** Returns the InputNode metadata (title, version, baseURL, description). */
+  export function getInputMeta(): InputMeta | undefined
 }
 
-declare module 'kubb:driver' {
-  import type { PluginDriver } from '@kubb/core'
+declare module 'kubb:outputs' {
+  import type { ImportNode } from '@kubb/ast'
+  import type { OutputEntry } from '@kubb/core'
+
   /**
-   * Returns the active PluginDriver instance.
-   * Must be called inside a generator schema(), operation(), or operations() method.
+   * Queries the OutputRegistry and returns all matching entries.
+   * Only plugins that tagged their files with `meta: { kind: '...' }` appear here.
    */
-  export const driver: () => PluginDriver
+  export function queryOutputs(filter: Partial<Pick<OutputEntry, 'nodeId' | 'nodeKind' | 'plugin' | 'kind'>>): Array<OutputEntry>
+
+  /**
+   * Resolves a cross-plugin output to a ready-to-use ImportNode.
+   *
+   * @example
+   * // Get the TypeScript type for the Pet schema from plugin-ts,
+   * // as an import relative to the current file being generated:
+   * const imp = resolveImport({ schema: 'Pet', plugin: 'plugin-ts', kind: 'type', from: myFilePath })
+   * // imp → { name: ['Pet'], path: '../types/pet.ts', isTypeOnly: true }
+   */
+  export function resolveImport(query: {
+    schema?: string
+    operation?: string
+    plugin: string
+    kind?: string
+    from: string
+  }): ImportNode | null
 }

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -1,0 +1,30 @@
+/**
+ * TypeScript ambient declarations for Kubb virtual modules.
+ *
+ * Add to your tsconfig.json to enable types for kubb:* imports:
+ *   { "compilerOptions": { "types": ["@kubb/core/virtual-modules"] } }
+ *
+ * Or add a reference in a .d.ts file in your project:
+ *   /// <reference types="@kubb/core/virtual-modules" />
+ *
+ * The virtual module loader must be registered for runtime use:
+ *   node --import @kubb/core/register
+ */
+
+declare module 'kubb:files' {
+  import type { FileNode } from '@kubb/ast'
+  /**
+   * Returns all files currently in the FileManager.
+   * Must be called inside a generator schema(), operation(), or operations() method.
+   */
+  export const files: () => Array<FileNode>
+}
+
+declare module 'kubb:driver' {
+  import type { PluginDriver } from '@kubb/core'
+  /**
+   * Returns the active PluginDriver instance.
+   * Must be called inside a generator schema(), operation(), or operations() method.
+   */
+  export const driver: () => PluginDriver
+}

--- a/packages/core/src/virtual-modules.d.ts
+++ b/packages/core/src/virtual-modules.d.ts
@@ -59,11 +59,5 @@ declare module 'kubb:outputs' {
    * const imp = resolveImport({ schema: 'Pet', plugin: 'plugin-ts', kind: 'type', from: myFilePath })
    * // imp → { name: ['Pet'], path: '../types/pet.ts', isTypeOnly: true }
    */
-  export function resolveImport(query: {
-    schema?: string
-    operation?: string
-    plugin: string
-    kind?: string
-    from: string
-  }): ImportNode | null
+  export function resolveImport(query: { schema?: string; operation?: string; plugin: string; kind?: string; from: string }): ImportNode | null
 }

--- a/packages/kubb/CHANGELOG.md
+++ b/packages/kubb/CHANGELOG.md
@@ -89,7 +89,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -230,7 +229,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -239,19 +237,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -180,7 +180,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).

--- a/packages/unplugin-kubb/CHANGELOG.md
+++ b/packages/unplugin-kubb/CHANGELOG.md
@@ -192,7 +192,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).


### PR DESCRIPTION
Plugin generators can now import `kubb:files` and `kubb:driver` to
access live FileManager data and the PluginDriver without navigating
through the GeneratorContext manually.

Internally, AsyncLocalStorage propagates the active GeneratorContext
through the async execution tree so that any code called within a
schema(), operation(), or operations() method can read it. The Node.js
ESM loader (register via `--import @kubb/core/register`) intercepts
`kubb:*` bare specifiers and returns synthetic modules backed by that
context. TypeScript types are provided via `@kubb/core/virtual-modules`.

https://claude.ai/code/session_0161ajF4itgB4Fdn4rNGErdE