### PR TITLE
ci: align v4 release workflow with main, fix canary step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -51,7 +51,7 @@ jobs:
         run: pnpm run test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -76,7 +76,6 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
-          git checkout main
           pnpm version:canary
           pnpm release:canary --tag "$RELEASE_TAG"
 
@@ -90,7 +89,7 @@ jobs:
     steps:
       - name: Get version
         id: version
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PUBLISHED_PACKAGES: ${{ needs.release.outputs.published_packages }}
         with:
@@ -117,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send a discord notification
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           PUBLISHED_PACKAGES: ${{ needs.release.outputs.published_packages }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: true
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
+          git checkout main
           pnpm version:canary
           pnpm release:canary --tag "$RELEASE_TAG"
 


### PR DESCRIPTION
## Context

`main` successfully publishes `@kubb/*@5.x` beta with npm provenance via OIDC (no `NPM_TOKEN`). On `v4` the same flow reaches `npm publish` but is rejected by npm with an auth/OIDC error, even though the npm Trusted Publisher is already configured and known to work for `main`.

OIDC trusted publishing is **not branch-scoped** — npm matches on `{repo_owner, repo_name, workflow_filename}` (plus optional environment). The same TP that authorizes `main` should authorize `v4` because the workflow file is at the same path (`.github/workflows/release.yml`).

The OIDC-relevant bits in `release.yml` (`id-token: write`, `setupNpmrc: false`, `NPM_CONFIG_PROVENANCE: true`, no `NPM_TOKEN`) are already identical between branches. This PR removes the remaining incidental drift vs `main`.

## Changes

- `concurrency.cancel-in-progress: true` → `false` — avoid cancelling an in-flight publish if another push lands.
- `codecov/codecov-action@v3` → `@v6` — v3 is deprecated and can fail the run before `Publish` ever executes.
- `actions/github-script@v7` → `@v9` in the two post-publish jobs.

Per direction from the owner, this PR intentionally does **not**:
- bump `node-version: '20'`
- touch the canary publish step

## Not changed (intentional)

- `v4` in the `branches:` trigger list
- `permissions: models: read` (used by the `changelog` reusable workflow)
- `node-version: '20'`
- The v4-only `changelog` job
- The canary publish step (incl. its `git checkout main`)

## Test plan

- [ ] Merge a `.changeset/*.md` PR into `v4`
- [ ] On the resulting "Version Packages" PR merge, watch the **Publish** step (no `ENEEDAUTH`, no `automation token`, `publishedPackages` populated, exit 0)
- [ ] On npmjs.com, new `@kubb/core@4.x.y` shows the **Provenance** badge tied to `kubb-labs/kubb/.github/workflows/release.yml`
