### PR TITLE
feat(adapter-oas, core): stream AST through config.storage

### DIFF
--- a/.changeset/stream-ast-via-storage.md
+++ b/.changeset/stream-ast-via-storage.md
@@ -1,0 +1,14 @@
+---
+'@kubb/adapter-oas': minor
+'@kubb/core': minor
+---
+
+Stream parsed AST nodes through `config.storage` to reduce peak memory.
+
+`adapter-oas` now writes each parsed schema and operation to `config.storage` under a per-build `.kubb/.cache/<namespace>/` directory and exposes them through a new `Adapter.source` (`AdapterStreamSource`) that yields nodes lazily. `createKubb` walks this streaming source when present so only one schema/operation lives in memory at a time per plugin pass.
+
+The `InputNode` shape stays primitive-only — its `schemas` and `operations` arrays remain JSON-safe. Adapters that materialize everything up front (no `source`) continue to work unchanged.
+
+A new `bundle` option on `adapterOas()` (default `true`) toggles Redocly's pre-parse bundling. Set it to `false` for very large OpenAPI documents where the bundler dominates memory.
+
+The `operations` generator hook now receives an `AsyncIterable<OperationNode>` instead of `Array<OperationNode>` so consumers can stream through it. Existing first-party generators have been updated.

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,10 +1,135 @@
+import { randomBytes } from 'node:crypto'
+import path from 'node:path'
 import { ast, createAdapter } from '@kubb/core'
+import type { AdapterStreamSource, Storage } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
-import { applyDiscriminatorInheritance } from './discriminator.ts'
+import { collectDiscriminatorTargets, type DiscriminatorChildMap, patchDiscriminatorChild } from './discriminator.ts'
 import { parseDocument, parseFromConfig, validateDocument } from './factory.ts'
-import { parseOas } from './parser.ts'
+import { parseOasStreaming } from './parser.ts'
 import { resolveServerUrl } from './resolvers.ts'
 import type { AdapterOas, Document } from './types.ts'
+
+const AST_PREFIX = '.kubb/.cache'
+
+function safeKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, '_')
+}
+
+function cacheDir(root: string, namespace: string): string {
+  return path.resolve(root, AST_PREFIX, namespace)
+}
+
+function schemaKey(root: string, namespace: string, index: number, name: string): string {
+  return path.resolve(cacheDir(root, namespace), 'schemas', `${String(index).padStart(6, '0')}-${safeKey(name)}.json`)
+}
+
+function operationKey(root: string, namespace: string, index: number, id: string): string {
+  return path.resolve(cacheDir(root, namespace), 'operations', `${String(index).padStart(6, '0')}-${safeKey(id)}.json`)
+}
+
+/**
+ * Builds an {@link AdapterStreamSource} backed by `storage`. The maps capture
+ * the resolved storage key per name/id so re-reads in `loadSchema` /
+ * `loadOperation` do not need to scan the cache directory.
+ */
+function createStorageStreamSource(args: {
+  storage: Storage
+  namespaceDir: string
+  schemaNames: string[]
+  operationIds: string[]
+  schemaKeyByName: Map<string, string>
+  operationKeyById: Map<string, string>
+}): AdapterStreamSource {
+  const { storage, namespaceDir, schemaNames, operationIds, schemaKeyByName, operationKeyById } = args
+
+  async function loadFromKey<T>(key: string | undefined): Promise<T | undefined> {
+    if (!key) return undefined
+    const raw = await storage.getItem(key)
+    return raw ? (JSON.parse(raw) as T) : undefined
+  }
+
+  return {
+    schemas: {
+      async *[Symbol.asyncIterator]() {
+        for (const name of schemaNames) {
+          const node = await loadFromKey<ast.SchemaNode>(schemaKeyByName.get(name))
+          if (node) yield node
+        }
+      },
+    },
+    operations: {
+      async *[Symbol.asyncIterator]() {
+        for (const id of operationIds) {
+          const node = await loadFromKey<ast.OperationNode>(operationKeyById.get(id))
+          if (node) yield node
+        }
+      },
+    },
+    schemaNames,
+    operationIds,
+    schemaCount: schemaNames.length,
+    operationCount: operationIds.length,
+    async loadSchema(name) {
+      return loadFromKey<ast.SchemaNode>(schemaKeyByName.get(name))
+    },
+    async loadOperation(id) {
+      return loadFromKey<ast.OperationNode>(operationKeyById.get(id))
+    },
+    async dispose() {
+      try {
+        await storage.clear(namespaceDir)
+      } catch {
+        // best-effort cleanup
+      }
+    },
+  }
+}
+
+/**
+ * Builds an in-memory {@link AdapterStreamSource} for the no-storage fallback
+ * path (e.g. ad-hoc adapter usage outside `createKubb`). Holds nodes in maps
+ * so iteration and random access stay O(1).
+ */
+function createMemoryStreamSource(schemas: ast.SchemaNode[], operations: ast.OperationNode[]): AdapterStreamSource {
+  const schemaMap = new Map<string, ast.SchemaNode>()
+  const schemaNames: string[] = []
+  schemas.forEach((schema, index) => {
+    const name = schema.name ?? `__anonymous_schema_${index}`
+    schemaMap.set(name, schema)
+    schemaNames.push(name)
+  })
+
+  const operationMap = new Map<string, ast.OperationNode>()
+  const operationIds: string[] = []
+  operations.forEach((operation, index) => {
+    const id = operation.operationId ?? `${operation.method}_${operation.path}_${index}`
+    operationMap.set(id, operation)
+    operationIds.push(id)
+  })
+
+  return {
+    schemas: {
+      async *[Symbol.asyncIterator]() {
+        for (const name of schemaNames) yield schemaMap.get(name)!
+      },
+    },
+    operations: {
+      async *[Symbol.asyncIterator]() {
+        for (const id of operationIds) yield operationMap.get(id)!
+      },
+    },
+    schemaNames,
+    operationIds,
+    schemaCount: schemas.length,
+    operationCount: operations.length,
+    async loadSchema(name) {
+      return schemaMap.get(name)
+    },
+    async loadOperation(id) {
+      return operationMap.get(id)
+    },
+  }
+}
 
 /**
  * Stable string identifier for the OAS adapter used in Kubb's adapter registry.
@@ -14,8 +139,11 @@ export const adapterOasName = 'oas' satisfies AdapterOas['name']
 /**
  * Creates the default OpenAPI / Swagger adapter for Kubb.
  *
- * Parses the spec, optionally validates it, resolves the base URL, and converts
- * everything into an `InputNode` that downstream plugins consume.
+ * Parses the spec, optionally validates it, resolves the base URL, and exposes
+ * each parsed schema and operation through `adapter.source` (a streaming view
+ * backed by `config.storage` under `.kubb/.cache`). The returned `InputNode`
+ * itself stays small — meta only — so plugins always interact with the same
+ * primitives regardless of spec size.
  *
  * @example
  * ```ts
@@ -33,6 +161,7 @@ export const adapterOasName = 'oas' satisfies AdapterOas['name']
 export const adapterOas = createAdapter<AdapterOas>((options) => {
   const {
     validate = true,
+    bundle = true,
     contentType,
     serverIndex,
     serverVariables,
@@ -48,12 +177,14 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   let nameMapping = new Map<string, string>()
   let parsedDocument: Document | null
   let inputNode: ast.InputNode | null
+  let streamSource: AdapterStreamSource | null = null
 
   return {
     name: adapterOasName,
     get options() {
       return {
         validate,
+        bundle,
         contentType,
         serverIndex,
         serverVariables,
@@ -72,6 +203,9 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     get inputNode() {
       return inputNode
     },
+    get source() {
+      return streamSource
+    },
     async validate(input, options) {
       const document = await parseDocument(input)
       await validateDocument(document, options)
@@ -88,8 +222,8 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
         },
       })
     },
-    async parse(source) {
-      const document = await parseFromConfig(source)
+    async parse(source, context) {
+      const document = await parseFromConfig(source, { bundle })
 
       if (validate) {
         await validateDocument(document)
@@ -98,30 +232,99 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       const server = serverIndex !== undefined ? document.servers?.at(serverIndex) : undefined
       const baseURL = server?.url ? resolveServerUrl(server, serverVariables) : undefined
 
-      const { root: parsedRoot, nameMapping: parsedNameMapping } = parseOas(document, {
-        contentType,
-        dateType,
-        integerType,
-        unknownType,
-        emptySchemaType,
-        enumSuffix,
+      const meta = {
+        title: document.info?.title,
+        description: document.info?.description,
+        version: document.info?.version,
+        baseURL,
+      }
+
+      const parserOptions = { contentType, dateType, integerType, unknownType, emptySchemaType, enumSuffix }
+
+      // No storage context (e.g. ad-hoc adapter usage outside `createKubb`):
+      // collect everything in memory and expose it via an in-memory source.
+      if (!context) {
+        const schemas: ast.SchemaNode[] = []
+        const operations: ast.OperationNode[] = []
+        const childMap: DiscriminatorChildMap = new Map()
+
+        const { nameMapping: parsedNameMapping } = await parseOasStreaming(document, parserOptions, {
+          onSchema(node) {
+            if (discriminator === 'inherit') collectDiscriminatorTargets(node, childMap)
+            schemas.push(node)
+          },
+          onOperation(node) {
+            operations.push(node)
+          },
+        })
+
+        const finalSchemas = discriminator === 'inherit' && childMap.size > 0 ? schemas.map((s) => patchDiscriminatorChild(s, childMap)) : schemas
+
+        nameMapping = parsedNameMapping
+        parsedDocument = document
+        inputNode = ast.createInput({ meta })
+        streamSource = createMemoryStreamSource(finalSchemas, operations)
+        return inputNode
+      }
+
+      const { storage, root } = context
+      // Per-build cache directory so concurrent builds (and parallel tests)
+      // don't clobber each other under the shared `.kubb/.cache` prefix.
+      const namespace = `${process.pid}-${Date.now()}-${randomBytes(4).toString('hex')}`
+
+      const childMap: DiscriminatorChildMap = new Map()
+      const schemaNames: string[] = []
+      const operationIds: string[] = []
+      const schemaKeyByName = new Map<string, string>()
+      const operationKeyById = new Map<string, string>()
+
+      const { nameMapping: parsedNameMapping } = await parseOasStreaming(document, parserOptions, {
+        async onSchema(node) {
+          if (discriminator === 'inherit') collectDiscriminatorTargets(node, childMap)
+          const index = schemaNames.length
+          const name = node.name ?? `__anonymous_schema_${index}`
+          const key = schemaKey(root, namespace, index, name)
+          await storage.setItem(key, JSON.stringify(node))
+          schemaNames.push(name)
+          schemaKeyByName.set(name, key)
+        },
+        async onOperation(node) {
+          const index = operationIds.length
+          const id = node.operationId ?? `${node.method}_${node.path}_${index}`
+          const key = operationKey(root, namespace, index, id)
+          await storage.setItem(key, JSON.stringify(node))
+          operationIds.push(id)
+          operationKeyById.set(id, key)
+        },
       })
 
-      const node = discriminator === 'inherit' ? applyDiscriminatorInheritance(parsedRoot) : parsedRoot
+      // Pass 2: rewrite schemas that match a discriminator target. Skipped when
+      // no targets were collected, preserving the fast path.
+      if (discriminator === 'inherit' && childMap.size > 0) {
+        for (const name of schemaNames) {
+          const key = schemaKeyByName.get(name)
+          if (!key) continue
+          const raw = await storage.getItem(key)
+          if (!raw) continue
+          const node = JSON.parse(raw) as ast.SchemaNode
+          const patched = patchDiscriminatorChild(node, childMap)
+          if (patched !== node) {
+            await storage.setItem(key, JSON.stringify(patched))
+          }
+        }
+      }
 
-      // This must happen after parseOas() because legacy enum remapping is finalized there.
       nameMapping = parsedNameMapping
-      // Expose the raw document so consumers (e.g. plugin-redoc) can access it.
       parsedDocument = document
 
-      inputNode = ast.createInput({
-        ...node,
-        meta: {
-          title: document.info?.title,
-          description: document.info?.description,
-          version: document.info?.version,
-          baseURL,
-        },
+      inputNode = ast.createInput({ meta })
+      streamSource = createStorageStreamSource({
+        storage,
+        namespaceDir: cacheDir(root, namespace),
+        schemaNames,
+        operationIds,
+        schemaKeyByName,
+        operationKeyById,
       })
 
       return inputNode

--- a/packages/adapter-oas/src/discriminator.test.ts
+++ b/packages/adapter-oas/src/discriminator.test.ts
@@ -18,10 +18,10 @@ describe('applyDiscriminatorInheritance', () => {
       },
     })
 
-    const root = parseOas(oas).root
-    const result = applyDiscriminatorInheritance(root)
+    const { schemas } = parseOas(oas)
+    const result = applyDiscriminatorInheritance(schemas)
 
-    expect(result).toBe(root)
+    expect(result).toBe(schemas)
   })
 
   it('injects the discriminator enum into child object schemas', async () => {
@@ -47,9 +47,9 @@ describe('applyDiscriminatorInheritance', () => {
       },
     })
 
-    const root = applyDiscriminatorInheritance(parseOas(oas).root)
+    const root = applyDiscriminatorInheritance(parseOas(oas).schemas)
 
-    const dog = root.schemas.find((s) => s.name === 'Dog')
+    const dog = root.find((s) => s.name === 'Dog')
     expect(toSnapshot(ast.narrowSchema(dog, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",
@@ -85,7 +85,7 @@ describe('applyDiscriminatorInheritance', () => {
       }
     `)
 
-    const cat = root.schemas.find((s) => s.name === 'Cat')
+    const cat = root.find((s) => s.name === 'Cat')
     expect(toSnapshot(ast.narrowSchema(cat, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",
@@ -145,9 +145,9 @@ describe('applyDiscriminatorInheritance', () => {
       },
     })
 
-    const root = applyDiscriminatorInheritance(parseOas(oas).root)
+    const root = applyDiscriminatorInheritance(parseOas(oas).schemas)
 
-    const dog = root.schemas.find((s) => s.name === 'Dog')
+    const dog = root.find((s) => s.name === 'Dog')
     expect(toSnapshot(ast.narrowSchema(dog, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",
@@ -211,9 +211,9 @@ describe('applyDiscriminatorInheritance', () => {
       },
     })
 
-    const root = applyDiscriminatorInheritance(parseOas(oas).root)
+    const root = applyDiscriminatorInheritance(parseOas(oas).schemas)
 
-    const dog = root.schemas.find((s) => s.name === 'Dog')
+    const dog = root.find((s) => s.name === 'Dog')
     expect(toSnapshot(ast.narrowSchema(dog, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",
@@ -249,7 +249,7 @@ describe('applyDiscriminatorInheritance', () => {
       }
     `)
 
-    const cat = root.schemas.find((s) => s.name === 'Cat')
+    const cat = root.find((s) => s.name === 'Cat')
     expect(toSnapshot(ast.narrowSchema(cat, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",
@@ -309,9 +309,9 @@ describe('applyDiscriminatorInheritance', () => {
       },
     })
 
-    const root = applyDiscriminatorInheritance(parseOas(oas).root)
+    const root = applyDiscriminatorInheritance(parseOas(oas).schemas)
 
-    const unrelated = root.schemas.find((s) => s.name === 'UnrelatedSchema')
+    const unrelated = root.find((s) => s.name === 'UnrelatedSchema')
     expect(toSnapshot(ast.narrowSchema(unrelated, 'object'))).toMatchInlineSnapshot(`
       {
         "kind": "Schema",

--- a/packages/adapter-oas/src/discriminator.ts
+++ b/packages/adapter-oas/src/discriminator.ts
@@ -6,103 +6,116 @@ type DiscriminatorTarget = {
 }
 
 /**
- * Injects discriminator enum values into child schemas so they know which value identifies them.
- *
- * Finds every union schema in `input.schemas` that has a `discriminatorPropertyName`, collects the
- * enum value each union member is mapped to, then adds (or replaces) that property on the matching
- * child object schema.
- *
- * Returns a new `InputNode` — the original is never mutated.
- *
- * @example
- * ```ts
- * const { root } = parseOas(document, options)
- * const next = applyDiscriminatorInheritance(root)
- * ```
+ * Map from child schema name to the discriminator enum values it inherits.
+ * Built incrementally as schemas are streamed in, then consumed during a
+ * second pass to patch matching child object schemas.
  */
-export function applyDiscriminatorInheritance(root: ast.InputNode): ast.InputNode {
-  const childMap = new Map<string, DiscriminatorTarget>()
+export type DiscriminatorChildMap = Map<string, DiscriminatorTarget>
 
-  for (const schema of root.schemas) {
-    // Case 1: top-level schema is a union (oneOf/anyOf with discriminator)
-    // Case 2: top-level schema is an intersection wrapping a union (oneOf/anyOf + shared properties)
-    let unionNode = ast.narrowSchema(schema, 'union')
+/**
+ * Inspects a single top-level schema and records any discriminator targets
+ * it implies. Safe to call once per streamed schema during parse.
+ */
+export function collectDiscriminatorTargets(schema: ast.SchemaNode, childMap: DiscriminatorChildMap): void {
+  // Case 1: top-level schema is a union (oneOf/anyOf with discriminator)
+  // Case 2: top-level schema is an intersection wrapping a union (oneOf/anyOf + shared properties)
+  let unionNode = ast.narrowSchema(schema, 'union')
 
-    if (!unionNode) {
-      const intersectionMembers = ast.narrowSchema(schema, 'intersection')?.members
-      if (intersectionMembers) {
-        for (const m of intersectionMembers) {
-          const u = ast.narrowSchema(m, 'union')
-          if (u) {
-            unionNode = u
-            break
-          }
+  if (!unionNode) {
+    const intersectionMembers = ast.narrowSchema(schema, 'intersection')?.members
+    if (intersectionMembers) {
+      for (const m of intersectionMembers) {
+        const u = ast.narrowSchema(m, 'union')
+        if (u) {
+          unionNode = u
+          break
         }
-      }
-    }
-
-    if (!unionNode?.discriminatorPropertyName || !unionNode.members) continue
-
-    const { discriminatorPropertyName, members } = unionNode
-
-    for (const member of members) {
-      // Members with a discriminant value are intersections: [RefSchemaNode, ObjectSchemaNode]
-      const intersectionNode = ast.narrowSchema(member, 'intersection')
-      if (!intersectionNode?.members) continue
-
-      let refNode: ReturnType<typeof ast.narrowSchema<'ref'>> | undefined
-      let objNode: ReturnType<typeof ast.narrowSchema<'object'>> | undefined
-
-      for (const m of intersectionNode.members) {
-        refNode ??= ast.narrowSchema(m, 'ref')
-        objNode ??= ast.narrowSchema(m, 'object')
-      }
-
-      if (!refNode?.name || !objNode) continue
-
-      const prop = objNode.properties.find((p) => p.name === discriminatorPropertyName)
-      const enumNode = prop ? ast.narrowSchema(prop.schema, 'enum') : undefined
-      if (!enumNode?.enumValues?.length) continue
-
-      const enumValues = enumNode.enumValues.filter((v): v is string | number | boolean => v !== null)
-      if (!enumValues.length) continue
-
-      const existing = childMap.get(refNode.name)
-      if (existing) {
-        existing.enumValues.push(...enumValues)
-      } else {
-        childMap.set(refNode.name, {
-          propertyName: discriminatorPropertyName,
-          enumValues: [...enumValues],
-        })
       }
     }
   }
 
-  if (childMap.size === 0) return root
+  if (!unionNode?.discriminatorPropertyName || !unionNode.members) return
 
-  return ast.transform(root, {
-    schema(node, { parent }) {
-      if (parent?.kind !== 'Input' || !node.name) return
+  const { discriminatorPropertyName, members } = unionNode
 
-      const entry = childMap.get(node.name)
-      if (!entry) return
+  for (const member of members) {
+    // Members with a discriminant value are intersections: [RefSchemaNode, ObjectSchemaNode]
+    const intersectionNode = ast.narrowSchema(member, 'intersection')
+    if (!intersectionNode?.members) continue
 
-      const objectNode = ast.narrowSchema(node, 'object')
-      if (!objectNode) return
+    let refNode: ReturnType<typeof ast.narrowSchema<'ref'>> | undefined
+    let objNode: ReturnType<typeof ast.narrowSchema<'object'>> | undefined
 
-      const { propertyName, enumValues } = entry
-      const enumSchema = ast.createSchema({ type: 'enum', enumValues })
-      const newProp = ast.createProperty({
-        name: propertyName,
-        required: true,
-        schema: enumSchema,
+    for (const m of intersectionNode.members) {
+      refNode ??= ast.narrowSchema(m, 'ref')
+      objNode ??= ast.narrowSchema(m, 'object')
+    }
+
+    if (!refNode?.name || !objNode) continue
+
+    const prop = objNode.properties.find((p) => p.name === discriminatorPropertyName)
+    const enumNode = prop ? ast.narrowSchema(prop.schema, 'enum') : undefined
+    if (!enumNode?.enumValues?.length) continue
+
+    const enumValues = enumNode.enumValues.filter((v): v is string | number | boolean => v !== null)
+    if (!enumValues.length) continue
+
+    const existing = childMap.get(refNode.name)
+    if (existing) {
+      existing.enumValues.push(...enumValues)
+    } else {
+      childMap.set(refNode.name, {
+        propertyName: discriminatorPropertyName,
+        enumValues: [...enumValues],
       })
+    }
+  }
+}
 
-      const existingIdx = objectNode.properties.findIndex((p) => p.name === propertyName)
-      const newProperties = existingIdx >= 0 ? objectNode.properties.map((p, i) => (i === existingIdx ? newProp : p)) : [...objectNode.properties, newProp]
+/**
+ * Returns a patched copy of `node` if it matches a discriminator target in
+ * `childMap`, otherwise returns `node` unchanged. Used by the streaming
+ * discriminator pass to rewrite a single schema in place.
+ */
+export function patchDiscriminatorChild(node: ast.SchemaNode, childMap: DiscriminatorChildMap): ast.SchemaNode {
+  if (!node.name) return node
+  const entry = childMap.get(node.name)
+  if (!entry) return node
 
-      return { ...objectNode, properties: newProperties }
-    },
+  const objectNode = ast.narrowSchema(node, 'object')
+  if (!objectNode) return node
+
+  const { propertyName, enumValues } = entry
+  const enumSchema = ast.createSchema({ type: 'enum', enumValues })
+  const newProp = ast.createProperty({
+    name: propertyName,
+    required: true,
+    schema: enumSchema,
   })
+
+  const existingIdx = objectNode.properties.findIndex((p) => p.name === propertyName)
+  const newProperties = existingIdx >= 0 ? objectNode.properties.map((p, i) => (i === existingIdx ? newProp : p)) : [...objectNode.properties, newProp]
+
+  return { ...objectNode, properties: newProperties }
+}
+
+/**
+ * Injects discriminator enum values into child schemas so they know which
+ * value identifies them.
+ *
+ * Pure array-in / array-out so callers can operate on either an in-memory
+ * snapshot (tests, the eager `parseOas` helper) or a streamed batch from
+ * storage. Returns the same `schemas` reference when no discriminator
+ * targets apply, so callers can short-circuit.
+ *
+ * Streaming adapters that want to avoid buffering the whole array should
+ * collect targets via `collectDiscriminatorTargets` while parsing and then
+ * call `patchDiscriminatorChild` per node when re-streaming from storage.
+ */
+export function applyDiscriminatorInheritance(schemas: ast.SchemaNode[]): ast.SchemaNode[] {
+  const childMap: DiscriminatorChildMap = new Map()
+  for (const schema of schemas) collectDiscriminatorTargets(schema, childMap)
+  if (childMap.size === 0) return schemas
+
+  return schemas.map((schema) => patchDiscriminatorChild(schema, childMap))
 }

--- a/packages/adapter-oas/src/factory.ts
+++ b/packages/adapter-oas/src/factory.ts
@@ -109,7 +109,7 @@ export async function mergeDocuments(pathOrApi: Array<string | Document>): Promi
  * const document = await parseFromConfig({ type: 'data', data: '{"openapi":"3.0.0",...}' })
  * ```
  */
-export function parseFromConfig(source: AdapterSource): Promise<Document> {
+export function parseFromConfig(source: AdapterSource, { bundle = true }: { bundle?: boolean } = {}): Promise<Document> {
   if (source.type === 'data') {
     if (typeof source.data === 'object') {
       return parseDocument(structuredClone(source.data) as Document)
@@ -124,10 +124,10 @@ export function parseFromConfig(source: AdapterSource): Promise<Document> {
 
   // type === 'path'
   if (new URLPath(source.path).isURL) {
-    return parseDocument(source.path)
+    return parseDocument(source.path, { canBundle: bundle })
   }
 
-  return parseDocument(path.resolve(path.dirname(source.path), source.path))
+  return parseDocument(path.resolve(path.dirname(source.path), source.path), { canBundle: bundle })
 }
 
 /**

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -14,15 +14,15 @@ const emptyDocument: Document = {
 describe('buildAst', () => {
   it('returns an InputNode', async () => {
     const oas = await buildMinimalOas()
-    const root = parseOas(oas).root
+    const result = parseOas(oas)
 
-    expect(root.kind).toBe('Input')
+    expect(result.root.kind).toBe('Input')
   })
 
   describe('schemas', () => {
     it('converts named component schemas', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const names = root.schemas.map((s) => s.name)
 
       expect(names).toContain('Pet')
@@ -32,7 +32,7 @@ describe('buildAst', () => {
 
     it('converts object schema with properties', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const pet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Pet'),
         'object',
@@ -44,7 +44,7 @@ describe('buildAst', () => {
 
     it('marks required properties', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const pet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Pet'),
         'object',
@@ -58,7 +58,7 @@ describe('buildAst', () => {
 
     it('converts array schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const list = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'PetList'),
         'array',
@@ -71,7 +71,7 @@ describe('buildAst', () => {
 
     it('converts enum schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const status = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Status'),
         'enum',
@@ -83,7 +83,7 @@ describe('buildAst', () => {
 
     it('converts oneOf to union', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const petOrError = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'PetOrError'),
         'union',
@@ -95,7 +95,7 @@ describe('buildAst', () => {
 
     it('converts allOf to intersection', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -107,7 +107,7 @@ describe('buildAst', () => {
 
     it('flattens single-member allOf and propagates nullable', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const nullableString = root.schemas.find((s) => s.name === 'NullableString')
 
       // Should be flattened to 'string' — not an intersection
@@ -119,7 +119,7 @@ describe('buildAst', () => {
 
     it('flattens single-member allOf for nullable $ref', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const nullableRef = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'NullableRef'),
         'ref',
@@ -134,7 +134,7 @@ describe('buildAst', () => {
 
     it('maps format date-time to datetime SchemaType', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -151,7 +151,7 @@ describe('buildAst', () => {
 
     it('maps format email to email SchemaType', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -169,14 +169,14 @@ describe('buildAst', () => {
   describe('operations', () => {
     it('converts all operations', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
 
       expect(root.operations).toHaveLength(4)
     })
 
     it('sets operationId, method, path, tags', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
 
       expect(listPets?.method).toBe('GET')
@@ -187,7 +187,7 @@ describe('buildAst', () => {
 
     it('sets deprecated flag', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.deprecated).toBe(true)
@@ -195,7 +195,7 @@ describe('buildAst', () => {
 
     it('uses uppercase HTTP method per RFC 9110', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       for (const op of root.operations) {
         expect(op.method).toBe(op.method.toUpperCase())
       }
@@ -203,7 +203,7 @@ describe('buildAst', () => {
 
     it('converts query parameters', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const limit = listPets?.parameters.find((p) => p.name === 'limit')
 
@@ -214,7 +214,7 @@ describe('buildAst', () => {
 
     it('converts path parameters', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPet = root.operations.find((op) => op.operationId === 'getPetById')
       const petId = getPet?.parameters.find((p) => p.name === 'petId')
 
@@ -252,7 +252,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const op = root.operations.find((o) => o.operationId === 'getPetById')
       const petId = op?.parameters.find((p) => p.name === 'petId')
 
@@ -262,7 +262,7 @@ describe('buildAst', () => {
 
     it('converts requestBody', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody).toBeDefined()
@@ -271,7 +271,7 @@ describe('buildAst', () => {
 
     it('captures requestBody description', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.description).toBe('New pet to create')
@@ -279,7 +279,7 @@ describe('buildAst', () => {
 
     it('sets requestBody.required to true when spec has required: true', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.required).toBe(true)
@@ -288,7 +288,7 @@ describe('buildAst', () => {
 
     it('leaves requestBody.required undefined when spec omits required', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const patchPet = root.operations.find((op) => op.operationId === 'patchPet')
 
       expect(patchPet?.requestBody).toBeDefined()
@@ -298,7 +298,7 @@ describe('buildAst', () => {
 
     it('converts responses with statusCode and schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
@@ -308,7 +308,7 @@ describe('buildAst', () => {
 
     it('converts responses without a body schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPet = root.operations.find((op) => op.operationId === 'getPetById')
       const notFound = getPet?.responses.find((r) => r.statusCode === '404')
 
@@ -317,7 +317,7 @@ describe('buildAst', () => {
 
     it('sets mediaType on responses', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
@@ -326,7 +326,7 @@ describe('buildAst', () => {
 
     it('populates requestBody.content with a single entry when operation has one content type', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.content).toHaveLength(1)
@@ -358,7 +358,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content).toHaveLength(2)
@@ -390,7 +390,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content?.[0]?.contentType).toBe('application/json')
@@ -421,7 +421,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas, { contentType: 'multipart/form-data' }).root
+      const root = parseOas(oas, { contentType: 'multipart/form-data' })
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content).toHaveLength(1)
@@ -1105,7 +1105,7 @@ describe('parseSchema readOnly / writeOnly', () => {
 
   it('populates node.schema with the resolved ref schema when the document contains the definition', async () => {
     const oas = await buildMinimalOas()
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const petList = ast.narrowSchema(
       root.schemas.find((s) => s.name === 'PetList'),
       'array',
@@ -1120,9 +1120,9 @@ describe('parseSchema readOnly / writeOnly', () => {
 
   it('syncSchemaRef merges usage-site sibling fields over the resolved schema', async () => {
     const oas = await buildMinimalOas()
-    const { root } = parseOas(oas)
+    const { schemas } = parseOas(oas)
     const petList = ast.narrowSchema(
-      root.schemas.find((s) => s.name === 'PetList'),
+      schemas.find((s) => s.name === 'PetList'),
       'array',
     )
     const petRef = petList?.items?.find((item) => item.type === 'ref')
@@ -3297,7 +3297,7 @@ describe('parseSchema circular allOf discriminator detection', () => {
       },
     })
 
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const cat = root.schemas.find((s) => s.name === 'Cat')
 
     expect(cat).toBeDefined()
@@ -3337,7 +3337,7 @@ describe('parseSchema circular allOf discriminator detection', () => {
       },
     })
 
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
 
     const cat = root.schemas.find((s) => s.name === 'Cat')
     expect(cat?.type).toBe('intersection')
@@ -3362,10 +3362,10 @@ describe('parseSchema circular allOf discriminator detection', () => {
 
 describe('buildAst', async () => {
   const oas = await buildMinimalOas()
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
 
   it('produces an InputNode with expected schema and operation counts', () => {
-    expect(root.kind).toBe('Input')
+    expect(root.root.kind).toBe('Input')
     expect(root.schemas.length).toBeGreaterThan(0)
     expect(root.operations.length).toBeGreaterThan(0)
   })
@@ -3473,7 +3473,7 @@ describe('buildAst – header and cookie parameters', async () => {
     },
   })
 
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
   const getItems = root.operations.find((o) => o.operationId === 'getItems')
 
   it('parses operation description', () => {
@@ -3539,7 +3539,7 @@ describe('buildAst – parameter description propagation', async () => {
     },
   })
 
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
   const listPets = root.operations.find((o) => o.operationId === 'listPets')
 
   it('propagates parameter-level description to schema.description for query params', () => {
@@ -3576,7 +3576,7 @@ describe('buildAst – parameter description propagation', async () => {
         },
       },
     })
-    const root2 = parseOas(oasWithBoth).root
+    const root2 = parseOas(oasWithBoth)
     const getItems = root2.operations.find((o) => o.operationId === 'getItems')
     const q = getItems?.parameters.find((p) => p.name === 'q')
 
@@ -3658,7 +3658,7 @@ describe('parameter enum naming', () => {
         },
       },
     })
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const op = root.operations.find((o) => o.operationId === 'listPets')
     const statusParam = op?.parameters.find((p) => p.name === 'status')
     const enumNode = ast.narrowSchema(statusParam?.schema, 'enum')

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -954,26 +954,76 @@ export function parseSchema(
 }
 
 /**
+ * Sink invoked by {@link parseOasStreaming} for every parsed schema and operation.
+ * Adapters use this to persist nodes to storage without buffering the whole tree.
+ */
+export type ParseOasSink = {
+  onSchema(node: ast.SchemaNode): Promise<void> | void
+  onOperation(node: ast.OperationNode): Promise<void> | void
+}
+
+/**
+ * Streaming variant of {@link parseOas}. Emits each `SchemaNode` and `OperationNode`
+ * to `sink` as they are parsed instead of returning them in arrays. Use this when
+ * the document is large (e.g. Stripe) so peak memory stays bounded.
+ *
+ * Returns the `nameMapping` and the order in which schemas / operations were
+ * emitted so callers can reconstruct iteration order from storage.
+ */
+export async function parseOasStreaming(
+  document: Document,
+  options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {},
+  sink: ParseOasSink,
+): Promise<{ nameMapping: Map<string, string>; schemaNames: string[]; operationIds: string[] }> {
+  const { contentType, ...parserOptions } = options
+  const mergedOptions: ast.ParserOptions = {
+    ...DEFAULT_PARSER_OPTIONS,
+    ...parserOptions,
+  }
+
+  const { schemas: schemaObjects, nameMapping } = getSchemas(document, {
+    contentType,
+  })
+  const { parseSchema: _parseSchema, parseOperation: _parseOperation } = createSchemaParser({ document, contentType })
+
+  const schemaNames: string[] = []
+  for (const [name, schema] of Object.entries(schemaObjects)) {
+    const node = _parseSchema({ schema, name }, mergedOptions)
+    await sink.onSchema(node)
+    schemaNames.push(name)
+  }
+
+  const baseOas = new BaseOas(document)
+  const paths = baseOas.getPaths()
+
+  const operationIds: string[] = []
+  let anonymousCounter = 0
+  for (const [, methods] of Object.entries(paths)) {
+    for (const [, operation] of Object.entries(methods)) {
+      if (!operation) continue
+      const node = _parseOperation(mergedOptions, operation)
+      await sink.onOperation(node)
+      operationIds.push(node.operationId ?? `__anonymous_${anonymousCounter++}`)
+    }
+  }
+
+  return { nameMapping, schemaNames, operationIds }
+}
+
+/**
  * Parses an OpenAPI specification into Kubb's universal `InputNode` AST.
  *
- * This is the main entry point for `@kubb/adapter-oas`. It converts OpenAPI/Swagger specs into a spec-agnostic tree
- * that downstream plugins (`plugin-ts`, `plugin-zod`, etc.) consume for code generation. No code is generated here —
- * the tree is a pure data structure representing all schemas and operations.
+ * Returns the AST root, the underlying `schemas` / `operations` arrays (for
+ * convenient random-access in tests and adapters that buffer in memory), and
+ * a `nameMapping` for resolving schema references.
  *
- * Returns the AST root and a `nameMapping` for resolving schema references.
- *
- * @example
- * ```ts
- * import { parseOas } from '@kubb/adapter-oas'
- *
- * const document = await parseFromConfig(config)
- * const { root, nameMapping } = parseOas(document, { dateType: 'date', contentType: 'application/json' })
- * ```
+ * Production code that cares about peak memory should call
+ * {@link parseOasStreaming} directly so nodes never sit in memory together.
  */
 export function parseOas(
   document: Document,
   options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {},
-): { root: ast.InputNode; nameMapping: Map<string, string> } {
+): { root: ast.InputNode; nameMapping: Map<string, string>; schemas: ast.SchemaNode[]; operations: ast.OperationNode[] } {
   const { contentType, ...parserOptions } = options
   const mergedOptions: ast.ParserOptions = {
     ...DEFAULT_PARSER_OPTIONS,
@@ -998,5 +1048,5 @@ export function parseOas(
 
   const root = ast.createInput({ schemas, operations })
 
-  return { root, nameMapping }
+  return { root, nameMapping, schemas, operations }
 }

--- a/packages/adapter-oas/src/types.ts
+++ b/packages/adapter-oas/src/types.ts
@@ -143,6 +143,15 @@ export type AdapterOasOptions = {
    */
   validate?: boolean
   /**
+   * Bundle the source document through Redocly before parsing.
+   *
+   * When `false`, external `$ref`s are left as-is — only internal refs are
+   * resolved. Set this to `false` for very large specs (e.g. Stripe) where
+   * the bundling step dominates memory usage.
+   * @default true
+   */
+  bundle?: boolean
+  /**
    * Preferred content-type used when extracting request/response schemas.
    * Defaults to the first valid JSON media type found in the spec.
    */
@@ -178,6 +187,7 @@ export type AdapterOasOptions = {
  */
 export type AdapterOasResolvedOptions = {
   validate: boolean
+  bundle: boolean
   contentType: AdapterOasOptions['contentType']
   serverIndex: AdapterOasOptions['serverIndex']
   serverVariables: AdapterOasOptions['serverVariables']

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -68,16 +68,14 @@ type CreateSchemaOutput<T extends CreateSchemaInput> = InferSchemaNode<T> & {
 /**
  * Creates an `InputNode` with stable defaults for `schemas` and `operations`.
  *
+ * Streaming adapters typically pass empty arrays here and expose their
+ * schemas/operations through `Adapter.source` instead, so the InputNode
+ * itself stays small and JSON-serializable.
+ *
  * @example
  * ```ts
  * const input = createInput()
  * // { kind: 'Input', schemas: [], operations: [] }
- * ```
- *
- * @example
- * ```ts
- * const input = createInput({ schemas: [petSchema] })
- * // keeps default operations: []
  * ```
  */
 export function createInput(overrides: Partial<Omit<InputNode, 'kind'>> = {}): InputNode {

--- a/packages/ast/src/nodes/root.ts
+++ b/packages/ast/src/nodes/root.ts
@@ -35,6 +35,10 @@ export type InputMeta = {
  * Input AST node that contains all schemas and operations for one API document.
  * Produced by the adapter and consumed by all Kubb plugins.
  *
+ * `schemas` and `operations` are plain arrays of primitive nodes so the whole
+ * tree round-trips through `JSON.stringify`/`JSON.parse`. Streaming adapters
+ * leave them empty and expose nodes via `Adapter.source`.
+ *
  * @example
  * ```ts
  * const input: InputNode = {
@@ -50,11 +54,13 @@ export type InputNode = BaseNode & {
    */
   kind: 'Input'
   /**
-   * All schema nodes in the document.
+   * All schema nodes in the document. Empty when the adapter streams nodes
+   * via `Adapter.source` instead of materializing them up front.
    */
   schemas: Array<SchemaNode>
   /**
-   * All operation nodes in the document.
+   * All operation nodes in the document. Empty when the adapter streams nodes
+   * via `Adapter.source` instead of materializing them up front.
    */
   operations: Array<OperationNode>
   /**

--- a/packages/core/src/PluginDriver.ts
+++ b/packages/core/src/PluginDriver.ts
@@ -246,7 +246,7 @@ export class PluginDriver {
     }
 
     if (gen.operations) {
-      const operationsHandler = async (nodes: Array<OperationNode>, ctx: GeneratorContext) => {
+      const operationsHandler = async (nodes: AsyncIterable<OperationNode>, ctx: GeneratorContext) => {
         if (ctx.plugin.name !== pluginName) return
         const result = await gen.operations!(nodes, ctx)
         await applyHookResult(result, this, resolveRenderer())

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -1,11 +1,80 @@
 import type { PossiblePromise } from '@internals/utils'
-import type { ImportNode, InputNode, SchemaNode } from '@kubb/ast'
+import type { ImportNode, InputNode, OperationNode, SchemaNode } from '@kubb/ast'
+import type { Storage } from './createStorage.ts'
 
 /**
  * Source data passed to an adapter's `parse` function.
  * Mirrors the config input shape with paths resolved to absolute.
  */
 export type AdapterSource = { type: 'path'; path: string } | { type: 'data'; data: string | unknown } | { type: 'paths'; paths: Array<string> }
+
+/**
+ * Runtime context handed to {@link Adapter.parse}. Provides access to the
+ * shared `config.storage` (used for caching parsed nodes to disk) and the
+ * resolved project root so adapters can scope storage keys.
+ */
+export type AdapterParseContext = {
+  /**
+   * Storage shared with output file emission. Adapters that stream nodes must
+   * write under a reserved key prefix (e.g. `<root>/.kubb/.cache/...`).
+   */
+  storage: Storage
+  /**
+   * Absolute project root (`config.root`).
+   */
+  root: string
+}
+
+/**
+ * Streaming view over schemas and operations exposed by an adapter that
+ * persists nodes outside the `InputNode`. Implementations are free to read
+ * each node from disk on demand so peak memory stays bounded; consumers must
+ * never assume `Symbol.asyncIterator` is multi-shot — re-walks should rely on
+ * `loadSchema` / `loadOperation` or re-iterate via the returned iterables.
+ *
+ * Each yielded node is a plain `SchemaNode` / `OperationNode` (JSON-safe), so
+ * the AST primitives in `@kubb/ast` remain serializable.
+ */
+export type AdapterStreamSource = {
+  /**
+   * Streams every schema node in source order.
+   */
+  schemas: AsyncIterable<SchemaNode>
+  /**
+   * Streams every operation node in source order.
+   */
+  operations: AsyncIterable<OperationNode>
+  /**
+   * Stable schema names in source order.
+   */
+  schemaNames: ReadonlyArray<string>
+  /**
+   * Stable operation identifiers in source order.
+   */
+  operationIds: ReadonlyArray<string>
+  /**
+   * Total number of schemas.
+   */
+  schemaCount: number
+  /**
+   * Total number of operations.
+   */
+  operationCount: number
+  /**
+   * Random-access loader for a schema by name. Returns `undefined` when missing.
+   */
+  loadSchema(name: string): Promise<SchemaNode | undefined>
+  /**
+   * Random-access loader for an operation by id. Returns `undefined` when missing.
+   */
+  loadOperation(id: string): Promise<OperationNode | undefined>
+  /**
+   * Optional cleanup hook called by `createKubb` after the build completes.
+   * Adapters that persist nodes to `config.storage` should remove their own
+   * cache namespace here instead of clearing the whole `.kubb/.cache` tree.
+   */
+  dispose?(): Promise<void>
+}
 
 /**
  * Generic type parameters for an adapter definition.
@@ -59,9 +128,23 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
   document: TOptions['document'] | null
   inputNode: InputNode | null
   /**
-   * Parse the source into a universal `InputNode`.
+   * Streaming view over schemas / operations when the adapter persists nodes
+   * outside the `InputNode` (typically to `config.storage` under
+   * `.kubb/.cache`). When set, `createKubb` walks this source instead of
+   * iterating `inputNode.schemas` / `inputNode.operations` directly.
+   *
+   * `null` (or unset) means the adapter materialized everything into
+   * `inputNode` and there is no streaming view.
    */
-  parse: (source: AdapterSource) => PossiblePromise<InputNode>
+  source?: AdapterStreamSource | null
+  /**
+   * Parse the source into a universal `InputNode`.
+   *
+   * The optional `context` is supplied by `createKubb` and exposes
+   * `config.storage` so adapters can persist parsed schemas / operations to
+   * disk and expose them via `Adapter.source`.
+   */
+  parse: (source: AdapterSource, context?: AdapterParseContext) => PossiblePromise<InputNode>
   /**
    * Extract `ImportNode` entries for a schema tree.
    * Returns an empty array before the first `parse()` call.

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -3,7 +3,7 @@ import { version as nodeVersion } from 'node:process'
 import type { PossiblePromise } from '@internals/utils'
 import { AsyncEventEmitter, BuildError, exists, formatMs, getElapsedMs, URLPath } from '@internals/utils'
 import type { FileNode, InputNode, OperationNode, SchemaNode } from '@kubb/ast'
-import { collectUsedSchemaNames, transform, walk } from '@kubb/ast'
+import { collect, collectReferencedSchemaNames, collectUsedSchemaNames, transform, walk } from '@kubb/ast'
 import { version as KubbVersion } from '../package.json'
 import { DEFAULT_BANNER, DEFAULT_EXTENSION, DEFAULT_STUDIO_URL } from './constants.ts'
 import type { Adapter, AdapterSource } from './createAdapter.ts'
@@ -531,7 +531,7 @@ export interface KubbHooks {
   'kubb:build:end': [ctx: KubbBuildEndContext]
   'kubb:generate:schema': [node: SchemaNode, ctx: GeneratorContext]
   'kubb:generate:operation': [node: OperationNode, ctx: GeneratorContext]
-  'kubb:generate:operations': [nodes: Array<OperationNode>, ctx: GeneratorContext]
+  'kubb:generate:operations': [nodes: AsyncIterable<OperationNode>, ctx: GeneratorContext]
 }
 
 export type KubbBuildStartContext = {
@@ -835,14 +835,17 @@ async function setup(userConfig: UserConfig, options: SetupOptions = {}): Promis
     })
 
     driver.adapter = config.adapter
-    driver.inputNode = await config.adapter.parse(source)
+    driver.inputNode = await config.adapter.parse(source, { storage: config.storage, root: config.root })
+
+    const schemaCount = config.adapter.source?.schemaCount ?? driver.inputNode.schemas.length
+    const operationCount = config.adapter.source?.operationCount ?? driver.inputNode.operations.length
 
     await hooks.emit('kubb:debug', {
       date: new Date(),
       logs: [
         `✓ Adapter '${config.adapter.name}' resolved InputNode`,
-        `  • Schemas: ${driver.inputNode.schemas.length}`,
-        `  • Operations: ${driver.inputNode.operations.length}`,
+        `  • Schemas: ${schemaCount}`,
+        `  • Operations: ${operationCount}`,
       ],
     })
   }
@@ -878,7 +881,12 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
   }
 
   const generators = plugin.generators ?? []
-  const collectedOperations: Array<OperationNode> = []
+  /**
+   * Operation ids matched by the per-operation walk above. Stored as ids
+   * (not full nodes) so peak memory stays bounded; the batch `operations`
+   * generator hook re-streams them via `inputNode.loadOperation`.
+   */
+  const matchedOperationIds: string[] = []
 
   const generatorContext = {
     ...context,
@@ -893,74 +901,132 @@ async function runPluginAstHooks(plugin: NormalizedPlugin, context: GeneratorCon
   const hasOperationBasedIncludes = include?.some(({ type }) => operationFilterTypes.has(type)) ?? false
   const hasSchemaNameIncludes = include?.some(({ type }) => type === 'schemaName') ?? false
 
+  // Streaming source supplied by the adapter. When absent, fall back to the
+  // arrays on `inputNode` so adapters that materialize everything up front
+  // still work without an explicit source.
+  const source = adapter.source ?? null
+
   let allowedSchemaNames: Set<string> | undefined
   if (hasOperationBasedIncludes && !hasSchemaNameIncludes) {
-    const includedOps = inputNode.operations.filter((op) => resolver.resolveOptions(op, { options: plugin.options, exclude, include, override }) !== null)
-    allowedSchemaNames = collectUsedSchemaNames(includedOps, inputNode.schemas)
-  }
-
-  await walk(inputNode, {
-    depth: 'shallow',
-    async schema(node) {
-      const transformedNode = plugin.transformer ? transform(node, plugin.transformer) : node
-
-      // Skip named top-level schemas that are not reachable from any included operation.
-      if (allowedSchemaNames !== undefined && transformedNode.name && !allowedSchemaNames.has(transformedNode.name)) {
-        return
+    if (source) {
+      // Stream operations to collect directly-used ref names, then BFS through
+      // a ref-name-only schema graph. Avoids materializing full schema bodies.
+      const directlyUsed = new Set<string>()
+      for await (const op of source.operations) {
+        if (resolver.resolveOptions(op, { options: plugin.options, exclude, include, override }) === null) continue
+        for (const schema of collect<SchemaNode>(op, { depth: 'shallow', schema: (node) => node })) {
+          for (const name of collectReferencedSchemaNames(schema)) directlyUsed.add(name)
+        }
       }
 
-      const options = resolver.resolveOptions(transformedNode, {
-        options: plugin.options,
-        exclude,
-        include,
-        override,
-      })
-      if (options === null) return
+      const refGraph = new Map<string, Set<string>>()
+      for await (const schema of source.schemas) {
+        if (!schema.name) continue
+        refGraph.set(schema.name, collectReferencedSchemaNames(schema))
+      }
+
+      allowedSchemaNames = new Set<string>()
+      const stack = [...directlyUsed]
+      while (stack.length > 0) {
+        const name = stack.pop()!
+        if (allowedSchemaNames.has(name)) continue
+        allowedSchemaNames.add(name)
+        const refs = refGraph.get(name)
+        if (refs) for (const r of refs) stack.push(r)
+      }
+    } else {
+      const includedOps = inputNode.operations.filter((op) => resolver.resolveOptions(op, { options: plugin.options, exclude, include, override }) !== null)
+      allowedSchemaNames = collectUsedSchemaNames(includedOps, inputNode.schemas)
+    }
+  }
+
+  async function emitSchema(node: SchemaNode): Promise<void> {
+    const transformedNode = plugin.transformer ? transform(node, plugin.transformer) : node
+
+    // Skip named top-level schemas that are not reachable from any included operation.
+    if (allowedSchemaNames !== undefined && transformedNode.name && !allowedSchemaNames.has(transformedNode.name)) {
+      return
+    }
+
+    const options = resolver.resolveOptions(transformedNode, {
+      options: plugin.options,
+      exclude,
+      include,
+      override,
+    })
+    if (options === null) return
+
+    const ctx = { ...generatorContext, options }
+
+    for (const gen of generators) {
+      if (!gen.schema) continue
+      const result = await gen.schema(transformedNode, ctx)
+      await applyHookResult(result, driver, resolveRenderer(gen))
+    }
+
+    await driver.hooks.emit('kubb:generate:schema', transformedNode, ctx)
+  }
+
+  async function emitOperation(node: OperationNode): Promise<void> {
+    const transformedNode = plugin.transformer ? transform(node, plugin.transformer) : node
+    const options = resolver.resolveOptions(transformedNode, {
+      options: plugin.options,
+      exclude,
+      include,
+      override,
+    })
+    if (options !== null) {
+      if (transformedNode.operationId) {
+        matchedOperationIds.push(transformedNode.operationId)
+      }
 
       const ctx = { ...generatorContext, options }
 
       for (const gen of generators) {
-        if (!gen.schema) continue
-        const result = await gen.schema(transformedNode, ctx)
+        if (!gen.operation) continue
+        const result = await gen.operation(transformedNode, ctx)
         await applyHookResult(result, driver, resolveRenderer(gen))
       }
 
-      await driver.hooks.emit('kubb:generate:schema', transformedNode, ctx)
-    },
-    async operation(node) {
-      const transformedNode = plugin.transformer ? transform(node, plugin.transformer) : node
-      const options = resolver.resolveOptions(transformedNode, {
-        options: plugin.options,
-        exclude,
-        include,
-        override,
-      })
-      if (options !== null) {
-        collectedOperations.push(transformedNode)
+      await driver.hooks.emit('kubb:generate:operation', transformedNode, ctx)
+    }
+  }
 
-        const ctx = { ...generatorContext, options }
+  if (source) {
+    for await (const schema of source.schemas) await emitSchema(schema)
+    for await (const operation of source.operations) await emitOperation(operation)
+  } else {
+    await walk(inputNode, {
+      depth: 'shallow',
+      async schema(node) {
+        await emitSchema(node)
+      },
+      async operation(node) {
+        await emitOperation(node)
+      },
+    })
+  }
 
-        for (const gen of generators) {
-          if (!gen.operation) continue
-          const result = await gen.operation(transformedNode, ctx)
-          await applyHookResult(result, driver, resolveRenderer(gen))
-        }
-
-        await driver.hooks.emit('kubb:generate:operation', transformedNode, ctx)
-      }
-    },
-  })
-
-  if (collectedOperations.length > 0) {
+  if (matchedOperationIds.length > 0) {
     const ctx = { ...generatorContext, options: plugin.options }
+
+    const matchedOperations: AsyncIterable<OperationNode> = {
+      async *[Symbol.asyncIterator]() {
+        for (const id of matchedOperationIds) {
+          const op = source ? await source.loadOperation(id) : inputNode.operations.find((o) => o.operationId === id)
+          if (!op) continue
+          yield plugin.transformer ? transform(op, plugin.transformer) : op
+        }
+      },
+    }
 
     for (const gen of generators) {
       if (!gen.operations) continue
-      const result = await gen.operations(collectedOperations, ctx)
+      const result = await gen.operations(matchedOperations, ctx)
       await applyHookResult(result, driver, resolveRenderer(gen))
     }
 
-    await driver.hooks.emit('kubb:generate:operations', collectedOperations, ctx)
+    await driver.hooks.emit('kubb:generate:operations', matchedOperations, ctx)
   }
 }
 
@@ -1134,6 +1200,11 @@ async function safeBuild(setupResult: SetupResult): Promise<BuildOutput> {
       sources,
     }
   } finally {
+    // Let the adapter clean up any cache it persisted to `config.storage`.
+    // Errors are non-fatal — caches are tolerant of stale entries.
+    try {
+      await driver.adapter?.source?.dispose?.()
+    } catch {}
     driver.dispose()
   }
 }

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -159,8 +159,13 @@ export type Generator<TOptions extends PluginFactoryOptions = PluginFactoryOptio
    * Called once after all operations have been walked.
    * `ctx` carries the plugin context with `adapter` and `inputNode` guaranteed present,
    * plus `ctx.options` with the plugin-level options for the batch call.
+   *
+   * `nodes` is an `AsyncIterable` so the runtime can stream operations from
+   * storage instead of buffering them all in memory. Generators that need
+   * random access should pull each operation from `ctx.inputNode.loadOperation`
+   * using `nodes` (or `inputNode.operationIds`) as the iteration order.
    */
-  operations?: (nodes: Array<OperationNode>, ctx: GeneratorContext<TOptions>) => PossiblePromise<TElement | Array<FileNode> | void>
+  operations?: (nodes: AsyncIterable<OperationNode>, ctx: GeneratorContext<TOptions>) => PossiblePromise<TElement | Array<FileNode> | void>
 }
 
 /**

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -435,7 +435,11 @@ describe('PluginDriver — generator event dispatch', () => {
       inputNode: {},
       options: {},
     } as unknown as GeneratorContext
-    const fakeNodes = [{ kind: 'Operation', operationId: 'getPet' }] as unknown as Array<OperationNode>
+    const fakeNodes: AsyncIterable<OperationNode> = {
+      async *[Symbol.asyncIterator]() {
+        yield { kind: 'Operation', operationId: 'getPet' } as unknown as OperationNode
+      },
+    }
 
     await events.emit('kubb:generate:operations', fakeNodes, fakeCtx)
     expect(operationsMock).toHaveBeenCalledOnce()

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -169,7 +169,12 @@ export async function renderGeneratorOperations<TOptions extends PluginFactoryOp
   if (!generator.operations) return
   const context = createMockedPluginContext(opts)
   const transformedNodes = opts.plugin.transformer ? nodes.map((n) => transform(n, opts.plugin.transformer!)) : nodes
-  const result = await generator.operations(transformedNodes, {
+  const asyncNodes: AsyncIterable<OperationNode> = {
+    async *[Symbol.asyncIterator]() {
+      for (const node of transformedNodes) yield node
+    },
+  }
+  const result = await generator.operations(asyncNodes, {
     ...context,
     options: opts.options,
   })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,5 @@
 export type { DevtoolsOptions } from './devtools.ts'
-export type { Adapter, AdapterFactoryOptions, AdapterSource } from './createAdapter.ts'
+export type { Adapter, AdapterFactoryOptions, AdapterParseContext, AdapterSource, AdapterStreamSource } from './createAdapter.ts'
 export type {
   BuildOutput,
   CLIOptions,


### PR DESCRIPTION
## Summary

- `adapter-oas` now writes each parsed schema and operation as JSON to `config.storage` under a per-build `.kubb/.cache/<namespace>/` directory.
- A new `Adapter.source` (`AdapterStreamSource`) exposes the streaming view (`AsyncIterable<SchemaNode>` / `AsyncIterable<OperationNode>` + `loadSchema` / `loadOperation` + names/ids + counts).
- `createKubb` walks `adapter.source` when present so only one schema/operation lives in memory per plugin pass.
- `InputNode` stays JSON-safe primitives (`schemas: Array<SchemaNode>`, `operations: Array<OperationNode>`). Adapters that materialize up front (no `source`) keep working unchanged.
- New `adapterOas({ bundle: false })` opt-out for Redocly's pre-parse bundling on very large specs.
- `operations` generator hook now takes `AsyncIterable<OperationNode>` instead of `Array<OperationNode>`.
- Per-build cache lifecycle is owned by the adapter via `source.dispose()`; nothing under `.kubb/.cache` leaks across builds.

## Test plan

- [x] `pnpm --filter @kubb/ast --filter @kubb/core --filter @kubb/adapter-oas typecheck`
- [x] `pnpm --filter @kubb/ast --filter @kubb/core test` — 427 tests pass
- [x] `pnpm --filter @kubb/ast --filter @kubb/core --filter @kubb/adapter-oas build`
- [x] Verified `adapter.source` round-trip end-to-end via the plugins repo test suite (all 860 pass on the matching branch).
- [ ] Stripe perf benchmark in the plugins repo: streaming AST helps but the OAS parser's ref inlining still dominates Stripe memory; tracked as a follow-up.

## Companion PR

Plugins repo: `kubb-labs/plugins#claude/optimize-ast-storage-2dmjK`

https://claude.ai/code/session_01WH64S6KHuNvqR5joeABYjj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WH64S6KHuNvqR5joeABYjj)_