### PR TITLE
fix(ast): check import alias in combineImports tree-shake filter

### DIFF
--- a/.changeset/fix-faker-import-alias-treeshake.md
+++ b/.changeset/fix-faker-import-alias-treeshake.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+Fixed `combineImports` incorrectly tree-shaking aliased named imports.
+
+When an import uses a local alias (e.g. `import { fakerDE as faker } from '@faker-js/faker'`), the used-check now tests the alias (`faker`) rather than the original export name (`fakerDE`). Previously, any aliased import whose propertyName did not appear verbatim in the generated source was silently dropped, leaving files with no import at all.

--- a/packages/ast/src/utils.test.ts
+++ b/packages/ast/src/utils.test.ts
@@ -1753,6 +1753,21 @@ describe('combineImports', () => {
   it('returns empty array for empty input', () => {
     expect(combineImports([], [], '')).toEqual([])
   })
+
+  it('keeps aliased named import when the local alias appears in the source', () => {
+    const imp = createImport({ name: [{ propertyName: 'fakerDE', name: 'faker' }], path: '@faker-js/faker' })
+    const result = combineImports([imp], [], 'const x = faker.string.uuid()')
+
+    expect(result).toHaveLength(1)
+    expect(result[0]!.path).toBe('@faker-js/faker')
+  })
+
+  it('filters out aliased named import when neither alias nor propertyName appears in the source', () => {
+    const imp = createImport({ name: [{ propertyName: 'fakerDE', name: 'faker' }], path: '@faker-js/faker' })
+    const result = combineImports([imp], [], 'const x = 1')
+
+    expect(result).toHaveLength(0)
+  })
 })
 
 describe('findCircularSchemas', () => {

--- a/packages/ast/src/utils.ts
+++ b/packages/ast/src/utils.ts
@@ -669,7 +669,7 @@ export function combineImports(imports: Array<ImportNode>, exports: Array<Export
     let { name } = curr
 
     if (Array.isArray(name)) {
-      name = [...new Set(name)].filter((item) => (typeof item === 'string' ? isUsed(item) : isUsed(item.propertyName)))
+      name = [...new Set(name)].filter((item) => (typeof item === 'string' ? isUsed(item) : isUsed(item.name ?? item.propertyName)))
       if (!name.length) continue
 
       const key = pathTypeKey(path, isTypeOnly)


### PR DESCRIPTION
## Summary

- `combineImports` in `@kubb/ast` tree-shakes named imports by checking if the import name appears in the source text
- For aliased imports like `{ propertyName: 'fakerDE', name: 'faker' }`, the old code checked `propertyName` (`fakerDE`) but generated code only references the alias (`faker`) — causing the import to be incorrectly filtered out
- Fix: check `item.name` (the local alias) when present, falling back to `item.propertyName`

## Test plan

- [ ] Two new unit tests in `packages/ast/src/utils.test.ts` covering the aliased import keep/filter cases
- [ ] All 13 `combineImports` tests pass

https://claude.ai/code/session_01NVnLwvo3eDWeQVVjDt4mZh

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVnLwvo3eDWeQVVjDt4mZh)_