### PR TITLE
docs: simplify 'propagate' barrel type description

### DIFF
--- a/packages/middleware-barrel/src/types.ts
+++ b/packages/middleware-barrel/src/types.ts
@@ -3,7 +3,7 @@
  *
  * - `'all'` — generates `export * from '...'` for every file
  * - `'named'` — generates `export { name1, name2 } from '...'` using each file's named exports
- * - `'propagate'` — generates intermediate barrel files for every sub-directory so consumers can import from any depth
+ * - `'propagate'` — generates an `index.ts` in every sub-directory, each re-exporting only what's directly inside it
  */
 export type BarrelType = 'all' | 'named' | 'propagate'
 

--- a/packages/middleware-barrel/src/utils/getBarrelFiles.ts
+++ b/packages/middleware-barrel/src/utils/getBarrelFiles.ts
@@ -184,7 +184,7 @@ type GetBarrelFilesParams = {
    * Re-export style used when emitting each barrel.
    * - `'all'` re-exports the whole module (`export * from './x'`)
    * - `'named'` re-exports only the indexable named symbols
-   * - `'propagate'` emits one barrel per directory and chains sub-barrels
+   * - `'propagate'` generates an `index.ts` in every sub-directory, each re-exporting only what's directly inside it
    */
   barrelType: BarrelType
   /**


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Rewrites the `'propagate'` barrel type JSDoc in `types.ts` and `getBarrelFiles.ts` to a single clear sentence

## Changes

- `packages/middleware-barrel/src/types.ts`: updated description
- `packages/middleware-barrel/src/utils/getBarrelFiles.ts`: updated matching inline doc

https://claude.ai/code/session_01FWMs4cfNsUjw3AQS7Sk3Wx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWMs4cfNsUjw3AQS7Sk3Wx)_