### PR TITLE
refactor: remove inputNode from Adapter interface

### DIFF
--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -44,10 +44,8 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     emptySchemaType = unknownType || DEFAULT_PARSER_OPTIONS.emptySchemaType,
   } = options
 
-  // Let-binding so parse() can replace it with a simple reassignment (no clear+loop).
   let nameMapping = new Map<string, string>()
   let parsedDocument: Document | null
-  let inputNode: ast.InputNode | null
 
   return {
     name: adapterOasName,
@@ -111,7 +109,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       // Expose the raw document so consumers (e.g. plugin-redoc) can access it.
       parsedDocument = document
 
-      inputNode = ast.createInput({
+      const inputNode = ast.createInput({
         ...node,
         meta: {
           title: document.info?.title,

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -69,9 +69,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     get document() {
       return parsedDocument
     },
-    get inputNode() {
-      return inputNode
-    },
     async validate(input, options) {
       const document = await parseDocument(input)
       await validateDocument(document, options)

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -57,7 +57,6 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
    * Parsed source document after the first `parse()` call. `null` before parsing.
    */
   document: TOptions['document'] | null
-  inputNode: InputNode | null
   /**
    * Parse the source into a universal `InputNode`.
    */

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path'
-import type { FileNode, OperationNode, SchemaNode, Visitor } from '@kubb/ast'
+import type { FileNode, InputNode, OperationNode, SchemaNode, Visitor } from '@kubb/ast'
 import { transform } from '@kubb/ast'
 import { FileManager } from './FileManager.ts'
 import { applyHookResult, PluginDriver } from './PluginDriver.ts'
@@ -34,16 +34,13 @@ export function createMockedAdapter<TOptions extends AdapterFactoryOptions = Ada
   options: {
     name?: TOptions['name']
     resolvedOptions?: TOptions['resolvedOptions']
-    inputNode?: Adapter<TOptions>['inputNode']
     parse?: Adapter<TOptions>['parse']
     getImports?: Adapter<TOptions>['getImports']
   } = {},
 ): Adapter<TOptions> {
-  const inputNode = options.inputNode ?? null
   return {
     name: (options.name ?? 'oas') as TOptions['name'],
     options: (options.resolvedOptions ?? {}) as TOptions['resolvedOptions'],
-    inputNode,
     parse: options.parse ?? (async () => ({ kind: 'Input' as const, schemas: [], operations: [] })),
     getImports: options.getImports ?? ((_node: SchemaNode, _resolve: (schemaName: string) => { name: string; path: string }) => []),
   } as Adapter<TOptions>
@@ -75,6 +72,7 @@ export function createMockedPlugin<TOptions extends PluginFactoryOptions = Plugi
 type RenderGeneratorOptions<TOptions extends PluginFactoryOptions> = {
   config: Config
   adapter: Adapter
+  inputNode?: InputNode
   driver: PluginDriver
   plugin: NormalizedPlugin<TOptions>
   options: TOptions['resolvedOptions']
@@ -93,7 +91,7 @@ function createMockedPluginContext<TOptions extends PluginFactoryOptions>(opts: 
     plugin: opts.plugin,
     driver: opts.driver,
     getResolver: (name: string) => opts.driver.getResolver(name),
-    inputNode: { kind: 'Input', schemas: [], operations: [] },
+    inputNode: opts.inputNode ?? { kind: 'Input', schemas: [], operations: [] },
     addFile: async (...files: Array<FileNode>) => opts.driver.fileManager.add(...files),
     upsertFile: async (...files: Array<FileNode>) => opts.driver.fileManager.upsert(...files),
     hooks: opts.driver.hooks ?? ({} as never),


### PR DESCRIPTION
## Summary

- Remove `inputNode: InputNode | null` from the `Adapter<TOptions>` type in `createAdapter.ts`
- Remove the `get inputNode()` getter from `adapterOas` in `adapter-oas/src/adapter.ts`
- Update `createMockedAdapter` in `mocks.ts` to drop the `inputNode` option; add `inputNode?: InputNode` to `RenderGeneratorOptions` so tests can pass it directly to the generator context

## Motivation

`GeneratorContext` already exposes `inputNode: InputNode` as a guaranteed-non-null field when generators run. Storing the same (potentially large) parsed AST on the adapter as well doubled its memory footprint for no benefit. Plugins now read from `ctx.inputNode` directly.

## Test plan

- [ ] `pnpm typecheck` passes in kubb repo
- [ ] `pnpm test` passes in kubb repo
- [ ] Companion PR in kubb-labs/plugins updates all call sites

https://claude.ai/code/session_01Um1gYNswDED59mYFW2Y7m5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Um1gYNswDED59mYFW2Y7m5)_