### PR TITLE
feat(mcp): migrate to tmcp + add validate/init tools + HTTP hosting

### DIFF
--- a/docs/architecture/adr/0005_mcp_migrate_to_tmcp.md
+++ b/docs/architecture/adr/0005_mcp_migrate_to_tmcp.md
@@ -1,0 +1,229 @@
+# Plan 1: Migrate @kubb/mcp to tmcp
+
+## Why
+
+`@modelcontextprotocol/sdk` is complex and not typesafe — tools must receive `.shape` from Zod objects and callbacks are untyped. `tmcp` (v1.19.3, MIT core) gives full TypeScript inference from Zod schemas and a cleaner, modular API.
+
+> **License note**: The `@tmcp/*` sub-packages currently show "Proprietary" in npm metadata. Worth confirming with the author before shipping to production. Could be a metadata oversight.
+
+---
+
+## Verified API (from installed types)
+
+```typescript
+import { McpServer } from 'tmcp'
+import { ZodJsonSchemaAdapter } from '@tmcp/adapter-zod'
+import { StdioTransport } from '@tmcp/transport-stdio'
+import { HttpTransport } from '@tmcp/transport-http'
+import { defineTool } from 'tmcp/tool'
+import { tool } from 'tmcp/utils'
+
+const server = new McpServer(
+  { name: 'Kubb', version: '...' },
+  { adapter: new ZodJsonSchemaAdapter() }
+)
+
+const myTool = defineTool(
+  { name: 'generate', description: '...', schema: z.object({ config: z.string().optional() }) },
+  async (input) => tool.text('result')   // or tool.error('message') for errors
+)
+
+server.tools([myTool])
+
+// Stdio
+new StdioTransport(server).listen()
+
+// HTTP — respond() takes a Fetch API Request, returns Fetch API Response | null
+const http = new HttpTransport(server)
+const response = await http.respond(request)
+```
+
+---
+
+## Tools to add (matching CLI commands)
+
+| MCP Tool   | CLI equivalent    | Params                                           |
+|------------|-------------------|--------------------------------------------------|
+| `generate` | `kubb generate`   | `config?`, `input?`, `output?`, `logLevel?`      |
+| `validate` | `kubb validate`   | `input` (required — path or URL)                 |
+| `init`     | `kubb init`       | `input?`, `output?`, `plugins?`                  |
+
+---
+
+## Files to change in `packages/mcp`
+
+### `package.json`
+- Remove: `@modelcontextprotocol/sdk`
+- Add: `tmcp`, `@tmcp/adapter-zod`, `@tmcp/transport-stdio`, `@tmcp/transport-http`
+- Add optional peer: `@kubb/adapter-oas` (needed by `validate` tool — throws descriptive error if missing)
+- Bump `size-limit` from 510 KiB → 600 KiB (four packages instead of one)
+
+### `src/schemas/generateSchema.ts` — no change
+Already a plain Zod object, compatible with `ZodJsonSchemaAdapter`.
+
+### `src/schemas/validateSchema.ts` — new
+```typescript
+export const validateSchema = z.object({
+  input: z.string().describe('Path or URL to the OpenAPI/Swagger specification'),
+})
+```
+
+### `src/schemas/initSchema.ts` — new
+```typescript
+export const initSchema = z.object({
+  input: z.string().optional().describe('Path to OpenAPI spec (default: ./openapi.yaml)'),
+  output: z.string().optional().describe('Output directory (default: ./src/gen)'),
+  plugins: z.string().optional().describe('Comma-separated: plugin-ts,plugin-zod,...'),
+})
+```
+
+### `src/tools/generate.ts` — refactor
+- Remove `CallToolResult` import from `@modelcontextprotocol/sdk`
+- Remove `NotificationHandler` interface and param — progress messages are buffered into `messages[]` (already happens today) and included in the final text result
+- Change return: `return { content: [...], isError }` → `tool.text(...)` / `tool.error(...)`
+- All existing build logic (hooks, `loadUserConfig`, `resolveUserConfig`, `createKubb`, `safeBuild`) stays untouched
+- Export a `generateTool` constant via `defineTool`
+
+### `src/tools/validate.ts` — new
+```typescript
+export const validateTool = defineTool(
+  { name: 'validate', description: '...', schema: validateSchema },
+  async ({ input }) => {
+    let mod: typeof import('@kubb/adapter-oas')
+    try { mod = await import('@kubb/adapter-oas') }
+    catch {
+      return tool.error(
+        'The validate tool requires @kubb/adapter-oas.\n' +
+        'Install: npm install @kubb/adapter-oas'
+      )
+    }
+    try {
+      await mod.adapterOas().validate!(input, { throwOnError: true })
+      return tool.text(`Validation successful: ${input}`)
+    } catch (err) {
+      return tool.error(`Validation failed:\n${err instanceof Error ? err.message : err}`)
+    }
+  }
+)
+```
+
+### `src/tools/init.ts` — new (non-interactive)
+Duplicate `generateConfigFile()` + `availablePlugins` from `packages/cli/src/runners/init.ts` (pure data, no clack). Write `kubb.config.ts` to disk. Do **not** install packages — return the list of packages to install as part of the output text.
+
+```typescript
+export const initTool = defineTool(
+  { name: 'init', description: '...', schema: initSchema },
+  async ({ input = './openapi.yaml', output = './src/gen', plugins }) => {
+    const selected = resolvePlugins(plugins)
+    const content = generateConfigFile(selected, input, output)
+    const dest = path.join(process.cwd(), 'kubb.config.ts')
+    fs.writeFileSync(dest, content, 'utf-8')
+    return tool.text(
+      `Created kubb.config.ts\n\nInstall packages:\n  npm install kubb ${selected.map(p => p.packageName).join(' ')}\n\nThen: npx kubb generate`
+    )
+  }
+)
+```
+
+### `src/tools/index.ts` — new barrel
+```typescript
+export { generateTool } from './generate.ts'
+export { validateTool } from './validate.ts'
+export { initTool } from './init.ts'
+```
+
+### `src/server.ts` — rewrite
+```typescript
+export type ServerOptions = { port?: number; host?: string }
+
+export function createMcpServer(options?: { agentId?: string }): McpServer {
+  const server = new McpServer(
+    { name: 'Kubb', version },
+    { adapter: new ZodJsonSchemaAdapter() }
+  )
+  server.tools([generateTool, validateTool, initTool])
+  return server
+}
+
+export async function startServer({ port, host = 'localhost' }: ServerOptions = {}) {
+  const server = createMcpServer()
+  if (port !== undefined) {
+    const transport = new HttpTransport(server)
+    // Node.js HTTP bridge: IncomingMessage → Fetch Request → Fetch Response → ServerResponse
+    const httpServer = http.createServer(async (req, res) => {
+      const chunks: Buffer[] = []
+      for await (const chunk of req) chunks.push(chunk)
+      const fetchReq = new Request(
+        `http://${req.headers.host ?? `${host}:${port}`}${req.url}`,
+        { method: req.method, headers: req.headers as HeadersInit, body: chunks.length ? Buffer.concat(chunks) : undefined }
+      )
+      const fetchRes = await transport.respond(fetchReq)
+      if (!fetchRes) { res.writeHead(404); res.end('Not Found'); return }
+      res.writeHead(fetchRes.status, Object.fromEntries(fetchRes.headers))
+      if (fetchRes.body) {
+        const reader = fetchRes.body.getReader()
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          res.write(value)
+        }
+      }
+      res.end()
+    })
+    httpServer.listen(port, host, () =>
+      console.log(`Kubb MCP server on http://${host}:${port}`)
+    )
+  } else {
+    new StdioTransport(server).listen()
+  }
+}
+```
+
+Note: Streaming the body chunk-by-chunk is important for SSE (GET /mcp keeps a long-lived connection open).
+
+### `src/index.ts` — update
+Export `createMcpServer` and `ServerOptions` for platform integration. Accept `options` in `run()`.
+
+```typescript
+export { createMcpServer } from './server.ts'
+export type { ServerOptions } from './server.ts'
+
+export async function run(_argv?: string[], options?: ServerOptions): Promise<void> {
+  await startServer(options)
+}
+```
+
+---
+
+## Files to change in `packages/cli`
+
+### `src/commands/mcp.ts`
+Add `--port` (`-p`) and `--host` options:
+```typescript
+port: { type: 'string', short: 'p', description: 'Port for HTTP MCP server (omit for stdio)', hint: 'number' },
+host: { type: 'string', description: 'Hostname to bind to', default: 'localhost' },
+```
+
+### `src/runners/mcp.ts`
+Pass port/host through to `run()`:
+```typescript
+await mod.run(undefined, {
+  port: options.port !== undefined ? Number(options.port) : undefined,
+  host: options.host,
+})
+```
+
+---
+
+## Changeset
+- `@kubb/mcp`: minor (new tools, new dependency, new export `createMcpServer`)
+- `@kubb/cli`: patch (new flags on `mcp` command)
+
+---
+
+## Verification
+1. `pnpm --filter @kubb/mcp build` — dist artifacts produced
+2. `pnpm --filter @kubb/mcp typecheck`
+3. Stdio: `node packages/mcp/bin/kubb-mcp.cjs` + `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}` via stdin → 3 tools listed
+4. HTTP: `node packages/mcp/bin/kubb-mcp.cjs --port 3001` + `curl -X POST http://localhost:3001/mcp ...`
+5. MCP Inspector: `npx @modelcontextprotocol/inspector node ./packages/mcp/bin/kubb-mcp.cjs`

--- a/docs/architecture/adr/0006_mcp_on_kubb_studio.md
+++ b/docs/architecture/adr/0006_mcp_on_kubb_studio.md
@@ -1,0 +1,155 @@
+# Plan 2: Host MCP on kubb.studio
+
+## Context
+
+`kubb-labs/platform` is a **Nuxt + Nitro** app running at `kubb.studio`. It already communicates with `@kubb/agent` instances over **WebSocket**, where each session has a UUID. The MCP endpoint should be scoped per agent session at:
+
+```
+mcp.kubb.studio/agent/{uuid}/mcp
+```
+
+This mirrors the existing WebSocket session model (`kubb.studio/agent/{uuid}`) and keeps one uniform call convention — both the agent API and MCP tools accept the same kubb config structure.
+
+---
+
+## Prerequisites
+
+Plan 1 (tmcp migration) must be complete first because it exports `createMcpServer()` from `@kubb/mcp`.
+
+---
+
+## Architecture
+
+```
+AI assistant (Claude, Cursor, etc.)
+    │
+    │  JSON-RPC over SSE
+    ▼
+mcp.kubb.studio/agent/{uuid}/mcp    ← Nitro route in kubb-labs/platform
+    │
+    │  createMcpServer({ agentId: uuid })
+    ▼
+@kubb/mcp  (generate / validate / init tools)
+    │
+    │  WebSocket  (same connection the platform already manages)
+    ▼
+@kubb/agent  (running agent instance for this session)
+```
+
+---
+
+## Changes in `kubb-labs/platform`
+
+### 1. Install dependencies
+
+```json
+// package.json
+"@kubb/mcp": "latest",
+"@tmcp/transport-http": "^0.8.5"
+```
+
+### 2. Add Nitro route `server/routes/agent/[uuid]/mcp.ts`
+
+H3 (Nitro's router) exposes `toWebRequest(event)` which produces a standard Fetch `Request` and supports returning a Fetch `Response` directly — exactly what `HttpTransport.respond()` needs.
+
+```typescript
+// server/routes/agent/[uuid]/mcp.ts
+import { createMcpServer } from '@kubb/mcp'
+import { HttpTransport } from '@tmcp/transport-http'
+
+// One transport per agent UUID — keyed map, entries cleaned up when session ends
+const transports = new Map<string, HttpTransport>()
+
+function getTransport(uuid: string): HttpTransport {
+  if (!transports.has(uuid)) {
+    const server = createMcpServer({ agentId: uuid })
+    transports.set(uuid, new HttpTransport(server))
+  }
+  return transports.get(uuid)!
+}
+
+// Handles all methods: GET (SSE stream), POST (tool calls), DELETE (session cleanup)
+export default defineEventHandler(async (event) => {
+  const uuid = getRouterParam(event, 'uuid')!
+  const transport = getTransport(uuid)
+  const request = toWebRequest(event)
+  const response = await transport.respond(request)
+  return response ?? new Response('Not Found', { status: 404 })
+})
+```
+
+### 3. Session cleanup
+
+When the agent WebSocket session ends (existing platform lifecycle event), remove the transport entry:
+
+```typescript
+// wherever the platform tears down an agent session:
+transports.delete(uuid)
+```
+
+This prevents memory leaks from accumulating transport instances.
+
+### 4. DNS / reverse proxy
+
+Add a `mcp.kubb.studio` subdomain (or reuse the same domain with path routing) pointing to the Nitro server. The Nitro `routeRules` can handle CORS:
+
+```typescript
+// nitro.config.ts (or nuxt.config.ts routeRules)
+'/agent/*/mcp': {
+  cors: true,
+  headers: {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, mcp-session-id',
+  },
+}
+```
+
+---
+
+## How AI clients connect
+
+**Claude Desktop / Cursor (HTTP transport):**
+```json
+{
+  "mcpServers": {
+    "kubb": {
+      "url": "https://mcp.kubb.studio/agent/YOUR-UUID/mcp"
+    }
+  }
+}
+```
+
+**Local stdio (unchanged):**
+```json
+{
+  "mcpServers": {
+    "kubb": {
+      "command": "npx",
+      "args": ["kubb", "mcp"]
+    }
+  }
+}
+```
+
+---
+
+## Uniform calling convention
+
+Both the WebSocket agent API and the MCP tools share the same kubb config format. The MCP `generate` tool accepts `config` (path to `kubb.config.ts`), the same field the agent already understands. No parallel config formats.
+
+| Interface           | URL                                       | Protocol              |
+|---------------------|-------------------------------------------|-----------------------|
+| MCP per session     | `mcp.kubb.studio/agent/{uuid}/mcp`        | JSON-RPC over SSE     |
+| Agent (WebSocket)   | `kubb.studio/agent/{uuid}`                | WebSocket             |
+| Local stdio MCP     | `kubb mcp`                                | stdio                 |
+| Local HTTP MCP      | `kubb mcp --port 3001`                    | JSON-RPC over SSE     |
+
+---
+
+## Open questions before implementation
+
+1. **Does the platform have a `toWebRequest` import available?** It's a built-in H3 utility, should be available from `h3` or `nitropack/runtime`.
+2. **Where is the agent session lifecycle managed?** Need the exact hook/event to clean up the transport map on session end.
+3. **Subdomain vs path routing?** `mcp.kubb.studio` requires DNS config; `/mcp/agent/{uuid}` is simpler but changes the URL.
+4. **Auth?** Should the `/mcp` endpoint require the same token as the agent WebSocket, or be open? `@tmcp/transport-http` has optional OAuth support via `@tmcp/auth`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -63,8 +63,11 @@
   },
   "dependencies": {
     "@kubb/core": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@tmcp/adapter-zod": "^0.1.7",
+    "@tmcp/transport-http": "^0.8.5",
+    "@tmcp/transport-stdio": "^0.4.2",
     "jiti": "^2.7.0",
+    "tmcp": "^1.19.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {
@@ -72,12 +75,18 @@
     "@kubb/renderer-jsx": "workspace:*"
   },
   "peerDependencies": {
+    "@kubb/adapter-oas": "workspace:*",
     "@kubb/renderer-jsx": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@kubb/adapter-oas": {
+      "optional": true
+    }
   },
   "size-limit": [
     {
       "path": "./dist/*.js",
-      "limit": "510 KiB",
+      "limit": "600 KiB",
       "gzip": true
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,15 +304,27 @@ importers:
 
   packages/mcp:
     dependencies:
+      '@kubb/adapter-oas':
+        specifier: workspace:*
+        version: link:../adapter-oas
       '@kubb/core':
         specifier: workspace:*
         version: link:../core
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+      '@tmcp/adapter-zod':
+        specifier: ^0.1.7
+        version: 0.1.7(tmcp@1.19.3(typescript@6.0.3))(zod@4.4.3)
+      '@tmcp/transport-http':
+        specifier: ^0.8.5
+        version: 0.8.5(tmcp@1.19.3(typescript@6.0.3))
+      '@tmcp/transport-stdio':
+        specifier: ^0.4.2
+        version: 0.4.2(tmcp@1.19.3(typescript@6.0.3))
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
+      tmcp:
+        specifier: ^1.19.3
+        version: 1.19.3(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1044,12 +1056,6 @@ packages:
   '@henrygd/queue@1.2.0':
     resolution: {integrity: sha512-jW/BLSTpcvExDhqJGxtIPgGr2O0IFF8XUNDwEbfCfhrXT8a4xztQ9Lv6U/vbYzYC0xVWn+3zv6YnLUh3bEFUKA==}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@humanwhocodes/momoa@2.0.4':
     resolution: {integrity: sha512-RE815I4arJFtt+FVeU1Tgp9/Xvecacji8w/V6XtXsWWH/wz/eNkNbhb+ny/+PlVZjV0rxQpRSQKNKE3lcktHEA==}
     engines: {node: '>=10.10.0'}
@@ -1172,16 +1178,6 @@ packages:
 
   '@mdn/browser-compat-data@5.7.6':
     resolution: {integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==}
-
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@msgpack/msgpack@2.8.0':
     resolution: {integrity: sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==}
@@ -2296,6 +2292,31 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
+  '@tmcp/adapter-zod@0.1.7':
+    resolution: {integrity: sha512-XF7f9D9HFbKJDUwRHYSd1IaxGaTaWuFjTbwAfUUrh/ejucewvHClMXMxxe9mQYRFu3yOoPCQxmC9ZovVzuwMlQ==}
+    peerDependencies:
+      tmcp: ^1.16.1
+      zod: ^4.0.0
+
+  '@tmcp/session-manager@0.2.1':
+    resolution: {integrity: sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.5':
+    resolution: {integrity: sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
+
+  '@tmcp/transport-stdio@0.4.2':
+    resolution: {integrity: sha512-OLVLJzUXAKsCvenkjPf5ygli9ZcbEv3Lcei/ry+DB4T1NzvDc1oU3m41zYtHhAmbES1h6om3T9f/zonBSDFMRQ==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -2523,10 +2544,6 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
-  accepts@2.0.0:
-    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
-    engines: {node: '>= 0.6'}
-
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2734,10 +2751,6 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
-  body-parser@2.2.2:
-    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
-    engines: {node: '>=18'}
-
   bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
@@ -2937,10 +2950,6 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
-  content-disposition@1.1.0:
-    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
-    engines: {node: '>=18'}
-
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -2957,14 +2966,6 @@ packages:
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
-  cookie-signature@1.2.2:
-    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
-    engines: {node: '>=6.6.0'}
-
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
-
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -2978,10 +2979,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
 
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
@@ -3317,6 +3314,9 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esniff@2.0.1:
     resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
     engines: {node: '>=0.10'}
@@ -3365,14 +3365,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.7:
-    resolution: {integrity: sha512-zwxwiQqexizSXFZV13zMiEtW1E3lv7RlUv+1f5FBiR4x7wFhEjm3aFTyYkZQWzyN08WnPdox015GoRH5D/E5YA==}
-    engines: {node: '>=18.0.0'}
-
-  eventsource@3.0.7:
-    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
-    engines: {node: '>=18.0.0'}
-
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -3384,16 +3376,6 @@ packages:
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
-
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
-  express@5.2.1:
-    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
-    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3522,10 +3504,6 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  finalhandler@2.1.1:
-    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
-    engines: {node: '>= 18.0.0'}
-
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -3549,10 +3527,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  forwarded@0.2.0:
-    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
-    engines: {node: '>= 0.6'}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -3688,10 +3662,6 @@ packages:
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
-    engines: {node: '>=16.9.0'}
-
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -3795,14 +3765,6 @@ packages:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
-    engines: {node: '>= 12'}
-
-  ipaddr.js@1.9.1:
-    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
-    engines: {node: '>= 0.10'}
-
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -3872,9 +3834,6 @@ packages:
 
   is-promise@2.2.2:
     resolution: {integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -3948,9 +3907,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.2.2:
-    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
-
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
@@ -3984,6 +3940,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
   json-schema-compare@0.2.2:
     resolution: {integrity: sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==}
 
@@ -3997,9 +3956,6 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -4226,17 +4182,9 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
-    engines: {node: '>= 0.8'}
-
   memoizee@0.4.17:
     resolution: {integrity: sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==}
     engines: {node: '>=0.12'}
-
-  merge-descriptors@2.0.0:
-    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
-    engines: {node: '>=18'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -4443,14 +4391,6 @@ packages:
     resolution: {integrity: sha512-KZ3c5yNOvH5+v2jKUksSGXFLrAousM5eYdW8LwZTQrfTE4NVfTHHtOmlqhjNLWM8nUD5lnp14B3g89i2qZny6A==}
     engines: {node: '>=20'}
 
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
-
-  object-inspect@1.13.4:
-    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
-    engines: {node: '>= 0.4'}
-
   object-path@0.11.8:
     resolution: {integrity: sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==}
     engines: {node: '>= 10.12.0'}
@@ -4467,9 +4407,6 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -4624,10 +4561,6 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pkce-challenge@5.0.1:
-    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
-    engines: {node: '>=16.20.0'}
-
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -4665,14 +4598,6 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
-  proxy-addr@2.0.7:
-    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
-    engines: {node: '>= 0.10'}
-
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
-    engines: {node: '>=0.6'}
-
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -4688,10 +4613,6 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-
-  raw-body@3.0.2:
-    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
-    engines: {node: '>= 0.10'}
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -4845,10 +4766,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  router@2.2.0:
-    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
-    engines: {node: '>= 18'}
-
   run-applescript@5.0.0:
     resolution: {integrity: sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==}
     engines: {node: '>=12'}
@@ -4942,22 +4859,6 @@ packages:
   should@13.2.3:
     resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
 
-  side-channel-list@1.0.1:
-    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-map@1.0.1:
-    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
-    engines: {node: '>= 0.4'}
-
-  side-channel-weakmap@1.0.2:
-    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
-    engines: {node: '>= 0.4'}
-
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
-    engines: {node: '>= 0.4'}
-
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -5021,6 +4922,9 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
@@ -5201,6 +5105,9 @@ packages:
     resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
     hasBin: true
 
+  tmcp@1.19.3:
+    resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -5292,10 +5199,6 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
-    engines: {node: '>= 0.6'}
-
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
@@ -5358,10 +5261,6 @@ packages:
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
 
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
@@ -5474,11 +5373,22 @@ packages:
   uqr@0.1.3:
     resolution: {integrity: sha512-0rjE8iEJe4YmT9TOhwsZtqCMRLc5DXZUI2UEYUUg63ikBkqqE5EYWaI0etFe/5KUcmcYwLih2RND1kq+hrUJXA==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  valibot@1.4.0:
+    resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate.io-array@1.0.6:
     resolution: {integrity: sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg==}
@@ -5638,9 +5548,6 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -5718,11 +5625,6 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
-
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
 
   zod-validation-error@1.5.0:
     resolution: {integrity: sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw==}
@@ -6421,10 +6323,6 @@ snapshots:
 
   '@henrygd/queue@1.2.0': {}
 
-  '@hono/node-server@1.19.14(hono@4.12.14)':
-    dependencies:
-      hono: 4.12.14
-
   '@humanwhocodes/momoa@2.0.4': {}
 
   '@inquirer/ansi@2.0.5': {}
@@ -6601,28 +6499,6 @@ snapshots:
       - supports-color
 
   '@mdn/browser-compat-data@5.7.6': {}
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.7
-      express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
-      jose: 6.2.2
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@msgpack/msgpack@2.8.0': {}
 
@@ -7357,6 +7233,27 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tmcp/adapter-zod@0.1.7(tmcp@1.19.3(typescript@6.0.3))(zod@4.4.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/json-schema': 7.0.15
+      tmcp: 1.19.3(typescript@6.0.3)
+      zod: 4.4.3
+
+  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@6.0.3))':
+    dependencies:
+      tmcp: 1.19.3(typescript@6.0.3)
+
+  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@6.0.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@6.0.3))
+      esm-env: 1.2.2
+      tmcp: 1.19.3(typescript@6.0.3)
+
+  '@tmcp/transport-stdio@0.4.2(tmcp@1.19.3(typescript@6.0.3))':
+    dependencies:
+      tmcp: 1.19.3(typescript@6.0.3)
+
   '@tsconfig/node10@1.0.12': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -7637,11 +7534,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  accepts@2.0.0:
-    dependencies:
-      mime-types: 3.0.2
-      negotiator: 1.0.0
-
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7669,10 +7561,6 @@ snapshots:
   ajv-formats@3.0.1(@redocly/ajv@8.18.1):
     optionalDependencies:
       ajv: '@redocly/ajv@8.18.1'
-
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
 
   ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
@@ -7814,20 +7702,6 @@ snapshots:
       file-uri-to-path: 1.0.0
 
   birpc@4.0.0: {}
-
-  body-parser@2.2.2:
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 4.4.3
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      on-finished: 2.4.1
-      qs: 6.15.1
-      raw-body: 3.0.2
-      type-is: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
 
   bplist-parser@0.2.0:
     dependencies:
@@ -8030,8 +7904,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  content-disposition@1.1.0: {}
-
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
@@ -8041,10 +7913,6 @@ snapshots:
   cookie-es@2.0.1: {}
 
   cookie-es@3.1.1: {}
-
-  cookie-signature@1.2.2: {}
-
-  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
@@ -8056,11 +7924,6 @@ snapshots:
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cosmiconfig@9.0.1(typescript@6.0.3):
     dependencies:
@@ -8393,6 +8256,8 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  esm-env@1.2.2: {}
+
   esniff@2.0.1:
     dependencies:
       d: 1.0.2
@@ -8435,12 +8300,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.7: {}
-
-  eventsource@3.0.7:
-    dependencies:
-      eventsource-parser: 3.0.7
-
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8466,44 +8325,6 @@ snapshots:
       strip-final-newline: 3.0.0
 
   expect-type@1.3.0: {}
-
-  express-rate-limit@8.3.2(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.1.0
-
-  express@5.2.1:
-    dependencies:
-      accepts: 2.0.0
-      body-parser: 2.2.2
-      content-disposition: 1.1.0
-      content-type: 1.0.5
-      cookie: 0.7.2
-      cookie-signature: 1.2.2
-      debug: 4.4.3
-      depd: 2.0.0
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      etag: 1.8.1
-      finalhandler: 2.1.1
-      fresh: 2.0.0
-      http-errors: 2.0.1
-      merge-descriptors: 2.0.0
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      once: 1.4.0
-      parseurl: 1.3.3
-      proxy-addr: 2.0.7
-      qs: 6.15.1
-      range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
-      statuses: 2.0.2
-      type-is: 2.0.1
-      vary: 1.1.2
-    transitivePeerDependencies:
-      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -8617,17 +8438,6 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
-    dependencies:
-      debug: 4.4.3
-      encodeurl: 2.0.0
-      escape-html: 1.0.3
-      on-finished: 2.4.1
-      parseurl: 1.3.3
-      statuses: 2.0.2
-    transitivePeerDependencies:
-      - supports-color
-
   find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
@@ -8645,8 +8455,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
 
@@ -8795,8 +8603,6 @@ snapshots:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
-  hono@4.12.14: {}
-
   hookable@5.5.3: {}
 
   hookable@6.1.1: {}
@@ -8910,10 +8716,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.1.0: {}
-
-  ipaddr.js@1.9.1: {}
-
   iron-webcrypto@1.2.1: {}
 
   is-arrayish@0.2.1: {}
@@ -8963,8 +8765,6 @@ snapshots:
   is-plain-object@5.0.0: {}
 
   is-promise@2.2.2: {}
-
-  is-promise@4.0.0: {}
 
   is-reference@1.2.1:
     dependencies:
@@ -9032,8 +8832,6 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  jose@6.2.2: {}
-
   js-levenshtein@1.1.6: {}
 
   js-tokens@10.0.0: {}
@@ -9057,6 +8855,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-rpc-2.0@1.7.1: {}
+
   json-schema-compare@0.2.2:
     dependencies:
       lodash: 4.18.1
@@ -9074,8 +8874,6 @@ snapshots:
       ts-algebra: 1.2.2
 
   json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   jsonc-parser@3.2.0: {}
 
@@ -9305,8 +9103,6 @@ snapshots:
 
   media-typer@0.3.0: {}
 
-  media-typer@1.1.0: {}
-
   memoizee@0.4.17:
     dependencies:
       d: 1.0.2
@@ -9317,8 +9113,6 @@ snapshots:
       lru-queue: 0.1.0
       next-tick: 1.1.0
       timers-ext: 0.1.8
-
-  merge-descriptors@2.0.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -9645,10 +9439,6 @@ snapshots:
       path-to-regexp: 8.4.2
       remove-undefined-objects: 7.0.0
 
-  object-assign@4.1.1: {}
-
-  object-inspect@1.13.4: {}
-
   object-path@0.11.8: {}
 
   obug@2.1.1: {}
@@ -9664,10 +9454,6 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -9832,8 +9618,6 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pkce-challenge@5.0.1: {}
-
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -9868,15 +9652,6 @@ snapshots:
 
   process@0.11.10: {}
 
-  proxy-addr@2.0.7:
-    dependencies:
-      forwarded: 0.2.0
-      ipaddr.js: 1.9.1
-
-  qs@6.15.1:
-    dependencies:
-      side-channel: 1.1.0
-
   quansync@0.2.11: {}
 
   quansync@1.0.0: {}
@@ -9886,13 +9661,6 @@ snapshots:
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
-
-  raw-body@3.0.2:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.1
-      iconv-lite: 0.7.2
-      unpipe: 1.0.0
 
   rc9@3.0.1:
     dependencies:
@@ -10139,16 +9907,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
-  router@2.2.0:
-    dependencies:
-      debug: 4.4.3
-      depd: 2.0.0
-      is-promise: 4.0.0
-      parseurl: 1.3.3
-      path-to-regexp: 8.4.2
-    transitivePeerDependencies:
-      - supports-color
-
   run-applescript@5.0.0:
     dependencies:
       execa: 5.1.1
@@ -10257,34 +10015,6 @@ snapshots:
       should-type-adaptors: 1.1.0
       should-util: 1.0.1
 
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
-
   siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
@@ -10334,6 +10064,8 @@ snapshots:
       signal-exit: 4.1.0
 
   sprintf-js@1.0.3: {}
+
+  sqids@0.3.0: {}
 
   stack-trace@0.0.10: {}
 
@@ -10531,6 +10263,16 @@ snapshots:
     dependencies:
       tldts-core: 7.0.28
 
+  tmcp@1.19.3(typescript@6.0.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.4.0(typescript@6.0.3)
+    transitivePeerDependencies:
+      - typescript
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -10618,12 +10360,6 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.2
-
   type@2.7.3: {}
 
   typescript@6.0.3: {}
@@ -10688,8 +10424,6 @@ snapshots:
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
-
-  unpipe@1.0.0: {}
 
   unplugin-utils@0.3.1:
     dependencies:
@@ -10762,9 +10496,15 @@ snapshots:
 
   uqr@0.1.3: {}
 
+  uri-template-matcher@1.1.2: {}
+
   util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
+
+  valibot@1.4.0(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   validate.io-array@1.0.6: {}
 
@@ -10920,8 +10660,6 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2: {}
-
   ws@8.20.0: {}
 
   wsl-utils@0.3.1:
@@ -10988,10 +10726,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod-validation-error@1.5.0(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replace `@modelcontextprotocol/sdk` with `tmcp` (lighter, fully typesafe MCP library)
- Add `validate` and `init` MCP tools to match the CLI's `generate`, `validate`, and `init` commands
- Add `--port` / `--host` flags to `kubb mcp` for HTTP/SSE transport (in addition to stdio)
- Export `createMcpServer()` from `@kubb/mcp` to enable hosting at `mcp.kubb.studio/agent/{uuid}/mcp` via the platform's Nitro server

## Plans

Two implementation plans have been written:
- **Plan 1** (`plan-1-migrate-to-tmcp.md`): Full tmcp migration + 3 tools + HTTP transport
- **Plan 2** (`plan-2-mcp-on-kubb-studio.md`): Hosting at `mcp.kubb.studio/agent/{uuid}/mcp` via `kubb-labs/platform`

## What's in this commit

The `package.json` and lockfile have been updated to swap the dependency. No source code changes yet — implementation pending plan approval.

## Test plan

- [ ] `pnpm --filter @kubb/mcp build` succeeds
- [ ] `pnpm --filter @kubb/mcp typecheck` passes
- [ ] Stdio: `node packages/mcp/bin/kubb-mcp.cjs` lists 3 tools via MCP Inspector
- [ ] HTTP: `kubb mcp --port 3001` + `curl -X POST http://localhost:3001/mcp` responds

https://claude.ai/code/session_01MMs6CeAi59o9wibKX5UK62
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MMs6CeAi59o9wibKX5UK62)_