### PR TITLE
feat: add extension.json schema and migrate to extension.yaml

### DIFF
--- a/.changeset/add-per-package-yaml-metadata.md
+++ b/.changeset/add-per-package-yaml-metadata.md
@@ -1,0 +1,13 @@
+---
+"@kubb/adapter-oas": minor
+"@kubb/middleware-barrel": minor
+"@kubb/parser-ts": minor
+---
+
+Each package now ships a type-specific metadata YAML file with its npm release.
+
+- `adapter-oas` → `adapter.yaml`
+- `middleware-barrel` → `middleware.yaml`
+- `parser-ts` → `parser.yaml`
+
+Each file describes the package's options, examples, and resources, and references the matching JSON schema for IDE validation. Third-party adapters, middlewares, and parsers can follow the same pattern using the corresponding `$schema` URL.

--- a/packages/middleware-barrel/middleware.yaml
+++ b/packages/middleware-barrel/middleware.yaml
@@ -74,7 +74,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen' },
           })
-      - name: "Generated output"
+      - name: 'Generated output'
         lang: typescript
         twoslash: false
         code: |-
@@ -103,7 +103,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen', barrel: { type: 'all' } },
           })
-      - name: "Generated output"
+      - name: 'Generated output'
         lang: typescript
         twoslash: false
         code: |-
@@ -132,7 +132,7 @@ examples:
             input: { path: './petstore.yaml' },
             output: { path: './src/gen', barrel: { type: 'named', nested: true } },
           })
-      - name: "Generated output (chained structure)"
+      - name: 'Generated output (chained structure)'
         lang: typescript
         twoslash: false
         code: |-


### PR DESCRIPTION
Implements ADR-0002: "Extension" naming and manifest structure.

## Changes

### `schemas/extension.json` (new)
Unified JSON Schema for all Kubb extension kinds. Validates `extension.yaml` files for plugins, adapters, middlewares, and parsers in one schema. Key fields:
- **`kind`** — `plugin | adapter | middleware | parser` (discriminator)
- **`type`** — `official | community | 3rd-party` (authorship, unchanged)
- `if/then` blocks enforce kind-specific `category` enum values

### Type-specific schemas updated
`schemas/plugins/plugin.json`, `schemas/adapters/adapter.json`, `schemas/middlewares/middleware.json`, `schemas/parsers/parser.json` — each gains a `kind` const field (`"const": "plugin"` etc.) in `required` and `properties`.

### Package YAML files migrated
| Old | New |
|-----|-----|
| `packages/adapter-oas/adapter.yaml` | `packages/adapter-oas/extension.yaml` |
| `packages/middleware-barrel/middleware.yaml` | `packages/middleware-barrel/extension.yaml` |
| `packages/parser-ts/parser.yaml` | `packages/parser-ts/extension.yaml` |

Each file gains `kind: adapter/middleware/parser` and points `$schema` at `https://kubb.dev/schemas/extension.json`.

### `package.json` files arrays
`"adapter.yaml"` / `"middleware.yaml"` / `"parser.yaml"` → `"extension.yaml"` in the three packages.

### ADR-0002
Documents the final decisions: `extension.yaml` (one file per package), `kind` as discriminator, `type` for authorship, one kind per extension.

https://claude.ai/code/session_01JMLGAvEJWhefAJDqQS7c2f