### PR TITLE
feat(adapter-oas): hide parseDocument/parseFromConfig/validateDocument, add validate to adapterOas

### DIFF
--- a/.changeset/hide-adapter-oas-internal-methods.md
+++ b/.changeset/hide-adapter-oas-internal-methods.md
@@ -1,0 +1,11 @@
+---
+'@kubb/adapter-oas': major
+'@kubb/core': minor
+'@kubb/cli': patch
+---
+
+**Breaking change for `@kubb/adapter-oas`**: Remove `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API — these are implementation details that should not be exposed. Use `adapter.validate(input, options?)` instead for validation.
+
+**New feature for `@kubb/core`**: Add required `validate` method to the `Adapter<T>` type so all adapters must implement validation support.
+
+**Internal change for `@kubb/cli`**: Update the `kubb validate` command to use `adapterOas().validate()` instead of the removed standalone functions.

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,5 +1,4 @@
 import { ast, createAdapter } from '@kubb/core'
-import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
 import { applyDiscriminatorInheritance } from './discriminator.ts'
 import { parseDocument, parseFromConfig, validateDocument } from './factory.ts'
@@ -73,17 +72,8 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     get inputNode() {
       return inputNode
     },
-    async validate(input: string | AdapterSource | Document, options) {
-      let document: Document
-
-      if (typeof input === 'string') {
-        document = await parseDocument(input)
-      } else if ('type' in input) {
-        document = await parseFromConfig(input)
-      } else {
-        document = input
-      }
-
+    async validate(input, options) {
+      const document = await parseDocument(input)
       await validateDocument(document, options)
     },
     getImports(node, resolve) {
@@ -102,7 +92,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       const document = await parseFromConfig(source)
 
       if (validate) {
-        await this.validate?.(document)
+        await validateDocument(document)
       }
 
       const server = serverIndex !== undefined ? document.servers?.at(serverIndex) : undefined

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,7 +1,7 @@
 import { ast, createAdapter } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
 import { applyDiscriminatorInheritance } from './discriminator.ts'
-import { parseFromConfig, validateDocument } from './factory.ts'
+import { parseDocument, parseFromConfig, validateDocument } from './factory.ts'
 import { parseOas } from './parser.ts'
 import { resolveServerUrl } from './resolvers.ts'
 import type { AdapterOas, Document } from './types.ts'
@@ -71,6 +71,10 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     },
     get inputNode() {
       return inputNode
+    },
+    async validate(input, options) {
+      const document = await parseDocument(input)
+      await validateDocument(document, options)
     },
     getImports(node, resolve) {
       return ast.collectImports({

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,5 @@
 import { ast, createAdapter } from '@kubb/core'
+import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
 import { applyDiscriminatorInheritance } from './discriminator.ts'
 import { parseDocument, parseFromConfig, validateDocument } from './factory.ts'
@@ -72,8 +73,17 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     get inputNode() {
       return inputNode
     },
-    async validate(input, options) {
-      const document = await parseDocument(input)
+    async validate(input: string | AdapterSource | Document, options) {
+      let document: Document
+
+      if (typeof input === 'string') {
+        document = await parseDocument(input)
+      } else if ('type' in input) {
+        document = await parseFromConfig(input)
+      } else {
+        document = input
+      }
+
       await validateDocument(document, options)
     },
     getImports(node, resolve) {
@@ -92,7 +102,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       const document = await parseFromConfig(source)
 
       if (validate) {
-        await validateDocument(document)
+        await this.validate?.(document)
       }
 
       const server = serverIndex !== undefined ? document.servers?.at(serverIndex) : undefined

--- a/packages/adapter-oas/src/index.ts
+++ b/packages/adapter-oas/src/index.ts
@@ -1,6 +1,6 @@
 export { adapterOas, adapterOasName } from './adapter.ts'
-export type { ParseOptions, ValidateDocumentOptions } from './factory.ts'
-export { mergeDocuments, parseDocument, parseFromConfig, validateDocument } from './factory.ts'
+export type { ValidateDocumentOptions } from './factory.ts'
+export { mergeDocuments } from './factory.ts'
 export type {
   AdapterOas,
   AdapterOasOptions,

--- a/packages/cli/src/runners/validate.test.ts
+++ b/packages/cli/src/runners/validate.test.ts
@@ -22,8 +22,7 @@ describe('runValidate', () => {
   })
 
   it('validates input when @kubb/adapter-oas is available', async () => {
-    const parseDocument = vi.fn(async () => ({ openapi: '3.1.0' }))
-    const validateDocument = vi.fn(async () => undefined)
+    const validate = vi.fn(async () => undefined)
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
     const { runValidate } = await import('./validate.ts')
@@ -33,14 +32,12 @@ describe('runValidate', () => {
       {
         loadValidateModule: async () =>
           ({
-            parseDocument,
-            validateDocument,
+            adapterOas: () => ({ validate }),
           }) as unknown as Awaited<ReturnType<(typeof import('./validate.ts'))['loadValidateModule']>>,
       },
     )
 
-    expect(parseDocument).toHaveBeenCalledWith('spec.yaml')
-    expect(validateDocument).toHaveBeenCalledWith({ openapi: '3.1.0' }, { throwOnError: true })
+    expect(validate).toHaveBeenCalledWith('spec.yaml', { throwOnError: true })
     expect(logSpy).toHaveBeenCalledWith('✅ Validation success')
   })
 

--- a/packages/cli/src/runners/validate.ts
+++ b/packages/cli/src/runners/validate.ts
@@ -20,9 +20,9 @@ export function loadValidateModule(): Promise<ValidateModule> {
 export async function runValidate({ input, version }: ValidateOptions, dependencies: ValidateDependencies = { loadValidateModule }): Promise<void> {
   const hrStart = process.hrtime()
   try {
-    const { parseDocument, validateDocument } = await dependencies.loadValidateModule()
-    const document = await parseDocument(input)
-    await validateDocument(document, { throwOnError: true })
+    const { adapterOas } = await dependencies.loadValidateModule()
+    const adapter = adapterOas()
+    await adapter.validate!(input, { throwOnError: true })
 
     await sendTelemetry(
       buildTelemetryEvent({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,9 +132,8 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
   getImports: (node: SchemaNode, resolve: (schemaName: string) => { name: string; path: string }) => Array<ImportNode>
   /**
    * Validate the document at the given path or URL.
-   * Adapters that support validation implement this method; others leave it `undefined`.
    */
-  validate?: (input: string, options?: { throwOnError?: boolean }) => Promise<void>
+  validate: (input: string, options?: { throwOnError?: boolean }) => Promise<void>
 }
 
 export type DevtoolsOptions = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -130,6 +130,11 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
    * return `{ name, path }` for the import, or `undefined` to skip it.
    */
   getImports: (node: SchemaNode, resolve: (schemaName: string) => { name: string; path: string }) => Array<ImportNode>
+  /**
+   * Validate the document at the given path or URL.
+   * Adapters that support validation implement this method; others leave it `undefined`.
+   */
+  validate?: (input: string, options?: { throwOnError?: boolean }) => Promise<void>
 }
 
 export type DevtoolsOptions = {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Removes `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API of `@kubb/adapter-oas` — these are implementation details that should not be exposed
- Adds an optional `validate?` method to the core `Adapter<T>` type so adapters can declare validation support
- Implements `adapter.validate(input, options?)` on the `adapterOas` instance — it parses the file at `input` then validates it, replacing the two-step dance done by the CLI
- Keeps `mergeDocuments` and `ValidateDocumentOptions` exported (still useful publicly)
- Updates the CLI `validate` runner and its test to use `adapterOas().validate()` instead of the now-hidden standalone functions

## Test plan

- [ ] `pnpm --filter @kubb/adapter-oas typecheck` passes
- [ ] `pnpm --filter @kubb/cli typecheck` passes
- [ ] `pnpm --filter @kubb/core typecheck` passes
- [ ] CLI validate test mocks `adapterOas` and asserts `validate` is called with the right args
- [ ] Internal usages (`adapter.ts`, test files, `mocks/oas.ts`) all import from `./factory.ts` directly and are unaffected

https://claude.ai/code/session_01SbAxASzL7PeeYXiJz8qFm4
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbAxASzL7PeeYXiJz8qFm4)_