### PR TITLE
feat: add per-package metadata YAML files for adapter, middleware, parser

### DIFF
--- a/packages/adapter-oas/adapter.yaml
+++ b/packages/adapter-oas/adapter.yaml
@@ -1,0 +1,343 @@
+$schema: https://kubb.dev/schemas/adapters/adapter.json
+id: adapter-oas
+name: OpenAPI
+description: Parse and convert OpenAPI 2.0, 3.0, and 3.1 specifications into Kubb's universal AST with full support for discriminators, date types, and server configuration.
+category: openapi
+type: official
+npmPackage: '@kubb/adapter-oas'
+docsPath: /adapters/adapter-oas
+repo: https://github.com/kubb-labs/kubb
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: '>=5.0.0'
+  node: '>=22'
+tags:
+  - openapi
+  - swagger
+  - api-spec
+  - parser
+  - converter
+resources:
+  documentation: https://kubb.dev/adapters/adapter-oas
+  repository: https://github.com/kubb-labs/kubb
+  issues: https://github.com/kubb-labs/kubb/issues
+  changelog: https://github.com/kubb-labs/kubb/blob/main/packages/adapter-oas/CHANGELOG.md
+featured: true
+icon:
+  light: https://kubb.dev/feature/openapi.svg
+intro: |-
+  The OpenAPI adapter parses and converts your OpenAPI specification into Kubb's internal AST (Abstract Syntax Tree), which all downstream plugins consume.
+
+  The adapter is configured once in `defineConfig` and applies globally to all plugins.
+options:
+  - name: validate
+    type: boolean
+    required: false
+    default: 'true'
+    description: Validate the OpenAPI spec before parsing using `@readme/openapi-parser`.
+  - name: contentType
+    type: "'application/json' | string"
+    required: false
+    description: Preferred content-type used when extracting request/response schemas from the spec. Defaults to the first valid JSON media type found in the spec.
+    codeBlock:
+      lang: typescript
+      title: kubb.config.ts
+      twoslash: false
+      code: |-
+        import { adapterOas } from '@kubb/adapter-oas'
+
+        adapterOas({ contentType: 'application/vnd.api+json' })
+  - name: serverIndex
+    type: number
+    required: false
+    description: Index into the `servers` array from your OpenAPI spec for computing `baseURL`.
+    tip: Defining the server here will make it possible to use that endpoint as `baseURL` in other plugins.
+    examples:
+      - name: OpenAPI
+        files:
+          - lang: yaml
+            code: |-
+              openapi: 3.0.3
+              servers:
+                - url: http://petstore.swagger.io/api
+                - url: http://localhost:3000
+      - name: serverIndex 0
+        files:
+          - lang: typescript
+            code: |-
+              import { adapterOas } from '@kubb/adapter-oas'
+
+              adapterOas({ serverIndex: 0 })
+      - name: serverIndex 1
+        files:
+          - lang: typescript
+            code: |-
+              import { adapterOas } from '@kubb/adapter-oas'
+
+              adapterOas({ serverIndex: 1 })
+  - name: serverVariables
+    type: Record<string, string>
+    required: false
+    description: Override values for `{variable}` placeholders in the selected server URL. Only used when `serverIndex` is set. Variables not provided fall back to their `default` value from the spec.
+    examples:
+      - name: OpenAPI
+        files:
+          - lang: yaml
+            code: |-
+              openapi: 3.0.3
+              servers:
+                - url: https://api.{env}.example.com
+                  variables:
+                    env:
+                      default: dev
+                      enum: [dev, staging, prod]
+      - name: kubb.config.ts
+        files:
+          - lang: typescript
+            code: |-
+              import { adapterOas } from '@kubb/adapter-oas'
+
+              adapterOas({
+                serverIndex: 0,
+                serverVariables: { env: 'prod' },
+              })
+              // Results in baseURL: https://api.prod.example.com
+  - name: discriminator
+    type: "'strict' | 'inherit'"
+    required: false
+    default: "'strict'"
+    description: How the discriminator field is interpreted when processing `oneOf`/`anyOf` schemas.
+    details:
+      - title: strict
+        body: Uses `oneOf` schemas as written in the spec. The discriminator is used for type narrowing but child schemas are not modified.
+      - title: inherit
+        body: Propagates the discriminator property with appropriate enum values into each child schema, ensuring type safety and enabling better code generation.
+    examples:
+      - name: OpenAPI
+        files:
+          - lang: yaml
+            code: |-
+              openapi: 3.0.3
+              components:
+                schemas:
+                  Animal:
+                    required: [type]
+                    type: object
+                    oneOf:
+                      - $ref: '#/components/schemas/Cat'
+                      - $ref: '#/components/schemas/Dog'
+                    discriminator:
+                      propertyName: type
+                      mapping:
+                        cat: '#/components/schemas/Cat'
+                        dog: '#/components/schemas/Dog'
+                  Cat:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      indoor:
+                        type: boolean
+                  Dog:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      name:
+                        type: string
+      - name: strict
+        files:
+          - lang: typescript
+            code: |-
+              export type Cat = {
+                type: string
+                indoor?: boolean
+              }
+
+              export type Dog = {
+                type: string
+                name?: string
+              }
+
+              export type Animal = Cat | Dog
+      - name: inherit
+        files:
+          - lang: typescript
+            code: |-
+              export type Cat = {
+                type: 'cat'
+                indoor?: boolean
+              }
+
+              export type Dog = {
+                type: 'dog'
+                name?: string
+              }
+
+              export type Animal = Cat | Dog
+  - name: dateType
+    type: false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
+    required: false
+    default: "'string'"
+    description: "How `format: 'date-time'` schemas are represented in the generated AST and downstream output."
+    details:
+      - title: 'false'
+        body: Falls through to a plain `string` type.
+      - title: "'string'"
+        body: Emits a datetime string node (e.g. `z.string().datetime()`).
+      - title: "'stringOffset'"
+        body: 'Emits a datetime node with timezone offset (`{ offset: true }`).'
+      - title: "'stringLocal'"
+        body: 'Emits a local datetime node (`{ local: true }`).'
+      - title: "'date'"
+        body: Emits a `date` node (JavaScript `Date` object).
+    examples:
+      - name: 'false'
+        files:
+          - lang: typescript
+            code: |-
+              // format: date-time → plain string
+              type CreatedAt = string
+      - name: "'string' (default)"
+        files:
+          - lang: typescript
+            code: |-
+              // format: date-time → datetime string
+              type CreatedAt = string // validated as ISO 8601 datetime
+      - name: "'stringOffset'"
+        files:
+          - lang: typescript
+            code: |-
+              // format: date-time → datetime string with offset
+              type CreatedAt = string // validated as ISO 8601 datetime with offset
+      - name: "'stringLocal'"
+        files:
+          - lang: typescript
+            code: |-
+              // format: date-time → local datetime string
+              type CreatedAt = string // validated as local ISO 8601 datetime
+      - name: "'date'"
+        files:
+          - lang: typescript
+            code: |-
+              // format: date-time → JavaScript Date
+              type CreatedAt = Date
+  - name: integerType
+    type: "'number' | 'bigint'"
+    required: false
+    default: "'bigint'"
+    description: "Whether `type: 'integer'` and `format: 'int64'` produce `number` or `bigint` nodes."
+    examples:
+      - name: "'number' (default)"
+        files:
+          - lang: typescript
+            code: |-
+              type Pet = {
+                id: number
+              }
+      - name: "'bigint'"
+        files:
+          - lang: typescript
+            code: |-
+              type Pet = {
+                id: bigint
+              }
+  - name: unknownType
+    type: "'any' | 'unknown' | 'void'"
+    required: false
+    default: "'any'"
+    description: AST type used when no schema type can be inferred from the OpenAPI spec.
+    examples:
+      - name: "'any' (default)"
+        files:
+          - lang: typescript
+            code: |-
+              type Pet = {
+                extra: any
+              }
+      - name: "'unknown'"
+        files:
+          - lang: typescript
+            code: |-
+              type Pet = {
+                extra: unknown
+              }
+      - name: "'void'"
+        files:
+          - lang: typescript
+            code: |-
+              type Pet = {
+                extra: void
+              }
+  - name: emptySchemaType
+    type: "'any' | 'unknown' | 'void'"
+    required: false
+    default: unknownType | 'any'
+    description: AST type used for completely empty schemas (`{}`).
+    tip: When not set, `emptySchemaType` falls back to the value of `unknownType`. Set it explicitly only when you want a different type for empty schemas than for unresolvable ones.
+    examples:
+      - name: "'any' (default)"
+        files:
+          - lang: typescript
+            code: |-
+              // empty schema {} → any
+              type EmptyModel = any
+      - name: "'unknown'"
+        files:
+          - lang: typescript
+            code: |-
+              // empty schema {} → unknown
+              type EmptyModel = unknown
+  - name: enumSuffix
+    type: string
+    required: false
+    default: "'enum'"
+    description: Suffix appended to derived enum names when building nested property schema names.
+    examples:
+      - name: "'enum' (default)"
+        files:
+          - lang: typescript
+            code: |-
+              // property `status` with inline enum values
+              const statusEnum = { available: 'available', pending: 'pending' } as const
+              type StatusEnum = (typeof statusEnum)[keyof typeof statusEnum]
+      - name: "'type'"
+        files:
+          - lang: typescript
+            code: |-
+              // enumSuffix: 'type'
+              const statusType = { available: 'available', pending: 'pending' } as const
+              type StatusType = (typeof statusType)[keyof typeof statusType]
+examples:
+  - name: kubb.config.ts
+    files:
+      - lang: typescript
+        code: |-
+          import { defineConfig } from 'kubb'
+          import { adapterOas } from '@kubb/adapter-oas'
+          import { pluginTs } from '@kubb/plugin-ts'
+
+          export default defineConfig({
+            input: {
+              path: './petStore.yaml',
+            },
+            output: {
+              path: './src/gen',
+            },
+            adapter: adapterOas({
+              validate: true,
+              serverIndex: 0,
+              serverVariables: { env: 'prod' },
+              discriminator: 'inherit',
+              dateType: 'date',
+              integerType: 'number',
+              unknownType: 'unknown',
+              emptySchemaType: 'unknown',
+              enumSuffix: 'enum',
+            }),
+            plugins: [
+              pluginTs(),
+            ],
+          })

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -21,6 +21,7 @@
   "files": [
     "src",
     "dist",
+    "adapter.yaml",
     "!/**/**.test.**",
     "!/**/__tests__/**",
     "!/**/__snapshots__/**"

--- a/packages/middleware-barrel/middleware.yaml
+++ b/packages/middleware-barrel/middleware.yaml
@@ -1,0 +1,190 @@
+$schema: https://kubb.dev/schemas/middlewares/middleware.json
+id: middleware-barrel
+name: Barrel
+description: Automatically generates barrel files (index.ts exports) for every plugin output directory. Ships with Kubb and is enabled by default.
+category: output
+type: official
+npmPackage: '@kubb/middleware-barrel'
+docsPath: /middlewares/middleware-barrel
+repo: https://github.com/kubb-labs/kubb
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: '>=5.0.0'
+  node: '>=22'
+tags:
+  - barrel
+  - index
+  - exports
+  - output
+resources:
+  documentation: https://kubb.dev/middlewares/middleware-barrel
+  repository: https://github.com/kubb-labs/kubb
+  issues: https://github.com/kubb-labs/kubb/issues
+  changelog: https://github.com/kubb-labs/kubb/blob/main/packages/middleware-barrel/CHANGELOG.md
+featured: true
+intro: |-
+  The barrel middleware automatically generates `index.ts` (and `index.js`) re-export files for every plugin output directory **and** a root barrel at `config.output.path/index.ts` after the build finishes.
+
+  It ships with Kubb and is registered as a default middleware in `defineConfig`, so you get barrel files out of the box with no extra configuration. When `middlewareBarrel` is part of `config.middleware`, `defineConfig` also applies a default `output.barrel` of `{ type: 'named' }`. Custom middleware lists that omit `middlewareBarrel` leave `barrel` untouched.
+
+  Plugins inherit `output.barrel` from `config.output.barrel` when their own value is omitted. Setting `barrel: false` on a plugin disables that plugin's barrel **and** excludes its files from the root barrel.
+options:
+  - name: barrel
+    type: "{ type: 'all' | 'named', nested?: boolean } | false"
+    required: false
+    default: "{ type: 'named' }"
+    description: |-
+      Re-export style for the generated barrel files. Configured via `output.barrel` in `defineConfig` (root level) or per plugin via the plugin's own `output.barrel`. This is not a middleware argument.
+
+      At the config level:
+      - `{ type: 'all' }` — `export * from '...'` for every generated file
+      - `{ type: 'named' }` — `export { name1, name2 } from '...'` using each file's named exports
+      - `false` — disables barrel generation entirely
+
+      At the plugin level, the `nested` flag is also available:
+      - `{ type: 'named', nested: true }` — generates a barrel for every directory, re-exporting only direct children, creating a chain for imports from any depth
+      - `false` — disables barrel generation for that plugin and excludes its files from the root barrel
+
+      The `{ type: 'named' }` default is applied automatically by `defineConfig` only when `middlewareBarrel` is part of `config.middleware`.
+    codeBlock:
+      lang: typescript
+      title: kubb.config.ts
+      twoslash: false
+      code: |-
+        import { defineConfig } from 'kubb'
+        import { middlewareBarrel } from '@kubb/middleware-barrel'
+
+        export default defineConfig({
+          input: { path: './petstore.yaml' },
+          output: { path: './src/gen', barrel: { type: 'named' } },
+          middleware: [middlewareBarrel()],
+        })
+examples:
+  - name: "barrel: { type: 'named' } (default)"
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen' },
+          })
+      - name: "Generated output"
+        lang: typescript
+        twoslash: false
+        code: |-
+          // src/gen/index.ts
+          export { getUser, User } from './api/user'
+          export { getPost, Post } from './api/post'
+          export { User } from './api/types/User'
+          export { useUser } from './hooks/useUser'
+
+          // src/gen/api/index.ts
+          export { getUser, User } from './user'
+          export { getPost, Post } from './post'
+          export { User } from './types/User'
+
+          // src/gen/api/types/index.ts
+          export { User } from './User'
+  - name: "barrel: { type: 'all' }"
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen', barrel: { type: 'all' } },
+          })
+      - name: "Generated output"
+        lang: typescript
+        twoslash: false
+        code: |-
+          // src/gen/index.ts
+          export * from './api/user'
+          export * from './api/post'
+          export * from './api/types/User'
+          export * from './hooks/useUser'
+
+          // src/gen/api/index.ts
+          export * from './user'
+          export * from './post'
+          export * from './types/User'
+
+          // src/gen/api/types/index.ts
+          export * from './User'
+  - name: "barrel: { type: 'named', nested: true }"
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen', barrel: { type: 'named', nested: true } },
+          })
+      - name: "Generated output (chained structure)"
+        lang: typescript
+        twoslash: false
+        code: |-
+          // src/gen/index.ts (only exports directories)
+          export * from './api'
+          export * from './hooks'
+
+          // src/gen/api/index.ts (exports files and subdirs)
+          export * from './user'
+          export * from './post'
+          export * from './types'
+
+          // src/gen/api/types/index.ts (exports files)
+          export * from './User'
+  - name: Disable barrel for a single plugin
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+          import { pluginTs } from '@kubb/plugin-ts'
+          import { pluginZod } from '@kubb/plugin-zod'
+
+          // pluginZod opts out: no zod/index.ts is created
+          // and zod files are excluded from the root index.ts.
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen' },
+            plugins: [
+              pluginTs(),
+              pluginZod({ output: { barrel: false } }),
+            ],
+          })
+  - name: Disable the root barrel only
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+
+          // No root index.ts is generated, but each plugin
+          // still gets its own barrel using its inherited barrel config.
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen', barrel: false },
+          })
+notes:
+  - type: tip
+    body: |-
+      `middleware-barrel` is bundled with Kubb and enabled automatically when no `middleware` option is provided. You only need to install it explicitly when customising the barrel behaviour alongside other middlewares.
+  - type: note
+    body: |-
+      `output.barrel` is only auto-defaulted to `{ type: 'named' }` when `middlewareBarrel` is part of `config.middleware`. If you provide a custom middleware list without it, set `output.barrel` yourself if you still want a barrel.

--- a/packages/middleware-barrel/middleware.yaml
+++ b/packages/middleware-barrel/middleware.yaml
@@ -74,7 +74,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen' },
           })
-      - name: "Generated output"
+      - name: 'Generated output'
         lang: typescript
         twoslash: false
         code: |-
@@ -103,7 +103,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen', barrel: { type: 'all' } },
           })
-      - name: "Generated output"
+      - name: 'Generated output'
         lang: typescript
         twoslash: false
         code: |-
@@ -132,7 +132,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen', barrel: { type: 'named', nested: true } },
           })
-      - name: "Generated output (chained structure)"
+      - name: 'Generated output (chained structure)'
         lang: typescript
         twoslash: false
         code: |-

--- a/packages/middleware-barrel/package.json
+++ b/packages/middleware-barrel/package.json
@@ -21,6 +21,7 @@
   "files": [
     "src",
     "dist",
+    "middleware.yaml",
     "*.d.ts",
     "*.d.cts",
     "!/**/**.test.**",

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -20,6 +20,7 @@
   "files": [
     "src",
     "dist",
+    "parser.yaml",
     "!/**/**.test.**",
     "!/**/__tests__/**",
     "!/**/__snapshots__/**"

--- a/packages/parser-ts/parser.yaml
+++ b/packages/parser-ts/parser.yaml
@@ -1,0 +1,99 @@
+$schema: https://kubb.dev/schemas/parsers/parser.json
+id: parser-ts
+name: TypeScript
+description: TypeScript and TSX file parser for Kubb. Converts the universal AST to `.ts`/`.tsx` source code using the official TypeScript compiler.
+category: typescript
+type: official
+npmPackage: '@kubb/parser-ts'
+docsPath: /parsers/parser-ts
+repo: https://github.com/kubb-labs/kubb
+maintainers:
+  - name: Stijn Van Hulle
+    github: stijnvanhulle
+compatibility:
+  kubb: '>=5.0.0'
+  node: '>=22'
+tags:
+  - typescript
+  - tsx
+  - parser
+  - printer
+  - ast
+resources:
+  documentation: https://kubb.dev/parsers/parser-ts
+  repository: https://github.com/kubb-labs/kubb
+  issues: https://github.com/kubb-labs/kubb/issues
+  changelog: https://github.com/kubb-labs/kubb/blob/main/packages/parser-ts/CHANGELOG.md
+featured: true
+icon:
+  light: https://kubb.dev/feature/typescript.svg
+intro: |-
+  The TypeScript parser is the default file parser used by Kubb when no `parsers` option is set in `defineConfig`. It converts Kubb's universal AST into `.ts` and `.tsx` source code using the official [TypeScript compiler](https://www.typescriptlang.org/).
+
+  Two parser instances are exported:
+
+  - `parserTs` — handles `.ts` and `.js` files
+  - `parserTsx` — handles `.tsx` and `.jsx` files
+
+  Both are configured globally in `defineConfig` and apply to every file produced by every plugin.
+options:
+  - name: extname
+    type: "'.ts' | '.js' | '.tsx' | '.jsx' | string"
+    required: false
+    default: "'.ts'"
+    description: |-
+      File extension used when rewriting relative import paths. Set to `.js` for ESM-friendly emit, `.tsx` for React projects, or leave unset to keep TypeScript's default behaviour.
+
+      Extension rewriting is configured via `output.extension` in `defineConfig`, not as a parser argument.
+    codeBlock:
+      lang: typescript
+      title: kubb.config.ts
+      twoslash: false
+      code: |-
+        import { defineConfig } from 'kubb'
+        import { adapterOas } from '@kubb/adapter-oas'
+        import { parserTs } from '@kubb/parser-ts'
+
+        export default defineConfig({
+          input: { path: './petstore.yaml' },
+          output: { path: './src/gen', extension: { '.ts': '.js' } },
+          adapter: adapterOas(),
+          parsers: [parserTs],
+        })
+examples:
+  - name: TypeScript (default)
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+          import { adapterOas } from '@kubb/adapter-oas'
+          import { parserTs } from '@kubb/parser-ts'
+
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen' },
+            adapter: adapterOas(),
+            parsers: [parserTs],
+          })
+  - name: TSX (React)
+    files:
+      - name: kubb.config.ts
+        lang: typescript
+        twoslash: false
+        code: |-
+          import { defineConfig } from 'kubb'
+          import { adapterOas } from '@kubb/adapter-oas'
+          import { parserTsx } from '@kubb/parser-ts'
+
+          export default defineConfig({
+            input: { path: './petstore.yaml' },
+            output: { path: './src/gen' },
+            adapter: adapterOas(),
+            parsers: [parserTsx],
+          })
+notes:
+  - type: tip
+    body: |-
+      `parser-ts` is bundled with Kubb and used automatically when no `parsers` option is provided. You only need to install it explicitly when combining it with other parsers or providing a fully custom parsers list.


### PR DESCRIPTION
## Summary

- Adds `adapter.yaml` to `packages/adapter-oas/` — full metadata for `@kubb/adapter-oas` with all options, examples, and docs links
- Adds `middleware.yaml` to `packages/middleware-barrel/` — full metadata for `@kubb/middleware-barrel`
- Adds `parser.yaml` to `packages/parser-ts/` — full metadata for `@kubb/parser-ts`
- Updates `files` array in each `package.json` to include the new YAML file so it ships with the npm package

Content is sourced from the existing `kubb-labs/kubb.dev` `modules/` YAML files, which were already fully authored.

## Why

Each package now ships its own type-specific metadata file alongside the code. This enables:

- **Tooling discovery** — AI tools (MCP), registries, and docs generators can read `adapter.yaml` / `middleware.yaml` / `parser.yaml` directly from the installed npm package without fetching from the website
- **Third-party parity** — community adapters, middlewares, and parsers can follow the exact same pattern by placing a `adapter.yaml` (or equivalent) in their package root and referencing the hosted schema for IDE validation
- **Offline/programmatic access** — options, examples, and documentation metadata are available wherever the package is installed

## Test plan

- [ ] `pnpm pack --dry-run` on `@kubb/adapter-oas` shows `adapter.yaml` in the file list
- [ ] `pnpm pack --dry-run` on `@kubb/middleware-barrel` shows `middleware.yaml`
- [ ] `pnpm pack --dry-run` on `@kubb/parser-ts` shows `parser.yaml`
- [ ] Open each YAML in VS Code — `$schema` points to `https://kubb.dev/schemas/...` and IDE validation passes

https://claude.ai/code/session_01JMLGAvEJWhefAJDqQS7c2f

---
_Generated by [Claude Code](https://claude.ai/code/session_01JMLGAvEJWhefAJDqQS7c2f)_