### PR TITLE
fix: Added shared schema-graph helpers to `@kubb/ast` so plugins can stop reimplementing reference traversal and cycle detection:

### DIFF
--- a/.changeset/add-find-circular-schemas.md
+++ b/.changeset/add-find-circular-schemas.md
@@ -1,0 +1,10 @@
+---
+'@kubb/ast': minor
+---
+
+Added shared schema-graph helpers to `@kubb/ast` so plugins can stop reimplementing reference traversal and cycle detection:
+
+- `resolveRefName(node)` — extracts the referenced schema name from a `ref` node (with sensible fallbacks).
+- `collectReferencedSchemaNames(node)` — collects every schema name reachable via `ref` edges.
+- `findCircularSchemas(schemas)` — returns the set of named schemas that participate in a reference cycle (direct self-loops or indirect cycles such as `Pet → Cat → Pet`).
+- `containsCircularRef(node, { circularSchemas, excludeName? })` — checks whether a schema (or any nested node) references a circular schema, with optional self-name exclusion.

--- a/packages/adapter-oas/CHANGELOG.md
+++ b/packages/adapter-oas/CHANGELOG.md
@@ -112,17 +112,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -428,7 +428,6 @@
 ### Patch Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -440,7 +439,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -493,7 +491,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`
@@ -509,7 +506,6 @@
 ### Minor Changes
 
 - [#2821](https://github.com/kubb-labs/kubb/pull/2821) [`f4105fe`](https://github.com/kubb-labs/kubb/commit/f4105fe44e46ec2846e665fd6079290e6d6ce6c6) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - **`@kubb/plugin-ts`**: When `legacy: true`, the type generator now fully matches the v4 output:
-
   - Grouped parameter types: `<OperationId>PathParams`, `<OperationId>QueryParams`, `<OperationId>HeaderParams`
   - No `<OperationId>RequestConfig` type emitted
   - Wrapper types (`Mutation`/`Query`) use `{ Response, Request?, QueryParams?, Errors }` shape
@@ -519,7 +515,6 @@
   Six `@deprecated` resolver methods added to `ResolverTs` for grouped parameter naming (`resolvePathParamsName`, `resolveQueryParamsName`, `resolveHeaderParamsName` and typed variants). Implemented only in `resolverTsLegacy`; will be removed in v6.
 
   **`@kubb/adapter-oas`**: `collisionDetection` is now part of the public API with a default of `true`.
-
   - `collisionDetection: true` (default) → full-path enum names, e.g. `OrderParamsStatusEnum`
   - `collisionDetection: false` → immediate-parent enum names with numeric deduplication, e.g. `ParamsStatusEnum`, `ParamsStatusEnum2`
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -263,7 +263,6 @@
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`f7d19bb`](https://github.com/kubb-labs/kubb/commit/f7d19bb69177fbd1b54c855423b3b55c399678b0) Thanks [@pull](https://github.com/apps/pull)! - Decouple `@kubb/agent` from static plugin knowledge.
 
   Plugins are now resolved at runtime via dynamic `import()` instead of being hard-coded as dependencies. This means:
-
   - `@kubb/agent` no longer bundles or lists any `@kubb/plugin-*` packages as dependencies.
   - Any Kubb plugin (or third-party plugin) is supported — install whichever plugins you need alongside the agent.
   - Plugin factory resolution tries three strategies in order: camelCase named export (`pluginReactQuery`), `default` export, or first exported function.
@@ -363,7 +362,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -1889,7 +1887,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio

--- a/packages/ast/CHANGELOG.md
+++ b/packages/ast/CHANGELOG.md
@@ -47,17 +47,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -113,7 +113,6 @@
   ### `@kubb/ast`
 
   New node types in `nodes/code.ts`:
-
   - `ConstNode` (`kind: 'Const'`) — mirrors the `Const` component
   - `TypeNode` (`kind: 'Type'`) — mirrors the `Type` component; a plain type alias declaration with `name`, `export`, `JSDoc`, and `nodes` fields
   - `FunctionNode` (`kind: 'Function'`) — mirrors the `Function` component
@@ -148,7 +147,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -161,13 +159,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -176,26 +172,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -204,26 +199,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -238,7 +232,6 @@
   Complete rewrite of `@kubb/plugin-zod` to the v5 AST-based architecture. The plugin no longer depends on `@kubb/plugin-oas` or `@kubb/oas`; it operates entirely on the `@kubb/ast` node graph.
 
   **Breaking changes:**
-
   - `mapper` option removed — no replacement (naming is now controlled via `resolvers`)
   - `version` option removed — Zod v3 is no longer supported; Kubb v5 always generates Zod v4 code
   - `contentType` option removed — moved to `adapterOas(...)`
@@ -252,21 +245,18 @@
   - Naming conventions (default preset): response status schemas are now named `<operationId>Status<code>Schema` instead of `<operationId><code>Schema`. Use `compatibilityPreset: 'kubbV4'` to keep the old names.
 
   **New options:**
-
   - `paramsCasing?: 'camelcase'` — apply camelCase to path/query/header parameter names in operation schemas
   - `compatibilityPreset?: 'default' | 'kubbV4'` — select naming conventions; `'kubbV4'` reproduces Kubb v4 names for a gradual migration
   - `resolvers?: Array<ResolverZod>` — provide custom resolver instances to override naming conventions
   - `transformers?: Array<Visitor>` — AST visitor array applied to each `SchemaNode` before printing (replaces the old `transformers.schema` callback)
 
   **New exports:**
-
   - `resolverZod` — default v5 resolver (camelCase + `Schema` suffix)
   - `resolverZodLegacy` — Kubb v4-compatible resolver (use with `compatibilityPreset: 'kubbV4'`)
   - `printerZod` — Zod v4 chainable-API printer factory (`definePrinter`)
   - `printerZodMini` — Zod v4 Mini functional-API printer factory
 
   ### `@kubb/ast`
-
   - `createSchema`, `createProperty`, `createOperation` factory functions now automatically infer and set the `primitive` field based on the node `type`, reducing boilerplate in tests and custom generators.
 
 ## 5.0.0-alpha.24
@@ -276,7 +266,6 @@
 ### Minor Changes
 
 - [#2931](https://github.com/kubb-labs/kubb/pull/2931) [`8cfa19a`](https://github.com/kubb-labs/kubb/commit/8cfa19adbe681d4466f0ff97a8c14ece8ba1e5d8) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Added `createOperationParams(node, options)` utility that converts an `OperationNode` into a `FunctionParametersNode`.
   - Added `reference` variant to `TypeNode` for plain type name strings (e.g. `'string'`, `'QueryParams'`), so all type annotations in the AST are always `TypeNode` — never raw strings.
   - Changed `FunctionParameterNode.type` from `string | TypeNode` to `TypeNode`.
@@ -285,7 +274,6 @@
   - Removed `typeToString` helper from `utils.ts`; `resolveType` now returns `TypeNode` directly.
 
   ### `@kubb/plugin-ts`
-
   - Updated `functionPrinter` to handle all three `TypeNode` variants (`member`, `struct`, `reference`) explicitly; removed all `typeof … === 'string'` checks.
 
 ## 5.0.0-alpha.22
@@ -307,7 +295,6 @@
 ### Minor Changes
 
 - [#2889](https://github.com/kubb-labs/kubb/pull/2889) [`2546c05`](https://github.com/kubb-labs/kubb/commit/2546c051d81e490709df9d8a834402ef546a8f1c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Reorganized schema helper modules into clearer categories:
     - `transformers.ts` for schema transformation helpers
     - `resolvers.ts` for lookup/derivation helpers
@@ -319,7 +306,6 @@
   - Removed deprecated alias exports for old names.
 
   ### `@kubb/adapter-oas`
-
   - Fixed named import shape regression in adapter import resolution.
   - `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]` (for example `['PetType']`), with added regression coverage.
 
@@ -332,17 +318,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -356,7 +339,6 @@
 - [#2858](https://github.com/kubb-labs/kubb/pull/2858) [`975717e`](https://github.com/kubb-labs/kubb/commit/975717e2c8cf8d33f5d9d641be4bb164fd36f423) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix missing `@description` on request body type aliases.
 
   The OAS `requestBody.description` field (top-level on the request body object, distinct from the schema's own description) was silently dropped. It is now:
-
   - Added as `description?: string` to `OperationNode.requestBody` in `@kubb/ast`
   - Populated by `@kubb/adapter-oas` parser from `operation.schema.requestBody.description`
   - Used by `@kubb/plugin-ts` typeGenerator: `requestBody.description` takes precedence, falling back to `requestBody.schema.description`

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -34,5 +34,16 @@ export { childName, collectImports, enumPropName, findDiscriminator } from './re
 export { mergeAdjacentObjects, setDiscriminatorEnum, setEnumName, simplifyUnion } from './transformers.ts'
 export type * from './types.ts'
 export type { OperationParamsResolver } from './utils.ts'
-export { caseParams, createDiscriminantNode, createOperationParams, extractStringsFromNodes, isStringType, syncSchemaRef } from './utils.ts'
+export {
+  caseParams,
+  collectReferencedSchemaNames,
+  containsCircularRef,
+  createDiscriminantNode,
+  createOperationParams,
+  extractStringsFromNodes,
+  findCircularSchemas,
+  isStringType,
+  resolveRefName,
+  syncSchemaRef,
+} from './utils.ts'
 export { collect, transform, walk } from './visitor.ts'

--- a/packages/ast/src/utils.test.ts
+++ b/packages/ast/src/utils.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, it } from 'vitest'
-import { createFunctionParameter, createOperation, createParameter, createParamsType, createSchema } from './factory.ts'
+import { createFunctionParameter, createOperation, createParameter, createParamsType, createProperty, createSchema } from './factory.ts'
 import type { OperationNode, ParameterNode } from './types.ts'
 import type { OperationParamsResolver } from './utils.ts'
-import { caseParams, createDiscriminantNode, createOperationParams, isStringType, syncSchemaRef } from './utils.ts'
+import {
+  caseParams,
+  collectReferencedSchemaNames,
+  containsCircularRef,
+  createDiscriminantNode,
+  createOperationParams,
+  findCircularSchemas,
+  isStringType,
+  resolveRefName,
+  syncSchemaRef,
+} from './utils.ts'
 
 const param = (name: string) =>
   createParameter({
@@ -1742,5 +1752,175 @@ describe('combineImports', () => {
 
   it('returns empty array for empty input', () => {
     expect(combineImports([], [], '')).toEqual([])
+  })
+})
+
+describe('findCircularSchemas', () => {
+  it('returns empty set for acyclic schemas', () => {
+    const Category = createSchema({ type: 'object', name: 'Category', properties: [] })
+    const Pet = createSchema({
+      type: 'object',
+      name: 'Pet',
+      properties: [createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) })],
+    })
+
+    expect(findCircularSchemas([Category, Pet])).toEqual(new Set())
+  })
+
+  it('detects direct self-reference (TreeNode → TreeNode)', () => {
+    const TreeNode = createSchema({
+      type: 'object',
+      name: 'TreeNode',
+      properties: [
+        createProperty({ name: 'left', required: false, schema: createSchema({ type: 'ref', name: 'TreeNode', ref: '#/components/schemas/TreeNode' }) }),
+      ],
+    })
+
+    expect(findCircularSchemas([TreeNode])).toEqual(new Set(['TreeNode']))
+  })
+
+  it('detects indirect cycle (Pet → Cat → Pet)', () => {
+    const Pet = createSchema({
+      type: 'union',
+      name: 'Pet',
+      members: [createSchema({ type: 'ref', name: 'Cat', ref: '#/components/schemas/Cat' })],
+    })
+    const Cat = createSchema({
+      type: 'object',
+      name: 'Cat',
+      properties: [
+        createProperty({
+          name: 'friends',
+          required: false,
+          schema: createSchema({ type: 'array', items: [createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' })] }),
+        }),
+      ],
+    })
+
+    expect(findCircularSchemas([Pet, Cat])).toEqual(new Set(['Pet', 'Cat']))
+  })
+
+  it('detects refs nested inside unions and arrays', () => {
+    const A = createSchema({
+      type: 'object',
+      name: 'A',
+      properties: [
+        createProperty({
+          name: 'next',
+          required: false,
+          schema: createSchema({
+            type: 'union',
+            members: [createSchema({ type: 'null' }), createSchema({ type: 'ref', name: 'A', ref: '#/components/schemas/A' })],
+          }),
+        }),
+      ],
+    })
+
+    expect(findCircularSchemas([A])).toEqual(new Set(['A']))
+  })
+
+  it('does not flag schemas that only reference cyclic schemas without participating', () => {
+    // B → A → A, but A does not reference B.
+    const A = createSchema({
+      type: 'object',
+      name: 'A',
+      properties: [createProperty({ name: 'self', required: false, schema: createSchema({ type: 'ref', name: 'A', ref: '#/components/schemas/A' }) })],
+    })
+    const B = createSchema({
+      type: 'object',
+      name: 'B',
+      properties: [createProperty({ name: 'a', required: false, schema: createSchema({ type: 'ref', name: 'A', ref: '#/components/schemas/A' }) })],
+    })
+    const result = findCircularSchemas([A, B])
+
+    expect(result.has('A')).toBe(true)
+    expect(result.has('B')).toBe(false)
+  })
+
+  it('skips unnamed schemas', () => {
+    const anon = createSchema({ type: 'object' })
+    expect(findCircularSchemas([anon])).toEqual(new Set())
+  })
+})
+
+describe('resolveRefName', () => {
+  it('extracts the name from a $ref pointer', () => {
+    const ref = createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' })
+
+    expect(resolveRefName(ref)).toBe('Pet')
+  })
+
+  it('falls back to node.name when ref is missing', () => {
+    const ref = createSchema({ type: 'ref', name: 'Pet' })
+
+    expect(resolveRefName(ref)).toBe('Pet')
+  })
+
+  it('returns undefined for non-ref nodes', () => {
+    expect(resolveRefName(createSchema({ type: 'string' }))).toBeUndefined()
+    expect(resolveRefName(undefined)).toBeUndefined()
+  })
+})
+
+describe('collectReferencedSchemaNames', () => {
+  it('collects ref names nested in objects, arrays and unions', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'Pet',
+      properties: [
+        createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) }),
+        createProperty({
+          name: 'tags',
+          required: false,
+          schema: createSchema({ type: 'array', items: [createSchema({ type: 'ref', name: 'Tag', ref: '#/components/schemas/Tag' })] }),
+        }),
+        createProperty({
+          name: 'owner',
+          required: false,
+          schema: createSchema({
+            type: 'union',
+            members: [createSchema({ type: 'null' }), createSchema({ type: 'ref', name: 'User', ref: '#/components/schemas/User' })],
+          }),
+        }),
+      ],
+    })
+
+    expect(collectReferencedSchemaNames(schema)).toEqual(new Set(['Category', 'Tag', 'User']))
+  })
+
+  it('returns an empty set for schemas without refs', () => {
+    expect(collectReferencedSchemaNames(createSchema({ type: 'string' }))).toEqual(new Set())
+  })
+})
+
+describe('containsCircularRef', () => {
+  it('returns true when a nested ref points to a circular schema', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'Cat',
+      properties: [createProperty({ name: 'archEnemy', required: false, schema: createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' }) })],
+    })
+
+    expect(containsCircularRef(schema, { circularSchemas: new Set(['Pet']) })).toBe(true)
+  })
+
+  it('returns false when excludeName matches the only circular ref', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'TreeNode',
+      properties: [createProperty({ name: 'left', required: false, schema: createSchema({ type: 'ref', name: 'TreeNode', ref: '#/components/schemas/TreeNode' }) })],
+    })
+
+    expect(containsCircularRef(schema, { circularSchemas: new Set(['TreeNode']), excludeName: 'TreeNode' })).toBe(false)
+  })
+
+  it('returns false when there are no refs', () => {
+    expect(containsCircularRef(createSchema({ type: 'string' }), { circularSchemas: new Set(['Pet']) })).toBe(false)
+  })
+
+  it('short-circuits when the circular set is empty', () => {
+    const schema = createSchema({ type: 'ref', name: 'Pet', ref: '#/components/schemas/Pet' })
+
+    expect(containsCircularRef(schema, { circularSchemas: new Set() })).toBe(false)
   })
 })

--- a/packages/ast/src/utils.test.ts
+++ b/packages/ast/src/utils.test.ts
@@ -1761,7 +1761,9 @@ describe('findCircularSchemas', () => {
     const Pet = createSchema({
       type: 'object',
       name: 'Pet',
-      properties: [createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) })],
+      properties: [
+        createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) }),
+      ],
     })
 
     expect(findCircularSchemas([Category, Pet])).toEqual(new Set())
@@ -1908,7 +1910,9 @@ describe('containsCircularRef', () => {
     const schema = createSchema({
       type: 'object',
       name: 'TreeNode',
-      properties: [createProperty({ name: 'left', required: false, schema: createSchema({ type: 'ref', name: 'TreeNode', ref: '#/components/schemas/TreeNode' }) })],
+      properties: [
+        createProperty({ name: 'left', required: false, schema: createSchema({ type: 'ref', name: 'TreeNode', ref: '#/components/schemas/TreeNode' }) }),
+      ],
     })
 
     expect(containsCircularRef(schema, { circularSchemas: new Set(['TreeNode']), excludeName: 'TreeNode' })).toBe(false)

--- a/packages/ast/src/utils.ts
+++ b/packages/ast/src/utils.ts
@@ -854,7 +854,10 @@ export function findCircularSchemas(schemas: ReadonlyArray<SchemaNode>): Set<str
  * }
  * ```
  */
-export function containsCircularRef(node: SchemaNode | undefined, { circularSchemas, excludeName }: { circularSchemas: ReadonlySet<string>; excludeName?: string }): boolean {
+export function containsCircularRef(
+  node: SchemaNode | undefined,
+  { circularSchemas, excludeName }: { circularSchemas: ReadonlySet<string>; excludeName?: string },
+): boolean {
   if (!node || circularSchemas.size === 0) return false
 
   const matches = collect<true>(node, {

--- a/packages/ast/src/utils.ts
+++ b/packages/ast/src/utils.ts
@@ -16,6 +16,8 @@ import type {
   SourceNode,
 } from './nodes/index.ts'
 import type { SchemaType } from './nodes/schema.ts'
+import { extractRefName } from './refs.ts'
+import { collect } from './visitor.ts'
 
 const plainStringTypes = new Set<SchemaType>(['string', 'uuid', 'email', 'url', 'datetime'] as const)
 
@@ -738,4 +740,131 @@ export function extractStringsFromNodes(nodes: Array<CodeNode> | undefined): str
     })
     .filter(Boolean)
     .join('\n')
+}
+
+/**
+ * Resolves the referenced schema name of a `ref` node, falling back through
+ * `ref` → `name` → nested `schema.name`. Returns `undefined` for non-ref
+ * nodes or when no name can be resolved.
+ *
+ * @example
+ * ```ts
+ * resolveRefName({ kind: 'Schema', type: 'ref', ref: '#/components/schemas/Pet' })
+ * // => 'Pet'
+ * ```
+ */
+export function resolveRefName(node: SchemaNode | undefined): string | undefined {
+  if (!node || node.type !== 'ref') return undefined
+  if (node.ref) return extractRefName(node.ref) ?? node.name ?? node.schema?.name ?? undefined
+
+  return node.name ?? node.schema?.name ?? undefined
+}
+
+/**
+ * Recursively collects every named schema referenced (transitively) from
+ * `node` via `ref` edges. Refs are followed by name only — the resolved
+ * `node.schema` of a ref is not traversed inline.
+ *
+ * @example
+ * ```ts
+ * const refs = collectReferencedSchemaNames(petSchema)
+ * // => Set { 'Cat', 'Dog' }
+ * ```
+ */
+export function collectReferencedSchemaNames(node: SchemaNode | undefined, out: Set<string> = new Set()): Set<string> {
+  if (!node) return out
+  collect<void>(node, {
+    schema(child) {
+      if (child.type === 'ref') {
+        const name = resolveRefName(child)
+
+        if (name) out.add(name)
+      }
+      return undefined
+    },
+  })
+  return out
+}
+
+/**
+ * Identifies every named schema that participates in a circular dependency
+ * chain — including direct self-loops (e.g. `TreeNode → TreeNode`) and indirect
+ * cycles spanning multiple schemas (e.g. `Pet → Cat → Pet`).
+ *
+ * The returned set contains schema names. Plugins that translate schemas into
+ * a host language can use this to wrap recursive positions in a deferred
+ * construct (lazy getter, `z.lazy(() => …)`, etc.) and avoid runtime stack
+ * overflows when the generated code is executed.
+ *
+ * Refs are followed by name only — `node.schema` (the resolved referent) is
+ * not traversed inline, which keeps the algorithm linear in the size of the
+ * schema graph.
+ *
+ * @example
+ * ```ts
+ * const circular = findCircularSchemas(inputNode.schemas)
+ * if (circular.has('Pet')) {
+ *   // emit lazy wrapper for any property whose schema references Pet
+ * }
+ * ```
+ */
+export function findCircularSchemas(schemas: ReadonlyArray<SchemaNode>): Set<string> {
+  const graph = new Map<string, Set<string>>()
+
+  for (const schema of schemas) {
+    if (!schema.name) continue
+    graph.set(schema.name, collectReferencedSchemaNames(schema))
+  }
+
+  const circular = new Set<string>()
+  for (const start of graph.keys()) {
+    const visited = new Set<string>()
+    const stack: string[] = [...(graph.get(start) ?? [])]
+    while (stack.length > 0) {
+      const node = stack.pop()!
+      if (node === start) {
+        circular.add(start)
+        break
+      }
+      if (visited.has(node)) continue
+      visited.add(node)
+
+      const next = graph.get(node)
+      if (next) for (const r of next) stack.push(r)
+    }
+  }
+
+  return circular
+}
+
+/**
+ * Returns true when `node` (or anything nested within it) carries a `ref`
+ * whose resolved name belongs to `circularSchemas`.
+ *
+ * When `excludeName` is provided, refs to that name are ignored — useful
+ * when self-references are already handled separately from cross-schema
+ * cycles (e.g. the faker plugin emits `undefined as any` for direct
+ * self-recursion but a lazy getter for indirect cycles).
+ *
+ * @example
+ * ```ts
+ * const circular = findCircularSchemas(schemas)
+ * if (containsCircularRef(property.schema, { circularSchemas: circular, excludeName: 'Pet' })) {
+ *   // emit `get foo() { return fakeCat() }` instead of eager call
+ * }
+ * ```
+ */
+export function containsCircularRef(node: SchemaNode | undefined, { circularSchemas, excludeName }: { circularSchemas: ReadonlySet<string>; excludeName?: string }): boolean {
+  if (!node || circularSchemas.size === 0) return false
+
+  const matches = collect<true>(node, {
+    schema(child) {
+      if (child.type !== 'ref') return undefined
+      const name = resolveRefName(child)
+
+      return name && name !== excludeName && circularSchemas.has(name) ? true : undefined
+    },
+  })
+
+  return matches.length > 0
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -71,7 +71,6 @@
 ### Patch Changes
 
 - [#3156](https://github.com/kubb-labs/kubb/pull/3156) [`a91e448`](https://github.com/kubb-labs/kubb/commit/a91e448f6f08fc78c956cfe0662ffec75fac14cd) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Internal cleanup: dedupe backend code and drop unused exports.
-
   - `@kubb/parser-ts`: add `src/constants.ts` (regex + path-prefix literals); dedupe `printFunction`/`printArrowFunction` via `formatGenerics` / `formatReturnType`; dedupe the import/export path resolution inside `parserTs.parse` into `resolveOutputPath`.
   - `@kubb/core`: collapse `FileManager#add` and `FileManager#upsert` onto a shared private `#store` helper (`mergeFilesByPath`); drop unused `DEFAULT_CONCURRENCY` / `PATH_SEPARATORS` constants.
   - `@kubb/ast`: drop unused `parameterLocations` and `DEFAULT_STATUS_CODE` constants.
@@ -128,7 +127,6 @@
 ### Patch Changes
 
 - [#3138](https://github.com/kubb-labs/kubb/pull/3138) [`72025d7`](https://github.com/kubb-labs/kubb/commit/72025d7255c7d09b69b2665b938a9a5fd3890cf7) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix typecheck issues.
-
   - Remove unused `FileNode` and `Plugin` imports from `Kubb.ts`
   - Fix `context.emit('kubb:info', text)` to pass the correct `KubbInfoContext` shape (`{ message: text }`)
   - Remove unused `config` destructure in `plainLogger.ts` generation start handler
@@ -230,7 +228,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -353,7 +350,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).
@@ -686,7 +682,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -794,7 +789,6 @@
 - [#2607](https://github.com/kubb-labs/kubb/pull/2607) [`e244177`](https://github.com/kubb-labs/kubb/commit/e244177168a2e32a2818626a5efde990d1f1806f) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Add anonymous telemetry to the Kubb CLI to track usage data (command, plugins, version, duration, platform, Node.js version, and file count). No OpenAPI specs, file paths, plugin options, or secrets are ever collected.
 
   Telemetry can be disabled at any time by setting:
-
   - `DO_NOT_TRACK=1` – standard opt-out flag recognised by many developer tools ([consoledonottrack.com](https://consoledonottrack.com))
   - `KUBB_DISABLE_TELEMETRY=1` – Kubb-specific opt-out flag
 
@@ -928,7 +922,6 @@
   Add bidirectional WebSocket communication between Kubb Agent and Kubb Studio. The agent now automatically connects to Studio on startup when `KUBB_STUDIO_URL` and `KUBB_AGENT_TOKEN` environment variables are set.
 
   Features:
-
   - Persistent WebSocket connection with automatic reconnection
   - Real-time streaming of generation events to Studio
   - Command handling for `generate` and `connect` commands from Studio
@@ -1064,7 +1057,6 @@
 - [#2396](https://github.com/kubb-labs/kubb/pull/2396) [`b5c4fd9`](https://github.com/kubb-labs/kubb/commit/b5c4fd94711b1657cdffe9a629229cd0f708a4b1) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add new `init` command for interactive project setup
 
   The CLI now includes a new `kubb init` command that provides an interactive setup wizard to quickly scaffold a Kubb project:
-
   - **Interactive prompts**: Uses `@clack/prompts` for a beautiful CLI experience
   - **Package manager detection**: Automatically detects `npm`, `pnpm`, `yarn`, or `bun`
   - **Plugin selection**: Multi-select from all 13 available Kubb plugins
@@ -1079,7 +1071,6 @@
   ```
 
   The command will guide you through:
-
   1. Creating a `package.json` (if needed)
   2. Selecting your OpenAPI specification path
   3. Choosing which plugins to install
@@ -1255,13 +1246,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -69,7 +69,6 @@
 ### Patch Changes
 
 - [#3156](https://github.com/kubb-labs/kubb/pull/3156) [`a91e448`](https://github.com/kubb-labs/kubb/commit/a91e448f6f08fc78c956cfe0662ffec75fac14cd) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Internal cleanup: dedupe backend code and drop unused exports.
-
   - `@kubb/parser-ts`: add `src/constants.ts` (regex + path-prefix literals); dedupe `printFunction`/`printArrowFunction` via `formatGenerics` / `formatReturnType`; dedupe the import/export path resolution inside `parserTs.parse` into `resolveOutputPath`.
   - `@kubb/core`: collapse `FileManager#add` and `FileManager#upsert` onto a shared private `#store` helper (`mergeFilesByPath`); drop unused `DEFAULT_CONCURRENCY` / `PATH_SEPARATORS` constants.
   - `@kubb/ast`: drop unused `parameterLocations` and `DEFAULT_STATUS_CODE` constants.
@@ -125,12 +124,12 @@
 
   ```ts
   export const pluginBarrel = definePlugin<PluginBarrel>((options) => ({
-    name: "plugin-barrel",
-    enforce: "post", // always runs after all normal plugins
+    name: 'plugin-barrel',
+    enforce: 'post', // always runs after all normal plugins
     hooks: {
       /* ... */
     },
-  }));
+  }))
   ```
 
   Execution order: `pre → normal → post`. Existing `dependencies` constraints still take precedence within each group.
@@ -152,17 +151,17 @@
   **Before**
 
   ```ts
-  operation.requestBody?.schema;
-  operation.requestBody?.contentType;
-  operation.requestBody?.keysToOmit;
+  operation.requestBody?.schema
+  operation.requestBody?.contentType
+  operation.requestBody?.keysToOmit
   ```
 
   **After**
 
   ```ts
-  operation.requestBody?.content?.[0]?.schema;
-  operation.requestBody?.content?.[0]?.contentType;
-  operation.requestBody?.content?.[0]?.keysToOmit;
+  operation.requestBody?.content?.[0]?.schema
+  operation.requestBody?.content?.[0]?.contentType
+  operation.requestBody?.content?.[0]?.keysToOmit
   ```
 
   See `migration/requestBody-content.md` for a full migration guide.
@@ -178,7 +177,6 @@
 ### Patch Changes
 
 - [#3138](https://github.com/kubb-labs/kubb/pull/3138) [`72025d7`](https://github.com/kubb-labs/kubb/commit/72025d7255c7d09b69b2665b938a9a5fd3890cf7) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix typecheck issues.
-
   - Remove unused `FileNode` and `Plugin` imports from `Kubb.ts`
   - Fix `context.emit('kubb:info', text)` to pass the correct `KubbInfoContext` shape (`{ message: text }`)
   - Remove unused `config` destructure in `plainLogger.ts` generation start handler
@@ -198,25 +196,13 @@
   **Before**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    never,
-    object,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, never, object, ResolverZod>
   ```
 
   **After**
 
   ```ts
-  type PluginZod = PluginFactoryOptions<
-    "plugin-zod",
-    Options,
-    ResolvedOptions,
-    ResolverZod
-  >;
+  type PluginZod = PluginFactoryOptions<'plugin-zod', Options, ResolvedOptions, ResolverZod>
   ```
 
   Migrate any custom plugin types by removing the 4th (`TContext`) and 5th (`TResolvePathOptions`) positional arguments.
@@ -234,7 +220,6 @@
 - [#3127](https://github.com/kubb-labs/kubb/pull/3127) [`570d8d5`](https://github.com/kubb-labs/kubb/commit/570d8d514e8c1864c1981763ff61ac5cdc4c10db) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Replace `this` with explicit `ctx` parameter in `defineResolver` builder.
 
   ### `@kubb/core`
-
   - `ResolverBuilder<T>` now receives the assembled resolver as `ctx` instead of using `ThisType<T['resolver']>`.
   - `defaultResolveFile` accepts the resolver as an explicit `ctx: Resolver` third parameter instead of a `this` receiver.
   - `defineResolver` creates the resolver shell first and passes it to the builder, so `ctx` methods resolve lazily and include any builder overrides.
@@ -250,7 +235,6 @@
 ### Patch Changes
 
 - [#3124](https://github.com/kubb-labs/kubb/pull/3124) [`80d43c6`](https://github.com/kubb-labs/kubb/commit/80d43c66c86ee69359c78184024497f4e2eb1d3e) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Fix path traversal vulnerabilities in file path resolution.
-
   - `camelCase` / `pascalCase` with `isFile: true` no longer produces a leading `/` when a schema name starts with `.{letter}` (e.g. `..Schema`). Empty segments produced by such names are now filtered before joining with `/`, preventing the result from being interpreted as an absolute path.
   - `defaultResolvePath` default group name for `group.type === 'path'` now strips `.` and `..` components from the OpenAPI operation path before selecting the first segment as a subdirectory name.
   - Added an output-directory boundary check to `defaultResolvePath`: if the resolved path escapes the configured output directory an error is thrown, providing defense-in-depth against path traversal in malicious OpenAPI specs or misconfigured `group.name` functions.
@@ -307,10 +291,10 @@
 
   ```ts
   // before – always returned the base Resolver type
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // Resolver
+  const resolver = driver.getResolver('@kubb/plugin-ts') // Resolver
 
   // after – returns the plugin's typed resolver
-  const resolver = driver.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+  const resolver = driver.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
   ```
 
   ### `GeneratorContext.getResolver`
@@ -320,9 +304,9 @@
   ```ts
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, ctx) {
-      const tsResolver = ctx.getResolver("@kubb/plugin-ts"); // PluginTs['resolver']
+      const tsResolver = ctx.getResolver('@kubb/plugin-ts') // PluginTs['resolver']
     },
-  });
+  })
   ```
 
 ### Patch Changes
@@ -348,17 +332,14 @@
 - [#3095](https://github.com/kubb-labs/kubb/pull/3095) [`96ac140`](https://github.com/kubb-labs/kubb/commit/96ac140638e1c10bbdf91840f0c8271c91124c03) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Remove legacy plugin infrastructure now that all plugins use `definePlugin`.
 
   ### Removed types
-
   - `NormalizedPlugin` — internal plugin state is no longer part of the public API. Use `Plugin` for all external-facing plugin references.
   - `PluginContext` — replaced by the standalone `GeneratorContext` type.
   - `SchemaHook`, `OperationHook`, `OperationsHook` — unused hook type aliases.
 
   ### Renamed types
-
   - The internal `InternalPlugin` type (never public) was renamed to `NormalizedPlugin` for clarity, but this type is marked `@internal` and should not be used by plugin authors.
 
   ### Improved types
-
   - `ResolveOptionsContext` — marked `@internal`.
   - `FileMetaBase` — marked `@internal`.
   - `FileProcessor` — marked `@internal`.
@@ -373,10 +354,10 @@
 
   ```ts
   // Before
-  import type { NormalizedPlugin, PluginContext } from "@kubb/core";
+  import type { NormalizedPlugin, PluginContext } from '@kubb/core'
 
   // After
-  import type { Plugin, GeneratorContext } from "@kubb/core";
+  import type { Plugin, GeneratorContext } from '@kubb/core'
   ```
 
 ### Patch Changes
@@ -452,19 +433,18 @@
   **Before:**
 
   ```ts
-  import { getMode } from "@kubb/core";
-  getMode("src/gen/types.ts"); // 'single'
+  import { getMode } from '@kubb/core'
+  getMode('src/gen/types.ts') // 'single'
   ```
 
   **After:**
 
   ```ts
-  import { PluginDriver } from "@kubb/core";
-  PluginDriver.getMode("src/gen/types.ts"); // 'single'
+  import { PluginDriver } from '@kubb/core'
+  PluginDriver.getMode('src/gen/types.ts') // 'single'
   ```
 
   The following utilities have also been removed from `@kubb/core`'s public API as they are internal post-processing helpers used only by CLI/agent tooling:
-
   - `formatters` — moved to `@internals/utils`
   - `linters` — moved to `@internals/utils`
   - `detectFormatter` — moved to `@internals/utils`
@@ -565,13 +545,13 @@
   ```ts
   // Before
   pluginClient({
-    pre: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    pre: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
 
   // After
   pluginClient({
-    dependencies: ["@kubb/plugin-ts", "@kubb/plugin-zod"],
-  });
+    dependencies: ['@kubb/plugin-ts', '@kubb/plugin-zod'],
+  })
   ```
 
   All built-in plugins have been updated automatically. If you were setting `pre` or `post` directly on a custom plugin, update them to use `dependencies` instead.
@@ -602,7 +582,6 @@
 - [#2990](https://github.com/kubb-labs/kubb/pull/2990) [`3ac7d1f`](https://github.com/kubb-labs/kubb/commit/3ac7d1f9b75099bfe793e35152e5c322e65aa6ad) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Update `@kubb/react-fabric` and `@kubb/fabric-core` to v0.16.0
 
 - [#2994](https://github.com/kubb-labs/kubb/pull/2994) [`9e6a772`](https://github.com/kubb-labs/kubb/commit/9e6a772c7ca1ee54e931d2dbf0f2448f67707c0e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Add `@kubb/renderer-jsx` — a lightweight JSX renderer for Kubb plugins.
-
   - New package `@kubb/renderer-jsx` with a custom JSX runtime (`jsx-runtime`, `jsx-dev-runtime`)
   - Provides `createRenderer` to render JSX trees into `FileNode` arrays without React
   - Built-in components: `File`, `Const`, `Function`, `Type`, `Root`
@@ -627,7 +606,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -636,19 +614,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.
@@ -669,14 +647,14 @@
   Generators now receive a typed `this` context that guarantees `adapter` and `rootNode` are always present (non-optional). Use it instead of the raw `PluginContext` to avoid null-checks in every hook:
 
   ```ts
-  import { defineGenerator } from "@kubb/core";
+  import { defineGenerator } from '@kubb/core'
 
   export const myGenerator = defineGenerator<PluginMyPlugin>({
     async schema(node, options) {
-      const { adapter, rootNode } = this; // always present, no null-check needed
+      const { adapter, rootNode } = this // always present, no null-check needed
       // ...
     },
-  });
+  })
   ```
 
   ### New: `mergeGenerators(generators)`
@@ -684,25 +662,25 @@
   Combines an array of generators into a single merged generator. Each hook runs in sequence and applies its result via `applyHookResult`. Use this inside plugin hooks to delegate to all generators in the preset:
 
   ```ts
-  import { mergeGenerators } from "@kubb/core";
+  import { mergeGenerators } from '@kubb/core'
 
   export const myPlugin = createPlugin<MyPlugin>((options) => {
-    const generators = [generatorA, generatorB];
-    const mergedGenerator = mergeGenerators(generators);
+    const generators = [generatorA, generatorB]
+    const mergedGenerator = mergeGenerators(generators)
 
     return {
-      name: "my-plugin",
+      name: 'my-plugin',
       async schema(node, opts) {
-        return mergedGenerator.schema?.call(this, node, opts);
+        return mergedGenerator.schema?.call(this, node, opts)
       },
       async operation(node, opts) {
-        return mergedGenerator.operation?.call(this, node, opts);
+        return mergedGenerator.operation?.call(this, node, opts)
       },
       async operations(nodes, opts) {
-        return mergedGenerator.operations?.call(this, nodes, opts);
+        return mergedGenerator.operations?.call(this, nodes, opts)
       },
-    };
-  });
+    }
+  })
   ```
 
   ### New: `PluginRegistry` augmentation
@@ -710,7 +688,7 @@
   Every plugin now augments the global `Kubb.PluginRegistry` interface, enabling automatic typing for `getPlugin` and `requirePlugin`:
 
   ```ts
-  const tsPlugin = context.getPlugin("plugin-ts");
+  const tsPlugin = context.getPlugin('plugin-ts')
   // tsPlugin is typed as PluginTs automatically
   ```
 
@@ -772,7 +750,6 @@
 ### Minor Changes
 
 - [#2958](https://github.com/kubb-labs/kubb/pull/2958) [`795cac8`](https://github.com/kubb-labs/kubb/commit/795cac8edd6dd456185b7da90db9fd422c2b8330) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/ast`
-
   - Rename printer type exports to follow the `Printer{Suffix}` convention:
     - `TsPrinterFactory` → `PrinterTsFactory`
     - `TsPrinterNodes` → `PrinterTsNodes`
@@ -785,13 +762,11 @@
     - `ZodMiniPrinterOptions` → `PrinterZodMiniOptions`
 
   ### `@kubb/core`
-
   - Replace `mergeResolvers` with a single `resolver` partial override pattern. User-supplied methods are merged on top of the preset resolver via `withFallback`. Any method returning `null` or `undefined` falls back to the preset's implementation.
   - Remove `composeTransformers`. Replace the `transformers: Array<Visitor>` option with a single `transformer?: Visitor`. The visitor is applied directly via `transform(node, transformer ?? {})`.
   - `getPreset` now accepts `resolver?: Partial<TResolver> & ThisType<TResolver>` — use `this.default(...)` inside an override to call the preset resolver's implementation.
 
   ### `@kubb/plugin-ts`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverTs>` with `resolver?: Partial<ResolverTs> & ThisType<ResolverTs>`. Supply only the methods you want to override; all others fall back to the active preset resolver.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterTsNodes }` — override the TypeScript output for individual schema types (e.g. render `integer` as `bigint`).
@@ -800,26 +775,25 @@
   pluginTs({
     resolver: {
       resolveName(name) {
-        return `Custom${this.default(name, "function")}`;
+        return `Custom${this.default(name, 'function')}`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword);
+          return ts.factory.createKeywordTypeNode(ts.SyntaxKind.BigIntKeyword)
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-zod`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverZod>` with `resolver?: Partial<ResolverZod> & ThisType<ResolverZod>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
   - Add `printer?: { nodes?: PrinterZodNodes | PrinterZodMiniNodes }` — override Zod output for individual schema types (e.g. render `integer` as `z.number()`).
@@ -828,26 +802,25 @@
   pluginZod({
     resolver: {
       resolveName(name) {
-        return `${this.default(name, "function")}Schema`;
+        return `${this.default(name, 'function')}Schema`
       },
     },
     transformer: {
       schema(node) {
-        return { ...node, description: undefined };
+        return { ...node, description: undefined }
       },
     },
     printer: {
       nodes: {
         integer() {
-          return "z.number()";
+          return 'z.number()'
         },
       },
     },
-  });
+  })
   ```
 
   ### `@kubb/plugin-cypress`
-
   - **Breaking:** Replace `resolvers?: Array<ResolverCypress>` with `resolver?: Partial<ResolverCypress> & ThisType<ResolverCypress>`.
   - **Breaking:** Replace `transformers?: Array<Visitor>` with `transformer?: Visitor`.
 
@@ -870,7 +843,6 @@
 - [#2940](https://github.com/kubb-labs/kubb/pull/2940) [`c1e9257`](https://github.com/kubb-labs/kubb/commit/c1e92572c04cf82ddb4df2e9e72e1551287a21fa) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
 
   Add three generic helper functions to `renderNode.tsx` that encapsulate the repeated react + core generator dispatch boilerplate:
-
   - `runGeneratorSchema(node, ctx)` — dispatches a single schema node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperation(node, ctx)` — dispatches a single operation node to all generators (react + core), resolving and null-checking options per generator.
   - `runGeneratorOperations(nodes, ctx)` — batch-dispatches a list of collected operation nodes to all generators using `plugin.options` directly (no per-node filtering).
@@ -975,17 +947,14 @@
 ### Minor Changes
 
 - [#2872](https://github.com/kubb-labs/kubb/pull/2872) [`591977c`](https://github.com/kubb-labs/kubb/commit/591977c5c2f167736d6e43126ed0387a1e5e0ce5) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - ### `@kubb/core`
-
   - Add `name: string` to the `Resolver` base type. Every resolver now carries a name that identifies it.
   - `defineResolver` build functions must return a `name` property.
   - Add `mergeResolvers(...resolvers)` helper that merges multiple resolvers into one (last wins).
 
   ### `@kubb/ast`
-
   - Add `composeTransformers(...visitors)` helper that combines multiple `Visitor` objects into a single visitor. Each node kind is piped through all visitors sequentially (left to right).
 
   ### `@kubb/plugin-ts`
-
   - Add `resolvers` option — an array of named resolvers that control naming conventions. Later entries override earlier ones. Built-in resolvers: `resolverTs` (default) and `resolverTsLegacy`.
   - Add `transformers` option — an array of AST `Visitor` objects applied to each `SchemaNode` before printing. Uses `composeTransformers` + `transform` from `@kubb/ast`.
   - Export `resolverTs`, `resolverTsLegacy`, and `ResolverTs` from the package root.
@@ -1153,7 +1122,6 @@
   Introduces a `storage` option in `output` that replaces direct filesystem writes with a pluggable storage layer, inspired by the Nitro/unstorage API.
 
   **New exports from `@kubb/core`:**
-
   - `defineStorage(builder)` — factory helper (same pattern as `definePlugin`/`defineLogger`/`defineAdapter`) that wraps a builder function and makes options optional
   - `fsStorage()` — built-in filesystem driver; the default when no `storage` is configured, preserving existing on-disk behavior
   - `memoryStorage()` — built-in in-memory driver; useful for testing and dry-run scenarios
@@ -1162,43 +1130,43 @@
   **`output.write` is now deprecated.** Setting `write: false` for dry-runs still works and continues to be supported.
 
   ```ts
-  import { defineConfig, defineStorage, fsStorage } from "@kubb/core";
+  import { defineConfig, defineStorage, fsStorage } from '@kubb/core'
 
   // default (no change needed for existing configs)
   export default defineConfig({
-    output: { path: "./src/gen" },
-  });
+    output: { path: './src/gen' },
+  })
 
   // explicit filesystem storage
   export default defineConfig({
-    output: { path: "./src/gen", storage: fsStorage() },
-  });
+    output: { path: './src/gen', storage: fsStorage() },
+  })
 
   // custom in-memory storage
   export const memoryStorage = defineStorage((_options) => {
-    const store = new Map<string, string>();
+    const store = new Map<string, string>()
     return {
-      name: "memory",
+      name: 'memory',
       async hasItem(key) {
-        return store.has(key);
+        return store.has(key)
       },
       async getItem(key) {
-        return store.get(key) ?? null;
+        return store.get(key) ?? null
       },
       async setItem(key, value) {
-        store.set(key, value);
+        store.set(key, value)
       },
       async removeItem(key) {
-        store.delete(key);
+        store.delete(key)
       },
       async getKeys() {
-        return [...store.keys()];
+        return [...store.keys()]
       },
       async clear() {
-        store.clear();
+        store.clear()
       },
-    };
-  });
+    }
+  })
   ```
 
 ### Patch Changes
@@ -1241,7 +1209,6 @@
 - [#2689](https://github.com/kubb-labs/kubb/pull/2689) [`856fa78`](https://github.com/kubb-labs/kubb/commit/856fa78e5cc281ef3cd1b66a38e2deeca69f1b6e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Extract node-native and pure-TypeScript utilities into `@internals/utils`.
 
   The following utilities have been moved from `@kubb/core`, `@kubb/cli`, and `@kubb/plugin-oas` into the private `@internals/utils` package and are now bundled into each consumer at build time:
-
   - **`@kubb/core`** → `@internals/utils`: `clean`, `exists`/`existsSync`, `read`/`readSync`, `write`, `getRelativePath` (fs utilities), `formatHrtime`/`formatMs`/`getElapsedMs`, `spawnAsync`, `executeIfOnline`/`isOnline`, `canUseTTY`/`isCIEnvironment`/`isGitHubActions`, `serializePluginOptions`
   - **`@kubb/cli`** → `@internals/utils`: `randomCliColor`/`randomColors`, `formatMsWithColor`, `toError`/`getErrorMessage`/`toCause`
   - **`@kubb/plugin-oas`** → `@kubb/oas`: `resolveServerUrl` (moved to `@kubb/oas` as it depends on OAS types)
@@ -1432,12 +1399,10 @@
   Generated enums now support configurable key casing through the new `enumKeyCasing` option in `@kubb/plugin-ts`. This allows transforming enum keys into conventional casing formats instead of using raw values.
 
   **New transformers in @kubb/core:**
-
   - `screamingSnakeCase`: Converts to SCREAMING_SNAKE_CASE
   - `snakeCase`: Converts to snake_case
 
   **New option in @kubb/plugin-ts:**
-
   - `enumKeyCasing`: Choose from `'screamingSnakeCase'` | `'snakeCase'` | `'pascalCase'` | `'camelCase'` | `'none'` (default: `'none'`)
 
   **Example:**
@@ -1447,32 +1412,31 @@
   export default {
     plugins: [
       pluginTs({
-        enumKeyCasing: "screamingSnakeCase",
+        enumKeyCasing: 'screamingSnakeCase',
       }),
     ],
-  };
+  }
   ```
 
   Before:
 
   ```typescript
   export const enumStringEnum = {
-    "created at": "created at",
-    "FILE.UPLOADED": "FILE.UPLOADED",
-  } as const;
+    'created at': 'created at',
+    'FILE.UPLOADED': 'FILE.UPLOADED',
+  } as const
   ```
 
   After:
 
   ```typescript
   export const enumStringEnum = {
-    CREATED_AT: "created at",
-    FILE_UPLOADED: "FILE.UPLOADED",
-  } as const;
+    CREATED_AT: 'created at',
+    FILE_UPLOADED: 'FILE.UPLOADED',
+  } as const
   ```
 
   **Additional improvements:**
-
   - Enum member keys now use identifiers without quotes when the key is a valid JavaScript identifier, making the output cleaner and more idiomatic
   - Default value is `'none'` to preserve backward compatibility
 
@@ -1515,13 +1479,13 @@
   ```typescript
   // kubb.config.ts
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
+    input: { path: './petStore.yaml' },
     output: {
-      path: "./src/gen",
-      format: "auto", // Detects biome or prettier
-      lint: "auto", // Detects biome, oxlint, or eslint
+      path: './src/gen',
+      format: 'auto', // Detects biome or prettier
+      lint: 'auto', // Detects biome, oxlint, or eslint
     },
-  });
+  })
   ```
 
 ## 4.12.15

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -40,10 +40,11 @@ export function createMockedAdapter<TOptions extends AdapterFactoryOptions = Ada
     getImports?: Adapter<TOptions>['getImports']
   } = {},
 ): Adapter<TOptions> {
+  const inputNode = options.inputNode ?? null
   return {
     name: (options.name ?? 'oas') as TOptions['name'],
     options: (options.resolvedOptions ?? {}) as TOptions['resolvedOptions'],
-    inputNode: options.inputNode ?? null,
+    inputNode,
     parse: options.parse ?? (async () => ({ kind: 'Input' as const, schemas: [], operations: [] })),
     getImports: options.getImports ?? ((_node: SchemaNode, _resolve: (schemaName: string) => { name: string; path: string }) => []),
   } as Adapter<TOptions>

--- a/packages/kubb/CHANGELOG.md
+++ b/packages/kubb/CHANGELOG.md
@@ -44,7 +44,6 @@
 ### Patch Changes
 
 - [`33b9156`](https://github.com/kubb-labs/kubb/commit/33b91569d9c8f7fe2d7c7d826538249e3eeb18a2) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Refactor middleware-barrel internals and tighten `barrelType` defaulting.
-
   - `buildTree` is now exported from `@internals/utils` and reused by `@kubb/middleware-barrel`.
   - `middleware-barrel` utils are split into focused modules (`resolveBarrelType`, `excludedPaths`, `getBarrelFiles`, `generatePerPluginBarrel`, `generateRootBarrel`), each with its own test file.
   - `output.barrelType` now only defaults to `'named'` when `middlewareBarrel` is part of the resolved `middleware` list. Custom middleware lists without it leave `barrelType` untouched.
@@ -325,7 +324,6 @@
 ### Patch Changes
 
 - [#64](https://github.com/tigawanna/kubb/pull/64) [`84b4ba5`](https://github.com/kubb-labs/kubb/commit/84b4ba543597dd8fc2ca74914143865976741153) Thanks [@pull](https://github.com/apps/pull)! - Improve `defineConfig` usage in v5.
-
   - Fix `defineConfig` typing in the `kubb` package so object configs keep the expected inferred shape.
   - Update `kubb init` to install `kubb`, which matches the generated `import { defineConfig } from 'kubb'` config file.
 
@@ -466,7 +464,6 @@
 - [#2971](https://github.com/kubb-labs/kubb/pull/2971) [`6c49d8d`](https://github.com/kubb-labs/kubb/commit/6c49d8d02d7c4bf5341fb6f0114f6aa2ee735e1e) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - `UserConfig` now correctly marks `adapter` and `parsers` as optional properties.
 
   `defineConfig` automatically applies defaults when these options are omitted:
-
   - `adapter` defaults to `adapterOas()` from `@kubb/adapter-oas`
   - `parsers` defaults to `[parserTs]` from `@kubb/parser-ts`
 
@@ -475,19 +472,19 @@
   ```ts
   // before — had to set adapter and parsers explicitly
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     adapter: adapterOas(),
     parsers: [parserTs],
     plugins: [],
-  });
+  })
 
   // after — adapter and parsers are applied automatically
   export default defineConfig({
-    input: { path: "./petStore.yaml" },
-    output: { path: "./src/gen" },
+    input: { path: './petStore.yaml' },
+    output: { path: './src/gen' },
     plugins: [],
-  });
+  })
   ```
 
   `@kubb/adapter-oas` and `@kubb/parser-ts` must be installed for the defaults to work.

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -324,7 +324,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).

--- a/packages/middleware-barrel/CHANGELOG.md
+++ b/packages/middleware-barrel/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - [`0b1e3aa`](https://github.com/kubb-labs/kubb/commit/0b1e3aa73373eacead128f590432764d02f912f8) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Fix `middleware-barrel` failing on Windows due to mixed path separators.
-
   - `buildTree` now POSIX-normalizes its root path so all child paths use forward slashes.
   - `getBarrelFiles` indexes source files on POSIX-normalized paths, restoring the `'named'` strategy on Windows.
   - `getPluginOutputPrefix` / `isExcludedPath` POSIX-normalize both sides so plugins with `barrelType: false` are correctly excluded from the root barrel.
@@ -35,7 +34,6 @@
 ### Patch Changes
 
 - [`33b9156`](https://github.com/kubb-labs/kubb/commit/33b91569d9c8f7fe2d7c7d826538249e3eeb18a2) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Refactor middleware-barrel internals and tighten `barrelType` defaulting.
-
   - `buildTree` is now exported from `@internals/utils` and reused by `@kubb/middleware-barrel`.
   - `middleware-barrel` utils are split into focused modules (`resolveBarrelType`, `excludedPaths`, `getBarrelFiles`, `generatePerPluginBarrel`, `generateRootBarrel`), each with its own test file.
   - `output.barrelType` now only defaults to `'named'` when `middlewareBarrel` is part of the resolved `middleware` list. Custom middleware lists without it leave `barrelType` untouched.
@@ -139,12 +137,12 @@
   Provides barrel-file generation as a Kubb middleware. Add `middlewareBarrel` to `config.middleware` and set `output.barrelType` (`'all'`, `'named'`, or `'propagate'`) on the root config or individual plugins.
 
   ```ts
-  import { middlewareBarrel } from "@kubb/middleware-barrel";
+  import { middlewareBarrel } from '@kubb/middleware-barrel'
 
   export default defineConfig({
     middleware: [middlewareBarrel],
     plugins: [pluginTs(), pluginZod()],
-  });
+  })
   ```
 
 ### Patch Changes

--- a/packages/parser-ts/CHANGELOG.md
+++ b/packages/parser-ts/CHANGELOG.md
@@ -61,7 +61,6 @@
 ### Patch Changes
 
 - [#3156](https://github.com/kubb-labs/kubb/pull/3156) [`a91e448`](https://github.com/kubb-labs/kubb/commit/a91e448f6f08fc78c956cfe0662ffec75fac14cd) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Internal cleanup: dedupe backend code and drop unused exports.
-
   - `@kubb/parser-ts`: add `src/constants.ts` (regex + path-prefix literals); dedupe `printFunction`/`printArrowFunction` via `formatGenerics` / `formatReturnType`; dedupe the import/export path resolution inside `parserTs.parse` into `resolveOutputPath`.
   - `@kubb/core`: collapse `FileManager#add` and `FileManager#upsert` onto a shared private `#store` helper (`mergeFilesByPath`); drop unused `DEFAULT_CONCURRENCY` / `PATH_SEPARATORS` constants.
   - `@kubb/ast`: drop unused `parameterLocations` and `DEFAULT_STATUS_CODE` constants.

--- a/packages/unplugin-kubb/CHANGELOG.md
+++ b/packages/unplugin-kubb/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Patch Changes
 
 - [`baf9929`](https://github.com/kubb-labs/kubb/commit/baf99296cda9d7ae6d72eb887ed867e9cbbdb57c) Thanks [@stijnvanhulle](https://github.com/stijnvanhulle)! - Mirror `@kubb/kubb`'s `defineConfig` defaults inside `unplugin-kubb`:
-
   - `middleware` defaults to `[middlewareBarrel]` when not provided.
   - `output.barrelType` defaults to `'named'` when `middlewareBarrel` is part of the resolved `middleware` list.
   - Re-exports the `BarrelType` type from `@kubb/middleware-barrel` for convenience.
@@ -364,7 +363,6 @@
   | `plugins:hook:processing:end`   | `kubb:plugins:hook:processing:end`   |
 
 - [#3043](https://github.com/kubb-labs/kubb/pull/3043) [`e877926`](https://github.com/kubb-labs/kubb/commit/e877926222b4e3d56c7ccf07caaf7cdaba71bcd6) Thanks [@copilot-swe-agent](https://github.com/apps/copilot-swe-agent)! - Rename `KubbEvents` to `KubbHooks` and adopt `hooks` as the preferred emitter field.
-
   - `KubbEvents` is now `KubbHooks` in `@kubb/core`.
   - `driver.hooks` is now the primary emitter API.
   - Build/setup options now prefer `hooks` (`events` is kept as a deprecated alias for compatibility).


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).