### PR TITLE
ci(release): use NPM_TOKEN instead of npm provenance for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
 permissions:
   actions: write
   contents: write
-  id-token: write
   models: read
   packages: write
   pull-requests: write
@@ -65,7 +64,7 @@ jobs:
           setupGitUser: false
           setupNpmrc: false
         env:
-          NPM_CONFIG_PROVENANCE: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish ${{ inputs.tag || 'canary' }}
@@ -73,7 +72,7 @@ jobs:
         if: steps.changesets.outputs.published != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
           git checkout main


### PR DESCRIPTION
## Summary

- Replaces `NPM_CONFIG_PROVENANCE: true` with `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` in both the standard and canary publish steps
- Removes the `id-token: write` permission that was only required for OIDC-based npm provenance

## Test plan

- [ ] Verify `NPM_TOKEN` secret is configured in the repository settings
- [ ] Trigger a canary release via `workflow_dispatch` to confirm packages publish successfully with the token-based auth
- [ ] Confirm standard release flow publishes to npm on next changeset merge

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhoPmnhKda6wEbQvdhF72k)_