### PR TITLE
feat(core): make adapter and input optional in createKubb

### DIFF
--- a/.changeset/make-adapter-and-input-optional.md
+++ b/.changeset/make-adapter-and-input-optional.md
@@ -1,0 +1,31 @@
+---
+"@kubb/core": minor
+---
+
+Make `adapter` and `input` optional in `Config` and `UserConfig` to support plugin-only mode.
+
+When `adapter` is omitted, Kubb skips the spec parse phase and runs in plugin-only mode:
+- `kubb:plugin:setup` fires normally — `injectFile` works as usual
+- Files injected via `injectFile` are written through storage as usual
+- `kubb:build:start` is **not** emitted (no `inputNode`)
+- `kubb:generate:schema` / `kubb:generate:operation` are never emitted
+
+This enables scripts that use Kubb purely for its file-management layer without needing a dummy OpenAPI spec.
+
+```ts
+// before — a dummy spec was required even for file-injection-only scripts
+export default defineConfig({
+  input: { path: './dummy.yaml' },
+  output: { path: '.' },
+  adapter: adapterOas(),
+  plugins: [myFilePlugin()],
+})
+
+// after — adapter and input can be omitted entirely
+export default defineConfig({
+  output: { path: '.' },
+  plugins: [myFilePlugin()],
+})
+```
+
+When `adapter` is set but `input` is omitted, a clear runtime error is thrown: `[kubb] input is required when using an adapter`.

--- a/packages/cli/src/runners/generate.ts
+++ b/packages/cli/src/runners/generate.ts
@@ -131,7 +131,7 @@ async function generate(options: GenerateProps): Promise<void> {
   const { input, hooks, logLevel } = options
 
   const hrStart = process.hrtime()
-  const inputPath = input ?? ('path' in options.config.input ? options.config.input.path : undefined)
+  const inputPath = input ?? (options.config.input && 'path' in options.config.input ? options.config.input.path : undefined)
 
   const config: Config = {
     ...options.config,

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -100,10 +100,6 @@ async function setup(userConfig: UserConfig, options: SetupOptions = {}): Promis
     }
   }
 
-  if (!userConfig.adapter) {
-    throw new Error('Adapter should be defined')
-  }
-
   const config: Config = {
     ...userConfig,
     root: userConfig.root || process.cwd(),
@@ -156,28 +152,26 @@ async function setup(userConfig: UserConfig, options: SetupOptions = {}): Promis
     }
   }
 
-  const adapter = config.adapter
-  if (!adapter) {
-    throw new Error('No adapter configured. Please provide an adapter in your kubb.config.ts.')
+  if (config.adapter) {
+    const source = inputToAdapterSource(config)
+
+    await hooks.emit('kubb:debug', {
+      date: new Date(),
+      logs: [`Running adapter: ${config.adapter.name}`],
+    })
+
+    driver.adapter = config.adapter
+    driver.inputNode = await config.adapter.parse(source)
+
+    await hooks.emit('kubb:debug', {
+      date: new Date(),
+      logs: [
+        `✓ Adapter '${config.adapter.name}' resolved InputNode`,
+        `  • Schemas: ${driver.inputNode.schemas.length}`,
+        `  • Operations: ${driver.inputNode.operations.length}`,
+      ],
+    })
   }
-  const source = inputToAdapterSource(config)
-
-  await hooks.emit('kubb:debug', {
-    date: new Date(),
-    logs: [`Running adapter: ${adapter.name}`],
-  })
-
-  driver.adapter = adapter
-  driver.inputNode = await adapter.parse(source)
-
-  await hooks.emit('kubb:debug', {
-    date: new Date(),
-    logs: [
-      `✓ Adapter '${adapter.name}' resolved InputNode`,
-      `  • Schemas: ${driver.inputNode.schemas.length}`,
-      `  • Operations: ${driver.inputNode.operations.length}`,
-    ],
-  })
 
   return {
     config,
@@ -494,22 +488,27 @@ async function build(setupResult: SetupResult): Promise<BuildOutput> {
 }
 
 function inputToAdapterSource(config: Config): AdapterSource {
-  if (Array.isArray(config.input)) {
+  const input = config.input
+  if (!input) {
+    throw new Error('[kubb] input is required when using an adapter. Provide input.path or input.data in your config.')
+  }
+
+  if (Array.isArray(input)) {
     return {
       type: 'paths',
-      paths: config.input.map((i) => (new URLPath(i.path).isURL ? i.path : resolve(config.root, i.path))),
+      paths: input.map((i) => (new URLPath(i.path).isURL ? i.path : resolve(config.root, i.path))),
     }
   }
 
-  if ('data' in config.input) {
-    return { type: 'data', data: config.input.data }
+  if ('data' in input) {
+    return { type: 'data', data: input.data }
   }
 
-  if (new URLPath(config.input.path).isURL) {
-    return { type: 'path', path: config.input.path }
+  if (new URLPath(input.path).isURL) {
+    return { type: 'path', path: input.path }
   }
 
-  const resolved = resolve(config.root, config.input.path)
+  const resolved = resolve(config.root, input.path)
   return { type: 'path', path: resolved }
 }
 

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -325,9 +325,9 @@ export function buildDefaultBanner({
       if (first && 'path' in first) {
         source = path.basename(first.path)
       }
-    } else if ('path' in config.input) {
+    } else if (config.input && 'path' in config.input) {
       source = path.basename(config.input.path)
-    } else if ('data' in config.input) {
+    } else if (config.input && 'data' in config.input) {
       source = 'text content'
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,6 +189,10 @@ export type Config<TInput = Input> = {
    * Adapter that parses input files into the universal `InputNode` representation.
    * Use `@kubb/adapter-oas` for OpenAPI/Swagger or `@kubb/adapter-asyncapi` for other formats.
    *
+   * When omitted, Kubb runs in plugin-only mode: `kubb:plugin:setup` fires and files
+   * injected via `injectFile` are written, but no AST walk occurs and generator hooks
+   * (`kubb:generate:schema`, `kubb:generate:operation`) are never emitted.
+   *
    * @example
    * ```ts
    * import { adapterOas } from '@kubb/adapter-oas'
@@ -198,12 +202,13 @@ export type Config<TInput = Input> = {
    * })
    * ```
    */
-  adapter: Adapter
+  adapter?: Adapter
   /**
    * Source file or data to generate code from.
    * Use `input.path` for a file path or `input.data` for inline data.
+   * Required when an adapter is configured; omit when running in plugin-only mode.
    */
-  input: TInput
+  input?: TInput
   output: {
     /**
      * Output directory for generated files, absolute or relative to `root`.
@@ -594,7 +599,7 @@ export type UserConfig<TInput = Input> = Omit<Config<TInput>, 'root' | 'plugins'
    * Each parser handles a specific file type. By default, Kubb uses `parserTs` from `@kubb/parser-ts` for TypeScript files.
    * Pass custom parsers to support additional languages or custom formats.
    *
-   * @default [parserTs]  // from @kubb/parser-ts
+   * @default [parserTs]  // from `@kubb/parser-ts`
    * @example
    * ```ts
    * import { parserTs } from '@kubb/parser-ts'
@@ -609,15 +614,15 @@ export type UserConfig<TInput = Input> = Omit<Config<TInput>, 'root' | 'plugins'
   /**
    * Adapter that parses your API specification (OpenAPI, GraphQL, AsyncAPI, etc.) into Kubb's universal AST.
    *
-   * The adapter bridge between your input format and Kubb's internal representation. By default, uses the OAS adapter.
-   * Pass an alternative adapter (or multiple configs with different adapters) to support different spec formats.
+   * Pass an adapter to support different spec formats. When omitted, Kubb runs in plugin-only mode —
+   * `kubb:plugin:setup` fires and `injectFile` works, but no AST walk occurs and generator hooks
+   * (`kubb:generate:schema`, `kubb:generate:operation`) are never emitted.
    *
-   * @default new OasAdapter()  // from @kubb/adapter-oas
    * @example
    * ```ts
-   * import { Oas } from '@kubb/adapter-oas'
+   * import { adapterOas } from '@kubb/adapter-oas'
    *
-   * adapter: new Oas({ apiVersion: '3.0.0' })
+   * adapter: adapterOas()
    * ```
    *
    * @see {@link Adapter} to implement a custom adapter for GraphQL or other formats.

--- a/packages/core/src/utils/isInputPath.ts
+++ b/packages/core/src/utils/isInputPath.ts
@@ -3,8 +3,8 @@ import type { Config, InputPath, UserConfig } from '../types'
 /**
  * Type guard to check if a given config has an `input.path`.
  */
-export function isInputPath(config: UserConfig | undefined): config is UserConfig<InputPath>
-export function isInputPath(config: Config | undefined): config is Config<InputPath>
-export function isInputPath(config: Config | UserConfig | undefined): config is Config<InputPath> | UserConfig<InputPath> {
+export function isInputPath(config: UserConfig | undefined): config is UserConfig<InputPath> & { input: InputPath }
+export function isInputPath(config: Config | undefined): config is Config<InputPath> & { input: InputPath }
+export function isInputPath(config: Config | UserConfig | undefined): config is (Config<InputPath> | UserConfig<InputPath>) & { input: InputPath } {
   return typeof config?.input === 'object' && config.input !== null && 'path' in config.input
 }

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -246,8 +246,8 @@ describe('defineConfig', () => {
     const typedPathConfig: UserConfig<{ path: string }> = pathConfig
     const typedDataConfig: UserConfig<{ data: { openapi: string } }> = dataConfig
 
-    expect(typedPathConfig.input.path).toBe('spec.yaml')
-    expect(typedDataConfig.input.data).toEqual({ openapi: '3.1.0' })
+    expect(typedPathConfig.input!.path).toBe('spec.yaml')
+    expect(typedDataConfig.input!.data).toEqual({ openapi: '3.1.0' })
   })
 
   test('accepts named configs with hooks', () => {

--- a/packages/mcp/src/tools/generate.ts
+++ b/packages/mcp/src/tools/generate.ts
@@ -116,7 +116,7 @@ export async function generate(schema: z.infer<typeof generateSchema>, handler: 
       }
     }
 
-    const inputPath = input ?? ('path' in userConfig.input ? userConfig.input.path : undefined)
+    const inputPath = input ?? (userConfig.input && 'path' in userConfig.input ? userConfig.input.path : undefined)
 
     // Override config with CLI options
     const config: Config = {


### PR DESCRIPTION
## Summary

- Makes `adapter` and `input` optional in both `Config` and `UserConfig`
- Removes the early `throw new Error('Adapter should be defined')` in `setup()`
- Wraps the adapter parsing block in `if (config.adapter) { … }` so Kubb works without a spec input
- Moves the input null-check into `inputToAdapterSource` with a clear error when an adapter is configured but no input is provided
- Updates JSDoc to document plugin-only mode (no adapter/input)

## Behaviour

| Before | After |
|---|---|
| `adapter` required — throws at startup if omitted | `adapter` optional — plugin-only mode when omitted |
| `input` required when adapter present | `input` still required at runtime when `adapter` is set (throws from `inputToAdapterSource`), optional in types |
| Dummy OAS spec needed for file-injection scripts | Plain `createKubb({ output, plugins })` works |

## Plugin-only mode

When `adapter` is omitted:
- `kubb:plugin:setup` fires normally — `injectFile` works
- Files injected via `injectFile` are written through `fsStorage` as usual
- `kubb:build:start` is **not** emitted (no `inputNode`)
- `kubb:generate:schema` / `kubb:generate:operation` are **never** emitted
- Plugins that declare generators will throw if they run without an adapter (existing `runPluginAstHooks` guard is unchanged)

## Motivation

Enables scripts that use Kubb purely for its file-management layer (e.g. `build-plugin-yaml.ts` in `kubb-labs/plugins`) without needing a dummy OpenAPI spec.

## Test plan

- [ ] Existing tests pass (`pnpm test`)
- [ ] `createKubb({ output: { path: '.' }, plugins: [myFilePlugin()] })` builds without adapter
- [ ] `createKubb({ adapter: adapterOas() })` (no input) throws `[kubb] input is required when using an adapter`
- [ ] Normal OAS builds with adapter + input are unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01KC6q6im2qwSDF8FB3pzxKC)_