### PR TITLE
refactor(middleware-barrel): restructure barrel config with object-based api

### DIFF
--- a/.changeset/refactor-barrel-config-api.md
+++ b/.changeset/refactor-barrel-config-api.md
@@ -1,0 +1,43 @@
+---
+"@kubb/middleware-barrel": major
+---
+
+Refactor middleware-barrel API from string-based `barrelType` to object-based `barrel` configuration.
+
+**Breaking Changes:**
+
+- `barrelType` option replaced with `barrel` object at both config and plugin levels
+- `barrelType: 'propagate'` replaced with `barrel: { type: 'all' | 'named', nested: true }`
+- Root config: `barrel?: { type: 'all' | 'named' } | false`
+- Plugin level: `barrel?: { type: 'all' | 'named', nested?: boolean } | false`
+
+**Migration Guide:**
+
+```ts
+// Before
+export default defineConfig({
+  output: { path: 'src/gen', barrelType: 'named' },
+  plugins: [
+    pluginTs({ output: { path: 'types', barrelType: 'all' } }),
+    pluginZod({ output: { path: 'schemas', barrelType: 'propagate' } }),
+  ],
+  middleware: [middlewareBarrel()],
+})
+
+// After
+export default defineConfig({
+  output: { path: 'src/gen', barrel: { type: 'named' } },
+  plugins: [
+    pluginTs({ output: { path: 'types', barrel: { type: 'all' } } }),
+    pluginZod({ output: { path: 'schemas', barrel: { type: 'all', nested: true } } }),
+  ],
+  middleware: [middlewareBarrel()],
+})
+```
+
+**New Features:**
+
+- Explicit `nested` option for hierarchical barrel generation at plugin level
+- Clearer separation of export strategy (`type`) from structure (`nested`)
+- Better type safety with distinct `BarrelConfig` and `PluginBarrelConfig` types
+- `nested` parameter in `getBarrelFiles` for fine-grained control

--- a/packages/agent/server/plugins/studio.test.ts
+++ b/packages/agent/server/plugins/studio.test.ts
@@ -122,7 +122,7 @@ describe('Studio Plugin - Message Handling', () => {
           path: './dist',
           write: true,
           extension: '.ts',
-          barrelType: 'star',
+          barrel: { type: 'all' },
         },
         plugins: [],
       }
@@ -144,7 +144,7 @@ describe('Studio Plugin - Message Handling', () => {
           path: './dist',
           write: true,
           extension: '.ts',
-          barrelType: 'star',
+          barrel: { type: 'all' },
         },
         plugins: [],
       }

--- a/packages/core/src/Kubb.ts
+++ b/packages/core/src/Kubb.ts
@@ -267,7 +267,7 @@ declare global {
      *   namespace Kubb {
      *     interface ConfigOptionsRegistry {
      *       output: {
-     *         barrelType?: import('./types.ts').BarrelType | false
+     *         barrel?: import('./types.ts').BarrelConfig | false
      *       }
      *     }
      *   }
@@ -288,7 +288,7 @@ declare global {
      *   namespace Kubb {
      *     interface PluginOptionsRegistry {
      *       output: {
-     *         barrelType?: import('./types.ts').BarrelType | false
+     *         barrel?: import('./types.ts').PluginBarrelConfig | false
      *       }
      *     }
      *   }

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -18,7 +18,7 @@ describe('defineConfig', () => {
     output: {
       path: './src/gen',
       clean: true,
-      barrelType: 'named',
+      barrel: { type: 'named' },
     },
     parsers: [],
     adapter: createMockedAdapter(),
@@ -61,7 +61,7 @@ describe('defineConfig', () => {
     expect(resolved.middleware?.[0]?.name).toBe('middleware-barrel')
   })
 
-  test("defaults output.barrelType to 'named' when not set", () => {
+  test("defaults output.barrel to { type: 'named' } when not set", () => {
     const config = defineConfig({
       root: '.',
       input: { path: 'spec.yaml' },
@@ -69,23 +69,23 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrelType).toBe('named')
+    expect(resolved.output.barrel).toEqual({ type: 'named' })
   })
 
-  test('preserves explicit output.barrelType (including false)', () => {
+  test('preserves explicit output.barrel (including false)', () => {
     const named = defineConfig({
       root: '.',
       input: { path: 'spec.yaml' },
-      output: { path: './gen', barrelType: 'all' },
+      output: { path: './gen', barrel: { type: 'all' } },
     } as UserConfig) as UserConfig
     const disabled = defineConfig({
       root: '.',
       input: { path: 'spec.yaml' },
-      output: { path: './gen', barrelType: false },
+      output: { path: './gen', barrel: false },
     } as UserConfig) as UserConfig
 
-    expect(named.output.barrelType).toBe('all')
-    expect(disabled.output.barrelType).toBe(false)
+    expect(named.output.barrel).toEqual({ type: 'all' })
+    expect(disabled.output.barrel).toBe(false)
   })
 
   test('preserves existing middleware when non-empty', () => {
@@ -102,7 +102,7 @@ describe('defineConfig', () => {
     expect(resolved.middleware?.[0]).toBe(customMiddleware)
   })
 
-  test('does not default barrelType when middlewareBarrel is not part of middleware', () => {
+  test('does not default barrel when middlewareBarrel is not part of middleware', () => {
     const customMiddleware = { name: 'custom', hooks: {} }
     const config = defineConfig({
       root: '.',
@@ -112,10 +112,10 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrelType).toBeUndefined()
+    expect(resolved.output.barrel).toBeUndefined()
   })
 
-  test('defaults barrelType when middlewareBarrel is explicitly listed alongside others', () => {
+  test('defaults barrel when middlewareBarrel is explicitly listed alongside others', () => {
     const customMiddleware = { name: 'custom', hooks: {} }
     const config = defineConfig({
       root: '.',
@@ -125,7 +125,7 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrelType).toBe('named')
+    expect(resolved.output.barrel).toEqual({ type: 'named' })
   })
 
   test('preserves existing adapter', () => {

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -15,13 +15,13 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
     : NormalizeConfig<TConfig>
 
 /**
- * Applies default adapter, parsers, middleware, `output.barrelType`, `output.format`, and `output.lint` to a single user config when not set.
+ * Applies default adapter, parsers, middleware, `output.barrel`, `output.format`, and `output.lint` to a single user config when not set.
  *
  * - `adapter` defaults to `adapterOas()`
  * - `parsers` defaults to `[parserTs, parserTsx]`
  * - `middleware` defaults to `[middlewareBarrel()]`
- * - `output.barrelType` defaults to `'named'` **only when `middlewareBarrel` is part of `middleware`**.
- *   When the user provides a custom middleware list without `middlewareBarrel`, `barrelType` is left untouched.
+ * - `output.barrel` defaults to `{ type: 'named' }` **only when `middlewareBarrel` is part of `middleware`**.
+ *   When the user provides a custom middleware list without `middlewareBarrel`, `barrel` is left untouched.
  * - `output.format` defaults to `'auto'`
  * - `output.lint` defaults to `'auto'`
  */
@@ -30,8 +30,8 @@ function applyDefaults<TInput>(config: UserConfig<TInput>): UserConfig<TInput> {
   const hasBarrelMiddleware = middleware.some((m) => m.name === middlewareBarrelName)
 
   const output = { ...config.output }
-  if (hasBarrelMiddleware && output.barrelType === undefined) {
-    output.barrelType = 'named'
+  if (hasBarrelMiddleware && output.barrel === undefined) {
+    output.barrel = { type: 'named' }
   }
   if (output.format === undefined) {
     output.format = false

--- a/packages/middleware-barrel/src/index.ts
+++ b/packages/middleware-barrel/src/index.ts
@@ -1,2 +1,2 @@
 export { middlewareBarrel, middlewareBarrelName } from './middleware.ts'
-export type { BarrelType, RootBarrelType } from './types.ts'
+export type { BarrelType, BarrelConfig, PluginBarrelConfig } from './types.ts'

--- a/packages/middleware-barrel/src/middleware.ts
+++ b/packages/middleware-barrel/src/middleware.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { resolve } from 'node:path'
 import { defineMiddleware } from '@kubb/core'
 import type { Middleware } from '@kubb/core'
-import type { BarrelType, RootBarrelType } from './types.ts'
+import type { BarrelConfig, PluginBarrelConfig } from './types.ts'
 import { getPluginOutputPrefix, isExcludedPath } from './utils/excludedPaths.ts'
 import { getBarrelFiles } from './utils/getBarrelFiles.ts'
 
@@ -11,29 +11,27 @@ declare global {
     interface PluginOptionsRegistry {
       output: {
         /**
-         * Re-export style for this plugin's barrel file.
+         * Barrel configuration for this plugin's output.
          * Set to `false` to disable barrel generation for this plugin entirely; doing so also
          * excludes the plugin's files from the root barrel.
          *
-         * Falls back to `config.output.barrelType` when omitted.
+         * Falls back to `config.output.barrel` when omitted.
          *
-         * @default 'named'
+         * @default { type: 'named' }
          */
-        barrelType?: BarrelType | false
+        barrel?: PluginBarrelConfig | false
       }
     }
     interface ConfigOptionsRegistry {
       output: {
         /**
-         * Re-export style for the root barrel file at `config.output.path/index.ts`.
+         * Barrel configuration for the root barrel file at `config.output.path/index.ts`.
          * Set to `false` to disable root barrel generation. Individual plugins can override
-         * this via their own `output.barrelType`.
+         * this via their own `output.barrel`.
          *
-         * `'propagate'` is not available here — it only applies at the per-plugin level.
-         *
-         * @default 'named'
+         * @default { type: 'named' }
          */
-        barrelType?: RootBarrelType | false
+        barrel?: BarrelConfig | false
       }
     }
   }
@@ -42,8 +40,8 @@ declare global {
 /**
  * Generates `index.ts` barrel files for each plugin and a root barrel at `config.output.path/index.ts`.
  *
- * Each plugin inherits `output.barrelType` from `config.output.barrelType` (defaults to `'named'`).
- * Set `barrelType: false` on a plugin to disable its barrel and exclude it from the root barrel.
+ * Each plugin inherits `output.barrel` from `config.output.barrel` (defaults to `{ type: 'named' }`).
+ * Set `barrel: false` on a plugin to disable its barrel and exclude it from the root barrel.
  *
  * @example
  * ```ts
@@ -51,9 +49,9 @@ declare global {
  * import { middlewareBarrel } from '@kubb/middleware-barrel'
  *
  * export default defineConfig({
- *   output: { path: 'src/gen', barrelType: 'named' },
+ *   output: { path: 'src/gen', barrel: { type: 'named' } },
  *   plugins: [
- *     pluginTs({ output: { path: 'types', barrelType: 'all' } }),
+ *     pluginTs({ output: { path: 'types', barrel: { type: 'all' } } }),
  *     pluginZod({ output: { path: 'schemas' } }),
  *   ],
  *   middleware: [middlewareBarrel()],
@@ -73,12 +71,15 @@ export const middlewareBarrel = defineMiddleware(() => {
     name: middlewareBarrelName,
     hooks: {
       'kubb:plugin:end'({ plugin, config, files, upsertFile }) {
-        const barrelType = plugin.options.output?.barrelType ?? config.output.barrelType ?? 'named'
+        const barrelConfig = plugin.options.output?.barrel ?? config.output.barrel ?? { type: 'named' }
 
-        if (!barrelType) {
+        if (barrelConfig === false) {
           excludedPrefixes.add(getPluginOutputPrefix(plugin, config))
           return
         }
+
+        const barrelType = barrelConfig.type
+        const nested = barrelConfig.nested ?? false
 
         const base = resolve(config.root, config.output.path)
         const target = resolve(base, plugin.options.output.path)
@@ -90,6 +91,7 @@ export const middlewareBarrel = defineMiddleware(() => {
           outputPath: target,
           files,
           barrelType,
+          nested,
           recursive: true,
         })
 
@@ -98,17 +100,19 @@ export const middlewareBarrel = defineMiddleware(() => {
         }
       },
       'kubb:plugins:end'({ files, config, upsertFile }) {
-        const rootBarrelType = config.output.barrelType ?? 'named'
+        const barrelConfig = config.output.barrel ?? { type: 'named' }
 
         const filteredFiles = excludedPrefixes.size === 0 ? files : files.filter((f) => !isExcludedPath(f.path, excludedPrefixes))
         excludedPrefixes.clear()
 
-        if (!rootBarrelType) return
+        if (barrelConfig === false) return
+
+        const barrelType = barrelConfig.type
 
         const rootBarrelFiles = getBarrelFiles({
           outputPath: resolve(config.root, config.output.path),
           files: filteredFiles,
-          barrelType: rootBarrelType,
+          barrelType,
         })
 
         if (rootBarrelFiles.length > 0) {

--- a/packages/middleware-barrel/src/middleware.ts
+++ b/packages/middleware-barrel/src/middleware.ts
@@ -71,7 +71,19 @@ export const middlewareBarrel = defineMiddleware(() => {
     name: middlewareBarrelName,
     hooks: {
       'kubb:plugin:end'({ plugin, config, files, upsertFile }) {
-        const barrelConfig = plugin.options.output?.barrel ?? config.output.barrel ?? { type: 'named' }
+        const pluginBarrel = plugin.options.output?.barrel
+        const configBarrel = config.output.barrel
+        const defaultBarrel = { type: 'named' } as const
+
+        let barrelConfig: PluginBarrelConfig | false
+        if (pluginBarrel !== undefined) {
+          barrelConfig = pluginBarrel
+        } else if (configBarrel !== undefined) {
+          // Root config barrel doesn't have nested, so we add it
+          barrelConfig = configBarrel === false ? false : { ...configBarrel, nested: false }
+        } else {
+          barrelConfig = defaultBarrel
+        }
 
         if (barrelConfig === false) {
           excludedPrefixes.add(getPluginOutputPrefix(plugin, config))

--- a/packages/middleware-barrel/src/types.ts
+++ b/packages/middleware-barrel/src/types.ts
@@ -1,14 +1,54 @@
 /**
- * Barrel re-export style for generated `index.ts` files.
+ * Barrel export strategy.
  *
  * - `'all'` — generates `export * from '...'` for every file
  * - `'named'` — generates `export { name1, name2 } from '...'` using each file's named exports
- * - `'propagate'` — generates an `index.ts` in every sub-directory, each re-exporting only what's directly inside it
  */
-export type BarrelType = 'all' | 'named' | 'propagate'
+export type BarrelType = 'all' | 'named'
 
 /**
- * Barrel re-export style for the root barrel at `config.output.path/index.ts`.
- * `'propagate'` is only available at the per-plugin level.
+ * Barrel configuration at the root config level.
+ *
+ * @example
+ * ```ts
+ * barrel: { type: 'named' }  // default
+ * barrel: { type: 'all' }
+ * barrel: false  // disable barrel generation
+ * ```
  */
-export type RootBarrelType = Exclude<BarrelType, 'propagate'>
+export type BarrelConfig = {
+  /**
+   * Export strategy for the root barrel file.
+   * - `'all'` — wildcard exports: `export * from './file'`
+   * - `'named'` — explicit exports: `export { x, y } from './file'`
+   */
+  type: BarrelType
+}
+
+/**
+ * Barrel configuration at the plugin level.
+ * Supports nested barrel generation in subdirectories.
+ *
+ * @example
+ * ```ts
+ * barrel: { type: 'named' }  // single barrel with named exports
+ * barrel: { type: 'all', nested: true }  // hierarchical barrels with wildcard exports
+ * barrel: { type: 'named', nested: true }  // hierarchical barrels with named exports
+ * barrel: false  // disable barrel generation
+ * ```
+ */
+export type PluginBarrelConfig = {
+  /**
+   * Export strategy for the plugin's barrel files.
+   * - `'all'` — wildcard exports: `export * from './file'`
+   * - `'named'` — explicit exports: `export { x, y } from './file'`
+   */
+  type: BarrelType
+  /**
+   * Generate an `index.ts` in every sub-directory, each re-exporting only what's directly inside it.
+   * Creates a hierarchical barrel structure instead of flat exports from the root.
+   *
+   * @default false
+   */
+  nested?: boolean
+}

--- a/packages/middleware-barrel/src/utils/getBarrelFiles.test.ts
+++ b/packages/middleware-barrel/src/utils/getBarrelFiles.test.ts
@@ -165,7 +165,7 @@ describe('getBarrelFiles', () => {
     })
   })
 
-  describe("strategy: nested (nested: true)", () => {
+  describe('strategy: nested (nested: true)', () => {
     it('generates intermediate barrels for each subdirectory, root exports sub-index files', () => {
       const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
       const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', nested: true })

--- a/packages/middleware-barrel/src/utils/getBarrelFiles.test.ts
+++ b/packages/middleware-barrel/src/utils/getBarrelFiles.test.ts
@@ -165,10 +165,10 @@ describe('getBarrelFiles', () => {
     })
   })
 
-  describe("strategy: 'propagate'", () => {
+  describe("strategy: nested (nested: true)", () => {
     it('generates intermediate barrels for each subdirectory, root exports sub-index files', () => {
       const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
-      const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'propagate' })
+      const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', nested: true })
 
       expect(barrels).toHaveLength(3)
       expect(barrels.find((b) => b.path === `${ROOT}/index.ts`)!.exports.map((e) => e.path)).toEqual(
@@ -178,7 +178,7 @@ describe('getBarrelFiles', () => {
     })
 
     it('returns empty when there are no files', () => {
-      const barrels = getBarrelFiles({ outputPath: ROOT, files: [], barrelType: 'propagate' })
+      const barrels = getBarrelFiles({ outputPath: ROOT, files: [], barrelType: 'all', nested: true })
       expect(barrels).toHaveLength(0)
     })
   })

--- a/packages/middleware-barrel/src/utils/getBarrelFiles.ts
+++ b/packages/middleware-barrel/src/utils/getBarrelFiles.ts
@@ -87,7 +87,7 @@ const namedStrategy: LeafStrategy = ({ dirPath, leafPath, sourceFile }) => {
   return exports
 }
 
-const LEAF_STRATEGIES: ReadonlyMap<Exclude<BarrelType, 'propagate'>, LeafStrategy> = new Map([
+const LEAF_STRATEGIES: ReadonlyMap<BarrelType, LeafStrategy> = new Map([
   ['all', allStrategy],
   ['named', namedStrategy],
 ])
@@ -127,8 +127,9 @@ function walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean
 
 /**
  * Recursive walk that emits one barrel per directory, re-exporting files and sub-barrels.
+ * Used when nested: true.
  */
-function walkPropagate(node: BuildTree, out: Array<FileNode>): void {
+function walkNested(node: BuildTree, out: Array<FileNode>): void {
   const exports: Array<ExportNode> = []
 
   for (const child of node.children) {
@@ -138,7 +139,7 @@ function walkPropagate(node: BuildTree, out: Array<FileNode>): void {
       continue
     }
 
-    walkPropagate(child, out)
+    walkNested(child, out)
     exports.push(createExport({ path: toRelativeModulePath(node.path, `${child.path}${BARREL_SUFFIX}`) }))
   }
 
@@ -181,15 +182,21 @@ type GetBarrelFilesParams = {
    */
   files: ReadonlyArray<FileNode>
   /**
-   * Re-export style used when emitting each barrel.
+   * Export strategy used when emitting each barrel.
    * - `'all'` re-exports the whole module (`export * from './x'`)
    * - `'named'` re-exports only the indexable named symbols
-   * - `'propagate'` generates an `index.ts` in every sub-directory, each re-exporting only what's directly inside it
    */
   barrelType: BarrelType
   /**
-   * Also generate a barrel for each sub-directory of `outputPath`.
-   * No effect for `barrelType: 'propagate'`, which always recurses.
+   * Generate an `index.ts` in every sub-directory, each re-exporting only what's directly inside it (hierarchical).
+   * When false, uses flat generation strategy with optional recursive subdirectory barrels.
+   *
+   * @default false
+   */
+  nested?: boolean
+  /**
+   * Also generate a barrel for each sub-directory when nested is false.
+   * No effect when nested is true (always generates hierarchical structure).
    *
    * @default false
    */
@@ -199,15 +206,16 @@ type GetBarrelFilesParams = {
 /**
  * Generates barrel `FileNode`s for the directory rooted at `outputPath`.
  */
-export function getBarrelFiles({ outputPath, files, barrelType, recursive = false }: GetBarrelFilesParams): Array<FileNode> {
+export function getBarrelFiles({ outputPath, files, barrelType, nested = false, recursive = false }: GetBarrelFilesParams): Array<FileNode> {
   const { sourceFiles, paths } = indexRelevantFiles(files, outputPath)
   if (paths.length === 0) return []
 
   const tree = buildTree(outputPath, paths)
   const result: Array<FileNode> = []
 
-  if (barrelType === 'propagate') {
-    walkPropagate(tree, result)
+  // Use nested walk for hierarchical barrel structure
+  if (nested) {
+    walkNested(tree, result)
     return result
   }
 

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -33,8 +33,8 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     const middleware = options.config.middleware?.length ? options.config.middleware : [middlewareBarrel()]
     const hasBarrelMiddleware = middleware.some((m) => m.name === middlewareBarrelName)
     const output = { ...options.config.output }
-    if (hasBarrelMiddleware && output.barrelType === undefined) {
-      output.barrelType = 'named'
+    if (hasBarrelMiddleware && output.barrel === undefined) {
+      output.barrel = { type: 'named' }
     }
     if (output.format === undefined) {
       output.format = false


### PR DESCRIPTION
## Summary

Restructured the middleware-barrel API from string-based types to object-based configuration with clearer separation of concerns:

- **Config level**: `barrel?: { type: 'all' | 'named' } | false`
- **Plugin level**: `barrel?: { type: 'all' | 'named', nested?: boolean } | false`
- Removed `'propagate'` string type, replaced with `nested: true` option
- Added explicit `nested` parameter to `getBarrelFiles` for hierarchical barrel structures

## Key Changes

### Type Definitions
- Renamed `BarrelType` from `'all' | 'named' | 'propagate'` to `'all' | 'named'`
- Added `BarrelConfig` for root config level (no nested support)
- Added `PluginBarrelConfig` for plugin level (supports optional nested flag)
- Added examples and JSDoc documentation

### Middleware Logic
- Updated barrel config resolution to handle objects instead of strings
- Plugin level always uses `recursive: true` with `getBarrelFiles`
- Nested behavior controlled by `nested` flag separate from `recursive`

### Implementation Details
- `getBarrelFiles` now accepts both `nested` and `recursive` parameters
- `nested: true` → hierarchical barrel structure (via `walkNested`)
- `recursive: true` (without nested) → flat exports with subdirectory barrels (via `walkAllOrNamed`)
- Renamed `walkPropagate` → `walkNested` for clarity

### Tests & Examples
- Updated all tests to use new object-based barrel configuration
- Updated defineConfig examples and defaults
- All tests passing ✓

## Migration Path

Old API → New API:
- `barrelType: 'all'` → `barrel: { type: 'all' }`
- `barrelType: 'named'` → `barrel: { type: 'named' }`
- `barrelType: 'propagate'` → `barrel: { type: 'all', nested: true }` (or `'named'`)
- `barrelType: false` → `barrel: false`

---
_Generated by [Claude Code](https://claude.ai/code/session_01EWSjkj3bEW63HDkw9xYy7A)_