### PR TITLE
docs(adr): AI-powered SDK generation via createAiRenderer

### DIFF
--- a/docs/architecture/adr/0004_ai_sdk_generation.md
+++ b/docs/architecture/adr/0004_ai_sdk_generation.md
@@ -16,7 +16,7 @@ One approach to this problem is to feed a normalized, dereferenced representatio
 
 Kubb's AST is already that normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved and free of `$ref` indirection. No new data layer is needed.
 
-Kubb already separates language-specific knowledge into parsers. `@kubb/parser-ts` and `@kubb/parser-tsx` know how to serialize TypeScript AST nodes for their respective file extensions, but nothing about the AST structure they receive. Skills files for AI generation belong at the same layer: with the language, not inside a shared execution engine.
+Kubb already separates language-specific knowledge into parsers. `@kubb/parser-ts` exports `parserTs` (`.ts`, `.js`) and `parserTsx` (`.tsx`, `.jsx`), each knowing how to serialize TypeScript AST nodes for its file extensions but nothing about the AST structure it receives. Skills files for AI generation belong at the same layer: with the language, not inside a shared execution engine.
 
 ## Decision
 
@@ -36,7 +36,7 @@ The renderer caches responses by a hash of the prompt. The cache lives under `.k
 
 Putting AI generation in a renderer keeps `defineGenerator` unchanged. The new capability is another renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path. Any existing generator can use it.
 
-A language-agnostic renderer mirrors how parsers work. `@kubb/parser-ts` knows TypeScript serialization but nothing about what AST it receives. The AI renderer knows how to call a provider but nothing about the target language. The skills content travels with the generator, which is where it belongs.
+A language-agnostic renderer mirrors how parsers work. `parserTs` from `@kubb/parser-ts` knows TypeScript serialization but nothing about what AST it receives. The AI renderer knows how to call a provider but nothing about the target language. The skills content travels with the generator, which is where it belongs.
 
 `serializeOperation` is a separate utility so multiple generators can share the same normalized operation view without duplicating logic.
 

--- a/docs/architecture/adr/0004_ai_sdk_generation.md
+++ b/docs/architecture/adr/0004_ai_sdk_generation.md
@@ -1,0 +1,86 @@
+# ADR-0004: AI-powered SDK generation via `createAiRenderer`
+
+| Status   | Authors        | Reviewers      | Issue | Decision date |
+| -------- | -------------- | -------------- | ----- | ------------- |
+| Proposed | @stijnvanhulle | @stijnvanhulle |       | 2026-05-07    |
+
+## Context
+
+Kubb generates SDK code deterministically from OpenAPI specifications through a plugin and renderer pipeline. A plugin walks the normalized AST produced by an adapter, a generator returns elements for each operation or schema node, a renderer converts those elements into `FileNode` objects, and a parser serializes each file to a string on disk. The current set of renderers and plugins covers TypeScript-centric targets well: TypeScript types, Zod schemas, React Query hooks, fetch and Axios clients, MSW handlers, and MCP tool definitions.
+
+This coverage does not extend naturally to other languages. Generating a Python, Go, Ruby, or Java SDK today requires a dedicated, maintained plugin per language, each with its own template system, naming logic, and serialization strategy. Building and keeping those plugins current across a growing API surface is expensive.
+
+WorkOS published a pattern that sidesteps this problem: rather than writing a deterministic template per language, they feed a clean, normalized representation of each API operation to an LLM — specifically Claude — alongside a "skills file" written in natural language that encodes the naming conventions, error handling strategy, serialization patterns, and file structure expected for that language. The LLM's task is narrowly constrained: translate a well-typed data structure into idiomatic code following the supplied conventions. It does not invent API behavior; the spec fixes what the API does.
+
+Kubb's AST already functions as this normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved, dereferenced, and free of OpenAPI-specific indirection. No new intermediate representation layer is needed. What is missing is a renderer that calls an LLM instead of the React reconciler.
+
+There is also a separation-of-concerns question. Kubb already holds language-specific knowledge in parsers: `@kubb/parser-ts` and `@kubb/parser-tsx` know how to serialize TypeScript AST nodes to strings for their respective file extensions. Skills files for AI generation occupy the same layer — language-specific conventions that belong with the language, not embedded in a shared execution engine.
+
+## Decision
+
+A generic `createAiRenderer` function is added to `@kubb/core`. It returns a renderer factory — the same contract as `jsxRenderer` from `@kubb/renderer-jsx` — that accepts an assembled prompt (a system message and a user message) and calls an AI provider to obtain generated file content.
+
+The renderer itself is entirely language-agnostic. It does not know what language it is generating, what conventions apply, or how the operation was serialized. Its only job is to call the provider, parse the response into `FileNode` objects, and expose them through the standard renderer interface.
+
+Language-specific concerns — the skills content and the serialization of an `OperationNode` into a user message — are the responsibility of the generator that uses the renderer. A generator's `operation` hook receives the full `GeneratorContext` including the adapter's `InputNode`. From there it assembles the system message from a skills file and the user message from a serialized view of the operation, then returns the assembled prompt as the element for the renderer to process.
+
+A `serializeOperation` utility is exported from `@kubb/core` to produce a clean, minimal JSON representation of one operation and only the schemas it directly references. This is the standard building block for the user message; generators may augment or replace it as needed.
+
+A concrete `AiProvider` implementation backed by the Anthropic API ships with `@kubb/core` as `createAnthropicProvider`. The Anthropic SDK is declared as an optional peer dependency: it is not installed unless the user explicitly adds it. If the function is called without the SDK present, a clear error is raised pointing to the install command.
+
+To avoid redundant API calls across unchanged operations, the renderer caches responses by a content hash derived from the prompt. The cache is stored under `.kubb/ai-cache/` at the project root and is automatically invalidated whenever the operation schema or skills content changes.
+
+## Rationale
+
+Placing the AI integration in a renderer rather than a new generator factory preserves the existing `defineGenerator` API without modification. Plugin authors continue to use the same primitives they know; the AI capability is an additional renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path. This also means the AI renderer composes naturally with any generator, whether it comes from a first-party plugin or a user-defined one.
+
+Keeping the renderer language-agnostic mirrors the role of the existing parsers. Just as `@kubb/parser-ts` knows TypeScript serialization rules but not the shape of the AST it receives, the AI renderer knows how to call a provider and collect files but not what language or conventions apply. The skills content travels with the generator, which is also where the OpenAPI-to-prompt serialization happens. This is the correct boundary.
+
+Exporting `serializeOperation` as a shared utility rather than embedding serialization inside the renderer lets multiple generators and plugins reuse the same normalized view of an operation without duplicating the logic. It is also independently testable and can be improved without touching the renderer.
+
+The optional peer dependency approach for the Anthropic SDK keeps `@kubb/core` lightweight. Users who generate only TypeScript output today do not download or bundle an SDK they do not need. The dynamic import path inside `createAnthropicProvider` surfaces a helpful error at call time rather than at module load time, which matches the pattern used elsewhere in the kubb ecosystem for optional integrations.
+
+## Consequences
+
+### Positive
+
+- Any target language is achievable without a new dedicated plugin, lowering the bar for community-contributed language support.
+- The `defineGenerator` API is unchanged; existing plugins require no migration.
+- Language-specific skills files are plain markdown, versionable alongside the project, and improvable incrementally without touching framework code.
+- Response caching makes repeated generation runs fast and deterministic for unchanged operations, even when the API key is required.
+- The `AiProvider` interface is vendor-agnostic; alternative providers (OpenAI, Gemini, local models) can be added without changes to the renderer or core.
+- AI generation is fully opt-in and adds no runtime cost for projects that do not use it.
+
+### Negative
+
+- The quality of generated code depends on the quality of the skills file. A poorly written skills file produces inconsistent or incorrect output.
+- AI generation requires network access and a valid API key at code generation time.
+- Generated output may contain subtle bugs that a deterministic template would not produce, and those bugs may not surface until the generated SDK is exercised at runtime.
+- Prompt assembly — constructing the system and user messages — is left to the generator author. There is no enforced structure beyond the prompt type, so two generators targeting the same language may produce different styles of output.
+- Caching is keyed on prompt content. A change to the skills file invalidates all cached entries for that generator, which may result in a full re-generation on the next run.
+
+## Considered options
+
+**Option A: `createAiRenderer` in `@kubb/core` with language-agnostic interface (chosen)**
+
+The renderer handles only provider calls and file collection. Language skills and serialization live in the generator. The `AiProvider` interface is vendor-agnostic. The Anthropic SDK is an optional peer dependency.
+
+**Option B: Language config embedded in `createAiRenderer`**
+
+Skills and language selection would be passed directly to the renderer, giving it knowledge of which language it is generating. Rejected because it merges two distinct concerns — execution and language conventions — into the renderer, violating the same boundary that separates parsers from generators. It would also make the renderer harder to test and reuse across languages.
+
+**Option C: `defineAiGenerator` as a new generator factory**
+
+A new factory function parallel to `defineGenerator` would hardwire AI behavior into the generator signature. Rejected in favor of the renderer approach: the AI capability is better modeled as a renderer strategy than as a generator type, since the generator's job (walking the AST and producing an element) is unchanged. Changing the factory would also require plugin authors to adopt a new API.
+
+**Option D: Raw OpenAPI YAML passed to the LLM**
+
+Passing the raw specification document rather than kubb's normalized AST was considered. Rejected because YAML is verbose, contains unresolved references, and requires the LLM to understand OpenAPI semantics before it can produce any output. The normalized AST removes that burden and produces a smaller, more precise prompt.
+
+**Option E: Batch mode — one LLM call per generation run**
+
+Sending all operations in a single request reduces API call count and overall latency for small APIs. Deferred rather than rejected. Per-operation generation gives finer caching granularity, avoids context-window limits on large specifications, and simplifies error isolation. Batch support can be layered on later using the existing `operations` generator hook, which receives all operation nodes at once.
+
+## Related ADRs
+
+ADR-0003: Kubb Agent architecture and security model.

--- a/docs/architecture/adr/0004_ai_sdk_generation.md
+++ b/docs/architecture/adr/0004_ai_sdk_generation.md
@@ -12,7 +12,7 @@ Today this covers TypeScript targets well: TypeScript types, Zod schemas, React 
 
 Adding a new target language requires a dedicated plugin with its own template system, naming conventions, and serialization logic. That plugin also needs to track API changes over time. Maintaining one plugin per language does not scale.
 
-WorkOS published an approach to this problem: feed a normalized, dereferenced representation of each API operation to an LLM, alongside a "skills file" that describes the naming conventions, error handling, and file structure expected for that language. The LLM translates the operation into idiomatic code. It does not decide what the API does; the spec fixes that.
+One approach to this problem is to feed a normalized, dereferenced representation of each API operation to an LLM, alongside a "skills file" that describes the naming conventions, error handling, and file structure expected for that language. The LLM translates the operation into idiomatic code. It does not decide what the API does; the spec fixes that.
 
 Kubb's AST is already that normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved and free of `$ref` indirection. No new data layer is needed.
 

--- a/docs/architecture/adr/0004_ai_sdk_generation.md
+++ b/docs/architecture/adr/0004_ai_sdk_generation.md
@@ -1,4 +1,4 @@
-# ADR-0004: AI-powered SDK generation via `createAiRenderer`
+# ADR-0004: AI-powered extensions across the generation pipeline
 
 | Status   | Authors        | Reviewers      | Issue | Decision date |
 | -------- | -------------- | -------------- | ----- | ------------- |
@@ -6,48 +6,82 @@
 
 ## Context
 
-Kubb generates SDK code from OpenAPI specifications through a plugin and renderer pipeline. An adapter converts the spec into a normalized AST. A plugin walks that AST, a generator returns elements for each operation or schema node, a renderer converts those elements into `FileNode` objects, and a parser serializes each file to a string on disk.
+Kubb generates SDK code from OpenAPI specifications through a fixed pipeline:
+
+```
+spec → [Adapter] → AST → [Generator] → element → [Renderer] → FileNode[] → [Parser] → string → disk
+```
+
+An adapter converts the spec into a normalized AST. A plugin walks that AST, a generator returns elements for each operation or schema node, a renderer converts those elements into `FileNode` objects, and a parser serializes each file to a string on disk.
 
 Today this covers TypeScript targets well: TypeScript types, Zod schemas, React Query hooks, Axios and fetch clients, MSW handlers, and MCP tool definitions.
 
-Adding a new target language requires a dedicated plugin with its own template system, naming conventions, and serialization logic. That plugin also needs to track API changes over time. Maintaining one plugin per language does not scale.
+Extending this to new targets requires a dedicated plugin per target. A Python SDK plugin needs its own template system and naming conventions. A Valibot plugin needs its own schema-mapping logic. Each plugin also needs to track API and library changes over time. This does not scale across many languages and libraries.
 
-One approach to this problem is to feed a normalized, dereferenced representation of each API operation to an LLM, alongside a "skills file" that describes the naming conventions, error handling, and file structure expected for that language. The LLM translates the operation into idiomatic code. It does not decide what the API does; the spec fixes that.
+One approach is to feed a normalized, dereferenced representation of each API operation to an LLM alongside a "skills file" that describes the naming conventions, error handling, and file structure expected for that target. The LLM translates the operation into idiomatic code. It does not decide what the API does; the spec fixes that.
 
 Kubb's AST is already that normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved and free of `$ref` indirection. No new data layer is needed.
 
-Kubb already separates language-specific knowledge into parsers. `@kubb/parser-ts` exports `parserTs` (`.ts`, `.js`) and `parserTsx` (`.tsx`, `.jsx`), each knowing how to serialize TypeScript AST nodes for its file extensions but nothing about the AST structure it receives. Skills files for AI generation belong at the same layer: with the language, not inside a shared execution engine.
+Each step in the pipeline has a well-defined input and output. AI can implement any of those steps. The right entry point depends on the target:
+
+- **Non-TypeScript targets** (Python, Go, Ruby): the renderer is the right place. AI decides file organization and generates content as a raw string.
+- **TypeScript-output targets** (Valibot, Effect Schema, ArkType): the parser is the right place. The generator decides file organization deterministically; AI fills in the content for each file.
+- **Non-standard spec formats**: the adapter is the right place. AI converts an unfamiliar format into kubb's normalized AST.
 
 ## Decision
 
-`createAiRenderer` is added to `@kubb/core`. It returns a renderer factory that follows the same contract as `jsxRenderer` from `@kubb/renderer-jsx`. The renderer accepts a prompt (a system message and a user message) and calls an AI provider to get back generated file content.
+Three AI-powered factory functions are added to `@kubb/core`, one per pipeline step.
 
-The renderer does not know what language it is generating or what conventions apply. It calls the provider, converts the response into `FileNode` objects, and exposes them through the standard renderer interface.
+### `createAiRenderer`
 
-Language-specific concerns, the skills content and the serialization of an `OperationNode` into a user message, are the generator's responsibility. The generator's `operation` hook receives the full `GeneratorContext`, including the adapter's `InputNode`. It assembles the system message from a skills file and the user message from a serialized view of the operation, then returns the assembled prompt for the renderer to process.
+`createAiRenderer` returns a renderer factory that follows the same contract as `jsxRenderer` from `@kubb/renderer-jsx`. The renderer accepts an `AiPrompt` (a system message and a user message) and calls an AI provider to get back generated file content.
 
-`serializeOperation` is exported from `@kubb/core` as a shared utility. It produces a minimal JSON representation of one operation and only the schemas it directly references. Generators can use it as-is or build on top of it.
+The renderer does not know what language it is generating or what conventions apply. It calls the provider, converts the response into `FileNode` objects where each source value is a complete raw string, and exposes them through the standard renderer interface.
+
+Language-specific concerns, the skills content and the serialization of an `OperationNode` into a user message, are the generator's responsibility. The generator's `operation` hook assembles the system message from a skills file and the user message from a serialized view of the operation, then returns the assembled prompt for the renderer to process.
+
+Use this path for targets where the output is not TypeScript: Python, Go, Ruby, Java, and similar languages.
+
+### `createAiParser`
+
+`createAiParser` returns a `Parser` that registers against specific file extensions, exactly like `parserTs` from `@kubb/parser-ts`. When the pipeline reaches the parse step, it calls Claude with the operation metadata stored in `FileNode.meta` and the skills file for that extension, and returns the generated string.
+
+The generator creates `FileNode` objects with operation context in `file.meta` and leaves the source content empty. `createAiParser` fills that content at parse time. File organization, names, and structure remain under the generator's control.
+
+Use this path for TypeScript-output targets like Valibot, Effect Schema, and ArkType, where `parserTs` handles other `.ts` files and `createAiParser` handles the AI-generated ones. The two parsers coexist because `createAiParser` only activates for `FileNode` objects that carry AI metadata.
+
+### `createAiAdapter`
+
+`createAiAdapter` returns an adapter that accepts a raw spec string and calls Claude with a skills file describing the source format. Claude returns the normalized AST as structured JSON. The rest of the pipeline is unchanged.
+
+Use this path when the input is a format kubb has no native adapter for: RAML, custom API description formats, legacy WSDLs, or proprietary schemas.
+
+### Shared utilities
+
+`serializeOperation` is exported from `@kubb/core` as a utility used by both `createAiRenderer` and `createAiParser`. It produces a minimal JSON representation of one operation and only the schemas it directly references. Generators and parsers can use it as-is or build on top of it.
 
 `createAnthropicProvider` ships with `@kubb/core` as a concrete `AiProvider` implementation. The Anthropic SDK is an optional peer dependency and is not installed unless the user adds it. If `createAnthropicProvider` is called without the SDK present, it throws an error with the install command.
 
-The renderer caches responses by a hash of the prompt. The cache lives under `.kubb/ai-cache/` at the project root and is invalidated whenever the operation schema or skills content changes.
+All three factory functions cache responses by a hash of the prompt under `.kubb/ai-cache/` at the project root. The cache is invalidated whenever the operation schema or skills content changes.
 
 ## Rationale
 
-Putting AI generation in a renderer keeps `defineGenerator` unchanged. The new capability is another renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path. Any existing generator can use it.
+Placing each AI factory at a different pipeline step matches the existing separation of concerns. The adapter converts input formats. The renderer produces files. The parser serializes content. AI can implement any of those steps without changing the steps around it.
 
-A language-agnostic renderer mirrors how parsers work. `parserTs` from `@kubb/parser-ts` knows TypeScript serialization but nothing about what AST it receives. The AI renderer knows how to call a provider but nothing about the target language. The skills content travels with the generator, which is where it belongs.
+`createAiRenderer` keeps `defineGenerator` unchanged. It is another renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path.
 
-`serializeOperation` is a separate utility so multiple generators can share the same normalized operation view without duplicating logic.
+`createAiParser` is the right path for TypeScript-output targets because `parserTs` expects TypeScript AST nodes, not raw strings. An AI-generated Valibot schema is a complete TypeScript string; passing it through `parserTs` would fail. A dedicated `createAiParser` registered for those files sidesteps the conflict cleanly.
 
-The Anthropic SDK is a peer dependency so projects that only generate TypeScript do not install it. The dynamic import inside `createAnthropicProvider` surfaces a clear error at call time, not at module load.
+`createAiAdapter` is the right path for non-standard inputs because it keeps all downstream steps unchanged. Once the adapter produces `InputNode[]`, the pipeline runs identically regardless of how those nodes were produced.
+
+`serializeOperation` is a shared utility so the renderer and parser paths produce consistent LLM inputs from the same source data.
 
 ## Consequences
 
 ### Positive
 
-- Adding a new target language does not require a new plugin.
-- `defineGenerator` is unchanged; existing plugins work without modification.
+- Adding a new target language or schema library does not require a new plugin.
+- `defineGenerator` and `defineParser` are unchanged; existing plugins and parsers work without modification.
 - Skills files are plain markdown and live alongside the project source.
 - The cache skips the LLM for operations that have not changed since the last run.
 - `AiProvider` is vendor-agnostic; other providers can implement it without changes to `@kubb/core`.
@@ -58,28 +92,32 @@ The Anthropic SDK is a peer dependency so projects that only generate TypeScript
 - Code quality depends on the skills file. A vague or incomplete skills file produces inconsistent output.
 - Generation requires a valid API key and network access.
 - Generated code may contain bugs that a deterministic template would not, and those bugs may not appear until the SDK is used.
-- Prompt assembly is the generator author's responsibility. Two generators targeting the same language may produce different styles if they maintain separate skills files.
+- `createAiParser` and `parserTs` both handle `.ts` files. The distinction relies on `FileNode.meta` being populated correctly by the generator; a misconfigured generator produces empty files.
 - Changing a skills file invalidates the entire cache for that generator and triggers a full re-generation on the next run.
 
 ## Considered options
 
-**Option A: `createAiRenderer` in `@kubb/core` with a language-agnostic interface (chosen)**
+**Option A: `createAiRenderer`, `createAiParser`, and `createAiAdapter` as separate factory functions (chosen)**
 
-The renderer handles provider calls and file collection. Language skills and serialization live in the generator. The `AiProvider` interface is vendor-agnostic. The Anthropic SDK is an optional peer dependency.
+Each factory targets one pipeline step and follows the existing interface for that step. The renderer path suits non-TypeScript targets; the parser path suits TypeScript-output libraries; the adapter path suits non-standard input formats. All three share the same `AiProvider` interface and caching strategy.
 
-**Option B: Language config embedded in `createAiRenderer`**
+**Option B: Single `createAiRenderer` for all targets**
 
-Skills and language selection would be passed to the renderer directly. Rejected because the renderer would then hold language-specific knowledge, which is the parser's job. It would also make the renderer harder to test in isolation.
+Using only the renderer for both Python and Valibot generation was considered. Rejected because `parserTs` expects TypeScript AST nodes, not raw strings. AI-generated TypeScript passed through `parserTs` would fail. A separate parser entry point is needed for TypeScript-output targets.
 
-**Option C: `defineAiGenerator` as a new generator factory**
+**Option C: Language config embedded in `createAiRenderer`**
 
-A new factory parallel to `defineGenerator` would hardwire AI behavior into the generator signature. Rejected because the generator's job, walking the AST and returning an element, is unchanged. Adding AI via a renderer avoids changing the generator API and does not require plugin authors to migrate.
+Skills and language selection passed directly to the renderer. Rejected because the renderer would then hold language-specific knowledge, which is the parser's job. It would also make the renderer harder to test in isolation.
 
-**Option D: Raw OpenAPI YAML passed to the LLM**
+**Option D: `defineAiGenerator` as a new generator factory**
+
+A new factory parallel to `defineGenerator` would hardwire AI behavior into the generator signature. Rejected because the generator's job, walking the AST and returning an element, is unchanged. The AI capability belongs in the renderer or parser, not the generator.
+
+**Option E: Raw OpenAPI YAML passed to the LLM**
 
 Passing the raw spec rather than the normalized AST was considered. Rejected because YAML contains unresolved `$ref` chains and requires the LLM to understand OpenAPI before it can produce any output. The normalized AST gives the LLM a smaller, unambiguous input.
 
-**Option E: Batch mode, one LLM call per generation run**
+**Option F: Batch mode, one LLM call per generation run**
 
 Sending all operations in one request reduces API calls and latency. Deferred. Per-operation generation gives finer cache granularity, avoids context-window limits on large specs, and makes error isolation simpler. Batch support can be added later using the existing `operations` generator hook.
 

--- a/docs/architecture/adr/0004_ai_sdk_generation.md
+++ b/docs/architecture/adr/0004_ai_sdk_generation.md
@@ -6,80 +6,82 @@
 
 ## Context
 
-Kubb generates SDK code deterministically from OpenAPI specifications through a plugin and renderer pipeline. A plugin walks the normalized AST produced by an adapter, a generator returns elements for each operation or schema node, a renderer converts those elements into `FileNode` objects, and a parser serializes each file to a string on disk. The current set of renderers and plugins covers TypeScript-centric targets well: TypeScript types, Zod schemas, React Query hooks, fetch and Axios clients, MSW handlers, and MCP tool definitions.
+Kubb generates SDK code from OpenAPI specifications through a plugin and renderer pipeline. An adapter converts the spec into a normalized AST. A plugin walks that AST, a generator returns elements for each operation or schema node, a renderer converts those elements into `FileNode` objects, and a parser serializes each file to a string on disk.
 
-This coverage does not extend naturally to other languages. Generating a Python, Go, Ruby, or Java SDK today requires a dedicated, maintained plugin per language, each with its own template system, naming logic, and serialization strategy. Building and keeping those plugins current across a growing API surface is expensive.
+Today this covers TypeScript targets well: TypeScript types, Zod schemas, React Query hooks, Axios and fetch clients, MSW handlers, and MCP tool definitions.
 
-WorkOS published a pattern that sidesteps this problem: rather than writing a deterministic template per language, they feed a clean, normalized representation of each API operation to an LLM — specifically Claude — alongside a "skills file" written in natural language that encodes the naming conventions, error handling strategy, serialization patterns, and file structure expected for that language. The LLM's task is narrowly constrained: translate a well-typed data structure into idiomatic code following the supplied conventions. It does not invent API behavior; the spec fixes what the API does.
+Adding a new target language requires a dedicated plugin with its own template system, naming conventions, and serialization logic. That plugin also needs to track API changes over time. Maintaining one plugin per language does not scale.
 
-Kubb's AST already functions as this normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved, dereferenced, and free of OpenAPI-specific indirection. No new intermediate representation layer is needed. What is missing is a renderer that calls an LLM instead of the React reconciler.
+WorkOS published an approach to this problem: feed a normalized, dereferenced representation of each API operation to an LLM, alongside a "skills file" that describes the naming conventions, error handling, and file structure expected for that language. The LLM translates the operation into idiomatic code. It does not decide what the API does; the spec fixes that.
 
-There is also a separation-of-concerns question. Kubb already holds language-specific knowledge in parsers: `@kubb/parser-ts` and `@kubb/parser-tsx` know how to serialize TypeScript AST nodes to strings for their respective file extensions. Skills files for AI generation occupy the same layer — language-specific conventions that belong with the language, not embedded in a shared execution engine.
+Kubb's AST is already that normalized representation. The `InputNode`, `OperationNode`, and `SchemaNode` types produced by `@kubb/adapter-oas` are fully resolved and free of `$ref` indirection. No new data layer is needed.
+
+Kubb already separates language-specific knowledge into parsers. `@kubb/parser-ts` and `@kubb/parser-tsx` know how to serialize TypeScript AST nodes for their respective file extensions, but nothing about the AST structure they receive. Skills files for AI generation belong at the same layer: with the language, not inside a shared execution engine.
 
 ## Decision
 
-A generic `createAiRenderer` function is added to `@kubb/core`. It returns a renderer factory — the same contract as `jsxRenderer` from `@kubb/renderer-jsx` — that accepts an assembled prompt (a system message and a user message) and calls an AI provider to obtain generated file content.
+`createAiRenderer` is added to `@kubb/core`. It returns a renderer factory that follows the same contract as `jsxRenderer` from `@kubb/renderer-jsx`. The renderer accepts a prompt (a system message and a user message) and calls an AI provider to get back generated file content.
 
-The renderer itself is entirely language-agnostic. It does not know what language it is generating, what conventions apply, or how the operation was serialized. Its only job is to call the provider, parse the response into `FileNode` objects, and expose them through the standard renderer interface.
+The renderer does not know what language it is generating or what conventions apply. It calls the provider, converts the response into `FileNode` objects, and exposes them through the standard renderer interface.
 
-Language-specific concerns — the skills content and the serialization of an `OperationNode` into a user message — are the responsibility of the generator that uses the renderer. A generator's `operation` hook receives the full `GeneratorContext` including the adapter's `InputNode`. From there it assembles the system message from a skills file and the user message from a serialized view of the operation, then returns the assembled prompt as the element for the renderer to process.
+Language-specific concerns, the skills content and the serialization of an `OperationNode` into a user message, are the generator's responsibility. The generator's `operation` hook receives the full `GeneratorContext`, including the adapter's `InputNode`. It assembles the system message from a skills file and the user message from a serialized view of the operation, then returns the assembled prompt for the renderer to process.
 
-A `serializeOperation` utility is exported from `@kubb/core` to produce a clean, minimal JSON representation of one operation and only the schemas it directly references. This is the standard building block for the user message; generators may augment or replace it as needed.
+`serializeOperation` is exported from `@kubb/core` as a shared utility. It produces a minimal JSON representation of one operation and only the schemas it directly references. Generators can use it as-is or build on top of it.
 
-A concrete `AiProvider` implementation backed by the Anthropic API ships with `@kubb/core` as `createAnthropicProvider`. The Anthropic SDK is declared as an optional peer dependency: it is not installed unless the user explicitly adds it. If the function is called without the SDK present, a clear error is raised pointing to the install command.
+`createAnthropicProvider` ships with `@kubb/core` as a concrete `AiProvider` implementation. The Anthropic SDK is an optional peer dependency and is not installed unless the user adds it. If `createAnthropicProvider` is called without the SDK present, it throws an error with the install command.
 
-To avoid redundant API calls across unchanged operations, the renderer caches responses by a content hash derived from the prompt. The cache is stored under `.kubb/ai-cache/` at the project root and is automatically invalidated whenever the operation schema or skills content changes.
+The renderer caches responses by a hash of the prompt. The cache lives under `.kubb/ai-cache/` at the project root and is invalidated whenever the operation schema or skills content changes.
 
 ## Rationale
 
-Placing the AI integration in a renderer rather than a new generator factory preserves the existing `defineGenerator` API without modification. Plugin authors continue to use the same primitives they know; the AI capability is an additional renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path. This also means the AI renderer composes naturally with any generator, whether it comes from a first-party plugin or a user-defined one.
+Putting AI generation in a renderer keeps `defineGenerator` unchanged. The new capability is another renderer option alongside `jsxRenderer` and the direct `FileNode[]` return path. Any existing generator can use it.
 
-Keeping the renderer language-agnostic mirrors the role of the existing parsers. Just as `@kubb/parser-ts` knows TypeScript serialization rules but not the shape of the AST it receives, the AI renderer knows how to call a provider and collect files but not what language or conventions apply. The skills content travels with the generator, which is also where the OpenAPI-to-prompt serialization happens. This is the correct boundary.
+A language-agnostic renderer mirrors how parsers work. `@kubb/parser-ts` knows TypeScript serialization but nothing about what AST it receives. The AI renderer knows how to call a provider but nothing about the target language. The skills content travels with the generator, which is where it belongs.
 
-Exporting `serializeOperation` as a shared utility rather than embedding serialization inside the renderer lets multiple generators and plugins reuse the same normalized view of an operation without duplicating the logic. It is also independently testable and can be improved without touching the renderer.
+`serializeOperation` is a separate utility so multiple generators can share the same normalized operation view without duplicating logic.
 
-The optional peer dependency approach for the Anthropic SDK keeps `@kubb/core` lightweight. Users who generate only TypeScript output today do not download or bundle an SDK they do not need. The dynamic import path inside `createAnthropicProvider` surfaces a helpful error at call time rather than at module load time, which matches the pattern used elsewhere in the kubb ecosystem for optional integrations.
+The Anthropic SDK is a peer dependency so projects that only generate TypeScript do not install it. The dynamic import inside `createAnthropicProvider` surfaces a clear error at call time, not at module load.
 
 ## Consequences
 
 ### Positive
 
-- Any target language is achievable without a new dedicated plugin, lowering the bar for community-contributed language support.
-- The `defineGenerator` API is unchanged; existing plugins require no migration.
-- Language-specific skills files are plain markdown, versionable alongside the project, and improvable incrementally without touching framework code.
-- Response caching makes repeated generation runs fast and deterministic for unchanged operations, even when the API key is required.
-- The `AiProvider` interface is vendor-agnostic; alternative providers (OpenAI, Gemini, local models) can be added without changes to the renderer or core.
-- AI generation is fully opt-in and adds no runtime cost for projects that do not use it.
+- Adding a new target language does not require a new plugin.
+- `defineGenerator` is unchanged; existing plugins work without modification.
+- Skills files are plain markdown and live alongside the project source.
+- The cache skips the LLM for operations that have not changed since the last run.
+- `AiProvider` is vendor-agnostic; other providers can implement it without changes to `@kubb/core`.
+- Projects that do not use AI generation are not affected.
 
 ### Negative
 
-- The quality of generated code depends on the quality of the skills file. A poorly written skills file produces inconsistent or incorrect output.
-- AI generation requires network access and a valid API key at code generation time.
-- Generated output may contain subtle bugs that a deterministic template would not produce, and those bugs may not surface until the generated SDK is exercised at runtime.
-- Prompt assembly — constructing the system and user messages — is left to the generator author. There is no enforced structure beyond the prompt type, so two generators targeting the same language may produce different styles of output.
-- Caching is keyed on prompt content. A change to the skills file invalidates all cached entries for that generator, which may result in a full re-generation on the next run.
+- Code quality depends on the skills file. A vague or incomplete skills file produces inconsistent output.
+- Generation requires a valid API key and network access.
+- Generated code may contain bugs that a deterministic template would not, and those bugs may not appear until the SDK is used.
+- Prompt assembly is the generator author's responsibility. Two generators targeting the same language may produce different styles if they maintain separate skills files.
+- Changing a skills file invalidates the entire cache for that generator and triggers a full re-generation on the next run.
 
 ## Considered options
 
-**Option A: `createAiRenderer` in `@kubb/core` with language-agnostic interface (chosen)**
+**Option A: `createAiRenderer` in `@kubb/core` with a language-agnostic interface (chosen)**
 
-The renderer handles only provider calls and file collection. Language skills and serialization live in the generator. The `AiProvider` interface is vendor-agnostic. The Anthropic SDK is an optional peer dependency.
+The renderer handles provider calls and file collection. Language skills and serialization live in the generator. The `AiProvider` interface is vendor-agnostic. The Anthropic SDK is an optional peer dependency.
 
 **Option B: Language config embedded in `createAiRenderer`**
 
-Skills and language selection would be passed directly to the renderer, giving it knowledge of which language it is generating. Rejected because it merges two distinct concerns — execution and language conventions — into the renderer, violating the same boundary that separates parsers from generators. It would also make the renderer harder to test and reuse across languages.
+Skills and language selection would be passed to the renderer directly. Rejected because the renderer would then hold language-specific knowledge, which is the parser's job. It would also make the renderer harder to test in isolation.
 
 **Option C: `defineAiGenerator` as a new generator factory**
 
-A new factory function parallel to `defineGenerator` would hardwire AI behavior into the generator signature. Rejected in favor of the renderer approach: the AI capability is better modeled as a renderer strategy than as a generator type, since the generator's job (walking the AST and producing an element) is unchanged. Changing the factory would also require plugin authors to adopt a new API.
+A new factory parallel to `defineGenerator` would hardwire AI behavior into the generator signature. Rejected because the generator's job, walking the AST and returning an element, is unchanged. Adding AI via a renderer avoids changing the generator API and does not require plugin authors to migrate.
 
 **Option D: Raw OpenAPI YAML passed to the LLM**
 
-Passing the raw specification document rather than kubb's normalized AST was considered. Rejected because YAML is verbose, contains unresolved references, and requires the LLM to understand OpenAPI semantics before it can produce any output. The normalized AST removes that burden and produces a smaller, more precise prompt.
+Passing the raw spec rather than the normalized AST was considered. Rejected because YAML contains unresolved `$ref` chains and requires the LLM to understand OpenAPI before it can produce any output. The normalized AST gives the LLM a smaller, unambiguous input.
 
-**Option E: Batch mode — one LLM call per generation run**
+**Option E: Batch mode, one LLM call per generation run**
 
-Sending all operations in a single request reduces API call count and overall latency for small APIs. Deferred rather than rejected. Per-operation generation gives finer caching granularity, avoids context-window limits on large specifications, and simplifies error isolation. Batch support can be layered on later using the existing `operations` generator hook, which receives all operation nodes at once.
+Sending all operations in one request reduces API calls and latency. Deferred. Per-operation generation gives finer cache granularity, avoids context-window limits on large specs, and makes error isolation simpler. Batch support can be added later using the existing `operations` generator hook.
 
 ## Related ADRs
 


### PR DESCRIPTION
## Summary

- Adds ADR-0004 documenting the architecture decision for AI-powered multi-language SDK generation
- Proposes a generic `createAiRenderer` factory in `@kubb/core` that slots into the existing renderer pipeline alongside `jsxRenderer`
- The renderer is language-agnostic; language-specific skills and IR serialization live in the generator layer, consistent with how parsers hold language-specific knowledge today

## What this ADR covers

- Why `createAiRenderer` (not `defineAiGenerator` or language config in the renderer)
- How language-specific skills stay separate from the renderer, mirroring the parser-per-language pattern
- `serializeOperation` as a shared IR-to-prompt utility
- `createAnthropicProvider` as an optional-peer-dep concrete provider
- Response caching by prompt hash
- Five considered alternatives and why each was rejected or deferred

## Test plan

- [ ] Review ADR for accuracy against kubb's existing architecture
- [ ] Confirm naming conventions align with `createX` / `defineX` patterns used elsewhere in the codebase
- [ ] Implementation of `createAiRenderer`, `createAnthropicProvider`, and `serializeOperation` follows in subsequent commits

https://claude.ai/code/session_01K51vZQxhYXZpzAPyVAw8yr