### PR TITLE
refactor(schemas): extract category definition and fix drift

### DIFF
--- a/packages/adapter-oas/CHANGELOG.md
+++ b/packages/adapter-oas/CHANGELOG.md
@@ -25,17 +25,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -341,7 +341,6 @@
 ### Patch Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -353,7 +352,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -406,7 +404,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`
@@ -422,7 +419,6 @@
 ### Minor Changes
 
 - [#2821](https://github.com/kubb-labs/kubb/pull/2821) [`f4105fe`](https://github.com/kubb-labs/kubb/commit/f4105fe44e46ec2846e665fd6079290e6d6ce6c6) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - **`@kubb/plugin-ts`**: When `legacy: true`, the type generator now fully matches the v4 output:
-
   - Grouped parameter types: `<OperationId>PathParams`, `<OperationId>QueryParams`, `<OperationId>HeaderParams`
   - No `<OperationId>RequestConfig` type emitted
   - Wrapper types (`Mutation`/`Query`) use `{ Response, Request?, QueryParams?, Errors }` shape
@@ -432,7 +428,6 @@
   Six `@deprecated` resolver methods added to `ResolverTs` for grouped parameter naming (`resolvePathParamsName`, `resolveQueryParamsName`, `resolveHeaderParamsName` and typed variants). Implemented only in `resolverTsLegacy`; will be removed in v6.
 
   **`@kubb/adapter-oas`**: `collisionDetection` is now part of the public API with a default of `true`.
-
   - `collisionDetection: true` (default) → full-path enum names, e.g. `OrderParamsStatusEnum`
   - `collisionDetection: false` → immediate-parent enum names with numeric deduplication, e.g. `ParamsStatusEnum`, `ParamsStatusEnum2`
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -175,7 +175,6 @@
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`f7d19bb`](https://github.com/kubb-labs/kubb/commit/f7d19bb69177fbd1b54c855423b3b55c399678b0) Thanks [@pull](https://github.com/apps/pull)! - Decouple `@kubb/agent` from static plugin knowledge.
 
   Plugins are now resolved at runtime via dynamic `import()` instead of being hard-coded as dependencies. This means:
-
   - `@kubb/agent` no longer bundles or lists any `@kubb/plugin-*` packages as dependencies.
   - Any Kubb plugin (or third-party plugin) is supported — install whichever plugins you need alongside the agent.
   - Plugin factory resolution tries three strategies in order: camelCase named export (`pluginReactQuery`), `default` export, or first exported function.
@@ -275,7 +274,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -1801,7 +1799,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio

--- a/packages/ast/CHANGELOG.md
+++ b/packages/ast/CHANGELOG.md
@@ -15,17 +15,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -81,7 +81,6 @@
   ### `@kubb/ast`
 
   New node types in `nodes/code.ts`:
-
   - `ConstNode` (`kind: 'Const'`) — mirrors the `Const` component
   - `TypeNode` (`kind: 'Type'`) — mirrors the `Type` component; a plain type alias declaration with `name`, `export`, `JSDoc`, and `nodes` fields
   - `FunctionNode` (`kind: 'Function'`) — mirrors the `Function` component
@@ -116,7 +115,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -129,13 +127,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -144,26 +140,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -172,26 +167,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -206,7 +200,6 @@
   Complete rewrite of `@kubb/plugin-zod` to the v5 AST-based architecture. The plugin no longer depends on `@kubb/plugin-oas` or `@kubb/oas`; it operates entirely on the `@kubb/ast` node graph.
 
   **Breaking changes:**
-
   - `mapper` option removed — no replacement (naming is now controlled via `resolvers`)
   - `version` option removed — Zod v3 is no longer supported; Kubb v5 always generates Zod v4 code
   - `contentType` option removed — moved to `adapterOas(...)`
@@ -220,21 +213,18 @@
   - Naming conventions (default preset): response status schemas are now named `<operationId>Status<code>Schema` instead of `<operationId><code>Schema`. Use `compatibilityPreset: 'kubbV4'` to keep the old names.
 
   **New options:**
-
   - `paramsCasing?: 'camelcase'` — apply camelCase to path/query/header parameter names in operation schemas
   - `compatibilityPreset?: 'default' | 'kubbV4'` — select naming conventions; `'kubbV4'` reproduces Kubb v4 names for a gradual migration
   - `resolvers?: Array<ResolverZod>` — provide custom resolver instances to override naming conventions
   - `transformers?: Array<Visitor>` — AST visitor array applied to each `SchemaNode` before printing (replaces the old `transformers.schema` callback)
 
   **New exports:**
-
   - `resolverZod` — default v5 resolver (camelCase + `Schema` suffix)
   - `resolverZodLegacy` — Kubb v4-compatible resolver (use with `compatibilityPreset: 'kubbV4'`)
   - `printerZod` — Zod v4 chainable-API printer factory (`definePrinter`)
   - `printerZodMini` — Zod v4 Mini functional-API printer factory
 
   ### `@kubb/ast`
-
   - `createSchema`, `createProperty`, `createOperation` factory functions now automatically infer and set the `primitive` field based on the node `type`, reducing boilerplate in tests and custom generators.
 
 ## 5.0.0-alpha.24
@@ -244,7 +234,6 @@
 ### Minor Changes
 
 - [#2931](https://github.com/kubb-labs/kubb/pull/2931) [`8cfa19a`](https://github.com/kubb-labs/kubb/commit/8cfa19adbe681d4466f0ff97a8c14ece8ba1e5d8) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Added `createOperationParams(node, options)` utility that converts an `OperationNode` into a `FunctionParametersNode`.
   - Added `reference` variant to `TypeNode` for plain type name strings (e.g. `'string'`, `'QueryParams'`), so all type annotations in the AST are always `TypeNode` — never raw strings.
   - Changed `FunctionParameterNode.type` from `string | TypeNode` to `TypeNode`.
@@ -253,7 +242,6 @@
   - Removed `typeToString` helper from `utils.ts`; `resolveType` now returns `TypeNode` directly.
 
   ### `@kubb/plugin-ts`
-
   - Updated `functionPrinter` to handle all three `TypeNode` variants (`member`, `struct`, `reference`) explicitly; removed all `typeof … === 'string'` checks.
 
 ## 5.0.0-alpha.22
@@ -275,7 +263,6 @@
 ### Minor Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -287,7 +274,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -300,17 +286,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -324,7 +307,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -29,7 +29,6 @@
 ### Patch Changes
 
 - [#3138](https://github.com/kubb-labs/kubb/pull/3138) [`72025d7`](https://github.com/kubb-labs/kubb/commit/72025d7255c7d09b69b2665b938a9a5fd3890cf7) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix typecheck issues.
-
   - Remove unused `FileNode` and `Plugin` imports from `Kubb.ts`
   - Fix `context.emit('kubb:info', text)` to pass the correct `KubbInfoContext` shape (`{ message: text }`)
   - Remove unused `config` destructure in `plainLogger.ts` generation start handler
@@ -131,7 +130,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -254,7 +252,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -587,7 +584,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -695,7 +691,6 @@
 - [#2607](https://github.com/kubb-labs/kubb/pull/2607) [`e244177`](https://github.com/kubb-labs/kubb/commit/e244177168a2e32a2818626a5efde990d1f1806f) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Add anonymous telemetry to the Kubb CLI to track usage data (command, plugins, version, duration, platform, Node.js version, and file count). No OpenAPI specs, file paths, plugin options, or secrets are ever collected.
 
   Telemetry can be disabled at any time by setting:
-
   - `DO_NOT_TRACK=1` – standard opt-out flag recognised by many developer tools ([consoledonottrack.com](https://consoledonottrack.com))
   - `KUBB_DISABLE_TELEMETRY=1` – Kubb-specific opt-out flag
 
@@ -829,7 +824,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio
@@ -965,7 +959,6 @@
 - [#2396](https://github.com/kubb-labs/kubb/pull/2396) [`b5c4fd9`](https://github.com/kubb-labs/kubb/commit/b5c4fd94711b1657cdffe9a629229cd0f708a4b1) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add new `init` command for interactive project setup
 
   The CLI now includes a new `kubb init` command that provides an interactive setup wizard to quickly scaffold a Kubb project:
-
   - **Interactive prompts**: Uses `@clack/prompts` for a beautiful CLI experience
   - **Package manager detection**: Automatically detects `npm`, `pnpm`, `yarn`, or `bun`
   - **Plugin selection**: Multi-select from all 13 available Kubb plugins
@@ -980,7 +973,6 @@
   ```
 
   The command will guide you through:
-
   1. Creating a `package.json` (if needed)
   2. Selecting your OpenAPI specification path
   3. Choosing which plugins to install
@@ -1156,13 +1148,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -28,12 +28,12 @@
 
   ```ts
   export const pluginBarrel = definePlugin<PluginBarrel>((options) => ({
-    name: "plugin-barrel",
-    enforce: "post", // always runs after all normal plugins
+    name: 'plugin-barrel',
+    enforce: 'post', // always runs after all normal plugins
     hooks: {
       /* ... */
     },
-  }));
+  }))
   ```
 
   Execution order: `pre → normal → post`. Existing `dependencies` constraints still take precedence within each group.
@@ -55,17 +55,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -81,7 +81,6 @@
 ### Patch Changes
 
 - [#3138](https://github.com/kubb-labs/kubb/pull/3138) [`72025d7`](https://github.com/kubb-labs/kubb/commit/72025d7255c7d09b69b2665b938a9a5fd3890cf7) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix typecheck issues.
-
   - Remove unused `FileNode` and `Plugin` imports from `Kubb.ts`
   - Fix `context.emit('kubb:info', text)` to pass the correct `KubbInfoContext` shape (`{ message: text }`)
   - Remove unused `config` destructure in `plainLogger.ts` generation start handler
@@ -101,25 +100,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
   Migrate any custom plugin types by removing the 4th (`TContext`) and 5th (`TResolvePathOptions`) positional arguments.
@@ -137,7 +124,6 @@
 - [#3127](https://github.com/kubb-labs/kubb/pull/3127) [`570d8d5`](https://github.com/kubb-labs/kubb/commit/570d8d514e8c1864c1981763ff61ac5cdc4c10db) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Replace `this` with explicit `ctx` parameter in `defineResolver` builder.
 
   ### `@kubb/core`
-
   - `ResolverBuilder<T>` now receives the assembled resolver as `ctx` instead of using `ThisType<T['resolver']>`.
   - `defaultResolveFile` accepts the resolver as an explicit `ctx: Resolver` third parameter instead of a `this` receiver.
   - `defineResolver` creates the resolver shell first and passes it to the builder, so `ctx` methods resolve lazily and include any builder overrides.
@@ -153,7 +139,6 @@
 ### Patch Changes
 
 - [#3124](https://github.com/kubb-labs/kubb/pull/3124) [`80d43c6`](https://github.com/kubb-labs/kubb/commit/80d43c66c86ee69359c78184024497f4e2eb1d3e) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix path traversal vulnerabilities in file path resolution.
-
   - `camelCase` / `pascalCase` with `isFile: true` no longer produces a leading `/` when a schema name starts with `.{letter}` (e.g. `..Schema`). Empty segments produced by such names are now filtered before joining with `/`, preventing the result from being interpreted as an absolute path.
   - `defaultResolvePath` default group name for `group.type === 'path'` now strips `.` and `..` components from the OpenAPI operation path before selecting the first segment as a subdirectory name.
   - Added an output-directory boundary check to `defaultResolvePath`: if the resolved path escapes the configured output directory an error is thrown, providing defense-in-depth against path traversal in malicious OpenAPI specs or misconfigured `group.name` functions.
@@ -210,10 +195,10 @@
 
   ```ts
   // before – always returned the base Resolver type
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // Resolver
+  const resolver = driver.getResolver('@kubb/plugin-ts') // Resolver
 
   // after – returns the plugin's typed resolver
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+  const resolver = driver.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
   ```
 
   ### `GeneratorContext.getResolver`
@@ -223,9 +208,9 @@
   ```ts
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, ctx) {
-      const tsResolver = ctx.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+      const tsResolver = ctx.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -251,17 +236,14 @@
 - [#3095](https://github.com/kubb-labs/kubb/pull/3095) [`96ac140`](https://github.com/kubb-labs/kubb/commit/96ac140638e1c10bbdf91840f0c8271c91124c03) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Remove legacy plugin infrastructure now that all plugins use `definePlugin`.
 
   ### Removed types
-
   - `NormalizedPlugin` — internal plugin state is no longer part of the public API. Use `Plugin` for all external-facing plugin references.
   - `PluginContext` — replaced by the standalone `GeneratorContext` type.
   - `SchemaHook`, `OperationHook`, `OperationsHook` — unused hook type aliases.
 
   ### Renamed types
-
   - The internal `InternalPlugin` type (never public) was renamed to `NormalizedPlugin` for clarity, but this type is marked `@internal` and should not be used by plugin authors.
 
   ### Improved types
-
   - `ResolveOptionsContext` — marked `@internal`.
   - `FileMetaBase` — marked `@internal`.
   - `FileProcessor` — marked `@internal`.
@@ -276,10 +258,10 @@
 
   ```ts
   // Before
-  import type { NormalizedPlugin, PluginContext } from "@kubb/core";
+  import type { NormalizedPlugin, PluginContext } from '@kubb/core'
 
   // After
-  import type { Plugin, GeneratorContext } from "@kubb/core";
+  import type { Plugin, GeneratorContext } from '@kubb/core'
   ```
 
 ### Patch Changes
@@ -355,19 +337,18 @@
   **Before:**
 
   ```ts
-  import { getMode } from "@kubb/core";
-  getMode("src/gen/types.ts"); // 'single'
+  import { getMode } from '@kubb/core'
+  getMode('src/gen/types.ts') // 'single'
   ```
 
   **After:**
 
   ```ts
-  import { PluginDriver } from "@kubb/core";
-  PluginDriver.getMode("src/gen/types.ts"); // 'single'
+  import { PluginDriver } from '@kubb/core'
+  PluginDriver.getMode('src/gen/types.ts') // 'single'
   ```
 
   The following utilities have also been removed from `@kubb/core`'s public API as they are internal post-processing helpers used only by CLI/agent tooling:
-
   - `formatters` — moved to `@internals/utils`
   - `linters` — moved to `@internals/utils`
   - `detectFormatter` — moved to `@internals/utils`
@@ -468,13 +449,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -505,7 +486,6 @@
 - [#2990](https://github.com/kubb-labs/kubb/pull/2990) [`3ac7d1f`](https://github.com/kubb-labs/kubb/commit/3ac7d1f9b75099bfe793e35152e5c322e65aa6ad) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Update `@kubb/react-fabric` and `@kubb/fabric-core` to v0.16.0
 
 - [#2994](https://github.com/kubb-labs/kubb/pull/2994) [`9e6a772`](https://github.com/kubb-labs/kubb/commit/9e6a772c7ca1ee54e931d2dbf0f2448f67707c0e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add `@kubb/renderer-jsx` — a lightweight JSX renderer for Kubb plugins.
-
   - New package `@kubb/renderer-jsx` with a custom JSX runtime (`jsx-runtime`, `jsx-dev-runtime`)
   - Provides `createRenderer` to render JSX trees into `FileNode` arrays without React
   - Built-in components: `File`, `Const`, `Function`, `Type`, `Root`
@@ -530,7 +510,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -539,19 +518,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.
@@ -572,14 +551,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -587,25 +566,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -613,7 +592,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -675,7 +654,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -688,13 +666,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -703,26 +679,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -731,26 +706,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -773,7 +747,6 @@
 - [#2940](https://github.com/kubb-labs/kubb/pull/2940) [`c1e9257`](https://github.com/kubb-labs/kubb/commit/c1e92572c04cf82ddb4df2e9e72e1551287a21fa) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
 
   Add three generic helper functions to `renderNode.tsx` that encapsulate the repeated react + core generator dispatch boilerplate:
-
   - `runGeneratorSchema(node, ctx)` — dispatches a single schema node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperation(node, ctx)` — dispatches a single operation node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperations(nodes, ctx)` — batch-dispatches a list of collected operation nodes to all generators using `plugin.options` directly (no per-node filtering).
@@ -878,17 +851,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -1056,7 +1026,6 @@
   Introduces a `storage` option in `output` that replaces direct filesystem writes with a pluggable storage layer, inspired by the Nitro/unstorage API.
 
   **New exports from `@kubb/core`:**
-
   - `defineStorage(builder)` — factory helper (same pattern as `definePlugin`/`defineLogger`/`defineAdapter`) that wraps a builder function and makes options optional
   - `fsStorage()` — built-in filesystem driver; the default when no `storage` is configured, preserving existing on-disk behavior
   - `memoryStorage()` — built-in in-memory driver; useful for testing and dry-run scenarios
@@ -1065,43 +1034,43 @@
   **`output.write` is now deprecated.** Setting `write: false` for dry-runs still works and continues to be supported.
 
   ```ts
-  import { defineConfig, defineStorage, fsStorage } from "@kubb/core";
+  import { defineConfig, defineStorage, fsStorage } from '@kubb/core'
 
   // default (no change needed for existing configs)
   export default defineConfig({
-    output: { path: "./src/gen" },
-  });
+    output: { path: './src/gen' },
+  })
 
   // explicit filesystem storage
   export default defineConfig({
-    output: { path: "./src/gen", storage: fsStorage() },
-  });
+    output: { path: './src/gen', storage: fsStorage() },
+  })
 
   // custom in-memory storage
   export const memoryStorage = defineStorage((_options) => {
-    const store = new Map<string, string>();
+    const store = new Map<string, string>()
     return {
-      name: "memory",
+      name: 'memory',
       async hasItem(key) {
-        return store.has(key);
+        return store.has(key)
       },
       async getItem(key) {
-        return store.get(key) ?? null;
+        return store.get(key) ?? null
       },
       async setItem(key, value) {
-        store.set(key, value);
+        store.set(key, value)
       },
       async removeItem(key) {
-        store.delete(key);
+        store.delete(key)
       },
       async getKeys() {
-        return [...store.keys()];
+        return [...store.keys()]
       },
       async clear() {
-        store.clear();
+        store.clear()
       },
-    };
-  });
+    }
+  })
   ```
 
 ### Patch Changes
@@ -1144,7 +1113,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -1335,12 +1303,10 @@
   Generated enums now support configurable key casing through the new `enumKeyCasing` option in `@kubb/plugin-ts`. This allows transforming enum keys into conventional casing formats instead of using raw values.
 
   **New transformers in @kubb/core:**
-
   - `screamingSnakeCase`: Converts to SCREAMING_SNAKE_CASE
   - `snakeCase`: Converts to snake_case
 
   **New option in @kubb/plugin-ts:**
-
   - `enumKeyCasing`: Choose from `'screamingSnakeCase'` | `'snakeCase'` | `'pascalCase'` | `'camelCase'` | `'none'` (default: `'none'`)
 
   **Example:**
@@ -1350,32 +1316,31 @@
   export default {
     plugins: [
       pluginTs({
-        enumKeyCasing: "screamingSnakeCase",
+        enumKeyCasing: 'screamingSnakeCase',
       }),
     ],
-  };
+  }
   ```
 
   Before:
 
   ```typescript
   export const enumStringEnum = {
-    "created at": "created at",
-    "FILE.UPLOADED": "FILE.UPLOADED",
-  } as const;
+    'created at': 'created at',
+    'FILE.UPLOADED': 'FILE.UPLOADED',
+  } as const
   ```
 
   After:
 
   ```typescript
   export const enumStringEnum = {
-    CREATED_AT: "created at",
-    FILE_UPLOADED: "FILE.UPLOADED",
-  } as const;
+    CREATED_AT: 'created at',
+    FILE_UPLOADED: 'FILE.UPLOADED',
+  } as const
   ```
 
   **Additional improvements:**
-
   - Enum member keys now use identifiers without quotes when the key is a valid JavaScript identifier, making the output cleaner and more idiomatic
   - Default value is `'none'` to preserve backward compatibility
 
@@ -1418,13 +1383,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ## 4.12.15

--- a/packages/kubb/CHANGELOG.md
+++ b/packages/kubb/CHANGELOG.md
@@ -175,7 +175,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -316,7 +315,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -325,19 +323,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -236,7 +236,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).

--- a/packages/middleware-barrel/CHANGELOG.md
+++ b/packages/middleware-barrel/CHANGELOG.md
@@ -22,12 +22,12 @@
   Provides barrel-file generation as a Kubb middleware. Add `middlewareBarrel` to `config.middleware` and set `output.barrelType` (`'all'`, `'named'`, or `'propagate'`) on the root config or individual plugins.
 
   ```ts
-  import { middlewareBarrel } from "@kubb/middleware-barrel";
+  import { middlewareBarrel } from '@kubb/middleware-barrel'
 
   export default defineConfig({
     middleware: [middlewareBarrel],
     plugins: [pluginTs(), pluginZod()],
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/unplugin-kubb/CHANGELOG.md
+++ b/packages/unplugin-kubb/CHANGELOG.md
@@ -255,7 +255,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).

--- a/schemas/adapters/adapter.json
+++ b/schemas/adapters/adapter.json
@@ -260,7 +260,8 @@
         "documentation": { "type": "string", "format": "uri", "description": "Documentation URL" },
         "repository": { "type": "string", "format": "uri", "description": "Repository URL" },
         "issues": { "type": "string", "format": "uri", "description": "Issue tracker URL" },
-        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" }
+        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" },
+        "codesandbox": { "type": "string", "format": "uri", "description": "CodeSandbox example URL" }
       }
     },
     "codeBlockOrArray": {

--- a/schemas/adapters/adapters.json
+++ b/schemas/adapters/adapters.json
@@ -23,17 +23,19 @@
     "categories": {
       "type": "array",
       "description": "Distinct adapter categories present in the registry.",
-      "items": {
-        "type": "object",
-        "required": ["id", "name"],
-        "properties": {
-          "id": { "type": "string", "description": "Category identifier" },
-          "name": { "type": "string", "description": "Category display name" }
-        }
-      }
+      "items": { "$ref": "#/definitions/category" }
     }
   },
   "definitions": {
+    "category": {
+      "type": "object",
+      "description": "Registry category entry.",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "description": "Category identifier" },
+        "name": { "type": "string", "description": "Category display name" }
+      }
+    },
     "registryAdapter": {
       "description": "An adapter entry as it appears in the aggregated registry: the canonical adapter schema plus runtime-derived stats and publish timestamps.",
       "allOf": [

--- a/schemas/middlewares/middleware.json
+++ b/schemas/middlewares/middleware.json
@@ -63,6 +63,13 @@
       },
       "description": "Discovery tags for search and filtering"
     },
+    "dependencies": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Required Kubb middleware dependencies (middleware IDs)"
+    },
     "options": {
       "type": "array",
       "description": "Middleware configuration options, used to auto-generate reference docs.",
@@ -248,7 +255,8 @@
         "documentation": { "type": "string", "format": "uri", "description": "Documentation URL" },
         "repository": { "type": "string", "format": "uri", "description": "Repository URL" },
         "issues": { "type": "string", "format": "uri", "description": "Issue tracker URL" },
-        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" }
+        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" },
+        "codesandbox": { "type": "string", "format": "uri", "description": "CodeSandbox example URL" }
       }
     },
     "codeBlockOrArray": {

--- a/schemas/parsers/parser.json
+++ b/schemas/parsers/parser.json
@@ -260,7 +260,8 @@
         "documentation": { "type": "string", "format": "uri", "description": "Documentation URL" },
         "repository": { "type": "string", "format": "uri", "description": "Repository URL" },
         "issues": { "type": "string", "format": "uri", "description": "Issue tracker URL" },
-        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" }
+        "changelog": { "type": "string", "format": "uri", "description": "Changelog URL" },
+        "codesandbox": { "type": "string", "format": "uri", "description": "CodeSandbox example URL" }
       }
     },
     "codeBlockOrArray": {

--- a/schemas/parsers/parsers.json
+++ b/schemas/parsers/parsers.json
@@ -23,17 +23,19 @@
     "categories": {
       "type": "array",
       "description": "Distinct parser categories present in the registry.",
-      "items": {
-        "type": "object",
-        "required": ["id", "name"],
-        "properties": {
-          "id": { "type": "string", "description": "Category identifier" },
-          "name": { "type": "string", "description": "Category display name" }
-        }
-      }
+      "items": { "$ref": "#/definitions/category" }
     }
   },
   "definitions": {
+    "category": {
+      "type": "object",
+      "description": "Registry category entry.",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "description": "Category identifier" },
+        "name": { "type": "string", "description": "Category display name" }
+      }
+    },
     "registryParser": {
       "description": "A parser entry as it appears in the aggregated registry: the canonical parser schema plus runtime-derived stats and publish timestamps.",
       "allOf": [

--- a/schemas/plugins/README.md
+++ b/schemas/plugins/README.md
@@ -35,7 +35,6 @@ Schema for the aggregated plugin registry. This is maintained in the kubb.dev re
 | `description` | `string` | Short description |
 | `category` | `string` | Plugin category |
 | `type` | `string` | `official`, `community`, or `3rd-party` |
-| `version` | `string` | Semantic version |
 | `npmPackage` | `string` | NPM package name |
 
 ### Optional Fields
@@ -46,82 +45,65 @@ Schema for the aggregated plugin registry. This is maintained in the kubb.dev re
 | `maintainers` | `array` | Plugin maintainers with GitHub info |
 | `repo` | `string` | Source repository URL |
 | `docsPath` | `string` | Documentation path on kubb.dev |
-| `resources` | `object` | Related URLs (docs, issues, changelog) |
-| `icon` | `string` | Emoji identifier |
+| `resources` | `object` | Related URLs (docs, issues, changelog, codesandbox) |
+| `icon` | `object` | Light/dark icon URLs |
 | `featured` | `boolean` | Feature prominently on homepage |
 | `tags` | `array` | Discovery tags |
 | `dependencies` | `array` | Required Kubb plugin IDs |
-| `skills` | `array` | Plugin capabilities for AI tools |
 | `options` | `array` | Plugin configuration options for auto-generated reference docs |
-| `fullExample` | `string` | Complete `kubb.config.ts` snippet used as the Example section on the reference page |
+| `examples` | `array` | Example tabs rendered as the page-level Example section |
+| `intro` | `string` | Free-form markdown rendered between header and installation |
+| `notes` | `array` | Page-level callouts |
 
-## Skills
+## Categories
 
-Skills represent plugin capabilities that can be discovered by AI tools. Each skill includes:
-
-- `name`: Skill identifier
-- `description`: What the skill does
-- `tags`: Categorization tags
-- `dependencies`: Required packages
-- `apiParameters`: Configuration options
-- `examples`: Usage examples with code
+| ID | Name |
+| -- | ---- |
+| `ai` | AI |
+| `client` | Client |
+| `documentation` | Documentation |
+| `framework` | Framework |
+| `mocks` | Mocks |
+| `testing` | Testing |
+| `types` | Types |
+| `validation` | Validation |
 
 ## Example
 
-```json
-{
-  "$schema": "https://kubb.dev/schemas/plugins/plugin.json",
-  "id": "plugin-react-query",
-  "name": "React Query Plugin",
-  "description": "Generate React Query hooks from API specifications",
-  "category": "framework",
-  "type": "official",
-  "version": "5.0.0",
-  "npmPackage": "@kubb/plugin-react-query",
-  "compatibility": {
-    "kubb": ">=5.0.0",
-    "node": ">=18.0.0"
-  },
-  "icon": "⚛️",
-  "featured": true,
-  "tags": ["react", "hooks", "tanstack-query"],
-  "dependencies": ["plugin-oas", "plugin-ts"],
-  "skills": [
-    {
-      "name": "generate-react-query-hooks",
-      "description": "Generate React Query hooks for API endpoints",
-      "tags": ["react", "hooks"],
-      "examples": [
-        {
-          "title": "Basic usage",
-          "code": "pluginReactQuery({ output: { path: './hooks' } })"
-        }
-      ]
-    }
-  ]
-}
+```yaml
+$schema: 'https://kubb.dev/schemas/plugin.json'
+id: plugin-react-query
+name: React Query
+description: Generate React Query hooks from API specifications.
+category: framework
+type: official
+npmPackage: '@kubb/plugin-react-query'
+docsPath: /plugins/plugin-react-query
+repo: https://github.com/kubb-labs/kubb
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: '>=5.0.0'
+  node: '>=22'
+tags:
+  - react
+  - hooks
+  - tanstack-query
+dependencies:
+  - plugin-oas
+  - plugin-ts
+featured: true
 ```
 
 ## Usage
 
 ### Validating Plugin Metadata
 
-Use the schema URL in your `plugin.json`:
+Use the schema URL in your YAML frontmatter:
 
-```json
-{
-  "$schema": "https://kubb.dev/schemas/plugin.json",
-  "id": "my-plugin",
-  ...
-}
+```yaml
+$schema: 'https://kubb.dev/schemas/plugin.json'
+id: my-plugin
+# ...
 ```
-## Categories
-
-| ID | Name | Description |
-| -- | ---- | ----------- |
-| `specification` | Specification | Core OpenAPI parsing plugins |
-| `framework` | Framework | Framework-specific code generation |
-| `testing` | Testing | Test utilities and mock data |
-| `utility` | Utility | Validation, types, and clients |
-| `documentation` | Documentation | API documentation generation |
-| `ai` | AI Integration | AI and MCP integration |

--- a/schemas/plugins/plugins.json
+++ b/schemas/plugins/plugins.json
@@ -23,17 +23,19 @@
     "categories": {
       "type": "array",
       "description": "Distinct plugin categories present in the registry.",
-      "items": {
-        "type": "object",
-        "required": ["id", "name"],
-        "properties": {
-          "id": { "type": "string", "description": "Category identifier" },
-          "name": { "type": "string", "description": "Category display name" }
-        }
-      }
+      "items": { "$ref": "#/definitions/category" }
     }
   },
   "definitions": {
+    "category": {
+      "type": "object",
+      "description": "Registry category entry.",
+      "required": ["id", "name"],
+      "properties": {
+        "id": { "type": "string", "description": "Category identifier" },
+        "name": { "type": "string", "description": "Category display name" }
+      }
+    },
     "registryPlugin": {
       "description": "A plugin entry as it appears in the aggregated registry: the canonical plugin schema plus runtime-derived stats and publish timestamps.",
       "allOf": [
@@ -63,7 +65,7 @@
         "downloads": {
           "type": "integer",
           "minimum": 0,
-          "description": "Weekly NPM downloads."
+          "description": "Monthly NPM downloads."
         },
         "stars": {
           "type": "integer",


### PR DESCRIPTION
- Extract inline categories[] item into named `category` definition in
  plugins.json, adapters.json, parsers.json (was duplicated inline).
- Normalize NPM download period wording to "Monthly" across all four
  registry schemas (plugins.json previously said "Weekly").
- Add `codesandbox` to `resources` in adapter.json, parser.json,
  middleware.json so `resources` matches plugin.json.
- Add `dependencies` array to middleware.json to align with the other
  three entity schemas.
- Refresh schemas/plugins/README.md: remove stale fields that no longer
  exist in plugin.json (`version`, `skills`, `fullExample`), update the
  optional-fields table and categories table to match the schema, and
  switch the example to the YAML form used in the adapters/parsers docs.