### PR TITLE
fix(plugin-vue-query): use toValue() in enabled guard for MaybeRefOrGetter params

### DIFF
--- a/.changeset/vue-query-enabled-tovalue.md
+++ b/.changeset/vue-query-enabled-tovalue.md
@@ -1,0 +1,17 @@
+---
+"@kubb/plugin-vue-query": patch
+---
+
+Fixed `enabled` flag generation to correctly unwrap `MaybeRefOrGetter` path params.
+
+Previously, the generator emitted `enabled: !!(petId)` — but since path params in Vue Query are typed as `MaybeRefOrGetter<T>`, the `!!` check was always `true` (a `Ref` object is always truthy), causing queries to fire even when the underlying value was `undefined`.
+
+The generator now emits a reactive getter that applies `toValue` per param:
+
+```typescript
+// Before
+enabled: !!(petId),
+
+// After
+enabled: () => !!toValue(petId),
+```

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -215,9 +215,9 @@ export function InfiniteQueryOptions({
       .filter(([, item]) => item && !item.optional && !item.default)
       .map(([key]) => key),
   )
-  const enabled = [...enabledParamNames].join(' && ')
+  const enabled = [...enabledParamNames].map((n) => `!!toValue(${n})`).join(' && ')
 
-  const enabledText = enabled ? `enabled: !!(${enabled}),` : ''
+  const enabledText = enabled ? `enabled: () => ${enabled},` : ''
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-vue-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/QueryOptions.tsx
@@ -153,9 +153,9 @@ export function QueryOptions({
       .filter(([, item]) => item && !item.optional && !item.default)
       .map(([key]) => key),
   )
-  const enabled = [...enabledParamNames].join(' && ')
+  const enabled = [...enabledParamNames].map((n) => `!!toValue(${n})`).join(' && ')
 
-  const enabledText = enabled ? `enabled: !!(${enabled}),` : ''
+  const enabledText = enabled ? `enabled: () => ${enabled},` : ''
 
   return (
     <File.Source name={name} isExportable isIndexable>

--- a/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
@@ -49,7 +49,7 @@ export function updatePetWithFormQueryOptions(
 ) {
   const queryKey = updatePetWithFormQueryKey(petId, data, params)
   return queryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, UpdatePetWithFormMutationResponse, typeof queryKey>({
-    enabled: !!petId,
+    enabled: () => !!toValue(petId),
     queryKey,
     queryFn: async ({ signal }) => {
       return updatePetWithForm(toValue(petId)!, toValue(data), toValue(params), { ...config, signal: config.signal ?? signal })

--- a/packages/plugin-vue-query/src/generators/__snapshots__/postAsQueryObjectParams.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/postAsQueryObjectParams.ts
@@ -53,7 +53,7 @@ export function updatePetWithFormQueryOptions(
 ) {
   const queryKey = updatePetWithFormQueryKey({ petId }, data, params)
   return queryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, UpdatePetWithFormMutationResponse, typeof queryKey>({
-    enabled: !!petId,
+    enabled: () => !!toValue(petId),
     queryKey,
     queryFn: async ({ signal }) => {
       return updatePetWithForm(toValue({ petId: toValue(petId)!, data: toValue(data), params: toValue(params) }), {


### PR DESCRIPTION
## Summary

- Fixes #3277 — applies the same fix from PR #3278 to the v4 branch
- `enabled: !!(petId)` was always truthy because a `Ref` object is never falsy
- Now emits `enabled: () => !!toValue(petId)` so the reactive getter correctly evaluates the underlying value
- Same fix applied to both `QueryOptions.tsx` and `InfiniteQueryOptions.tsx`
- Snapshots and changeset updated

## Test plan

- [ ] Run `pnpm test` in `packages/plugin-vue-query`
- [ ] Verify generated `enabled` field uses `() => !!toValue(param)` pattern
- [ ] Confirm queries no longer fire when a required path param is `undefined`

https://claude.ai/code/session_01U8nRPXgF4Cu2t94VVntUbA

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8nRPXgF4Cu2t94VVntUbA)_