### PR TITLE
feat: WeakMap/WeakSet for GC-eligible keying + generator-based barrel file emission

### DIFF
--- a/.changeset/barrel-getbarrelfiles-generator.md
+++ b/.changeset/barrel-getbarrelfiles-generator.md
@@ -1,0 +1,18 @@
+---
+'@kubb/middleware-barrel': minor
+---
+
+`getBarrelFiles` now returns a `Generator<FileNode>` instead of `Array<FileNode>`.
+
+Iterate with `for...of` or spread into an array to preserve existing behaviour:
+
+```ts
+// before
+const files = getBarrelFiles({ ... })
+
+// after — iterate incrementally
+for (const file of getBarrelFiles({ ... })) { ... }
+
+// after — spread to get an array
+const files = [...getBarrelFiles({ ... })]
+```

--- a/cspell.json
+++ b/cspell.json
@@ -101,6 +101,8 @@
     "picklist",
     "valibot",
     "Valibot",
-    "bunx"
+    "bunx",
+    "WeakMap",
+    "WeakSet"
   ]
 }

--- a/internals/utils/src/buildTree.ts
+++ b/internals/utils/src/buildTree.ts
@@ -41,7 +41,8 @@ export function buildTree(rootPath: string, filePaths: ReadonlyArray<string>): B
   const normalizedRoot = toPosixPath(rootPath)
   const root: BuildTree = { path: normalizedRoot, children: [], isFile: false }
   // Per-directory child lookup avoids the O(N) `Array.find` scan during insertion.
-  const childIndex = new Map<BuildTree, Map<string, BuildTree>>()
+  // WeakMap keyed by object identity so directory nodes are GC-eligible once the tree is discarded.
+  const childIndex = new WeakMap<BuildTree, Map<string, BuildTree>>()
   childIndex.set(root, new Map())
 
   const rootPrefix = `${normalizedRoot}/`

--- a/internals/utils/src/context.ts
+++ b/internals/utils/src/context.ts
@@ -5,14 +5,17 @@
 export type Context<T> = symbol & { readonly __type: T }
 
 /**
- * Context stack for tracking the current context values
+ * Context stack for tracking the current context values.
  *
- * Note: This uses a global Map for simplicity in code generation scenarios.
+ * WeakMap keyed by symbol so entries are GC-eligible once no external code
+ * holds a reference to the context key — important for long-running agent
+ * builds where plugins create and discard context keys across repeated runs.
+ *
  * For concurrent runtime execution, consider using AsyncLocalStorage or
  * instance-based context management.
  */
-const contextStack = new Map<symbol, unknown[]>()
-const contextDefaults = new Map<symbol, unknown>()
+const contextStack = new WeakMap<symbol, unknown[]>()
+const contextDefaults = new WeakMap<symbol, unknown>()
 
 /**
  * Provides a value to descendant components (Vue 3 style)

--- a/packages/middleware-barrel/src/middleware.ts
+++ b/packages/middleware-barrel/src/middleware.ts
@@ -98,16 +98,8 @@ export const middlewareBarrel = defineMiddleware(() => {
         if (relative.startsWith('..') || path.isAbsolute(relative)) {
           throw new Error('Invalid output path')
         }
-        const barrelFiles = getBarrelFiles({
-          outputPath: target,
-          files,
-          barrelType,
-          nested,
-          recursive: true,
-        })
-
-        if (barrelFiles.length > 0) {
-          upsertFile(...barrelFiles)
+        for (const file of getBarrelFiles({ outputPath: target, files, barrelType, nested, recursive: true })) {
+          upsertFile(file)
         }
       },
       'kubb:plugins:end'({ files, config, upsertFile }) {
@@ -120,14 +112,8 @@ export const middlewareBarrel = defineMiddleware(() => {
 
         const barrelType = barrelConfig.type
 
-        const rootBarrelFiles = getBarrelFiles({
-          outputPath: resolve(config.root, config.output.path),
-          files: filteredFiles,
-          barrelType,
-        })
-
-        if (rootBarrelFiles.length > 0) {
-          upsertFile(...rootBarrelFiles)
+        for (const file of getBarrelFiles({ outputPath: resolve(config.root, config.output.path), files: filteredFiles, barrelType })) {
+          upsertFile(file)
         }
       },
     },

--- a/packages/middleware-barrel/src/utils.test.ts
+++ b/packages/middleware-barrel/src/utils.test.ts
@@ -29,13 +29,13 @@ const ROOT = '/workspace/src/gen/types'
 
 describe('getBarrelFiles', () => {
   it('returns an empty array when there are no files under outputPath', () => {
-    const result = getBarrelFiles({ outputPath: ROOT, files: [], barrelType: 'all' })
+    const result = [...getBarrelFiles({ outputPath: ROOT, files: [], barrelType: 'all' })]
     expect(result).toHaveLength(0)
   })
 
   it('generates a single wildcard barrel for flat files with barrelType all', () => {
     const files = [makeFile(`${ROOT}/pet.ts`), makeFile(`${ROOT}/user.ts`)]
-    const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all' })
+    const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all' })]
 
     expect(barrels).toHaveLength(1)
     expect(barrels[0]!.path).toBe(`${ROOT}/index.ts`)
@@ -44,7 +44,7 @@ describe('getBarrelFiles', () => {
 
   it('generates named exports with barrelType named', () => {
     const files = [makeFile(`${ROOT}/pet.ts`, ['Pet', 'createPet'])]
-    const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'named' })
+    const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'named' })]
 
     expect(barrels).toHaveLength(1)
     expect(barrels[0]!.exports[0]?.name).toEqual(expect.arrayContaining(['Pet', 'createPet']))
@@ -52,14 +52,14 @@ describe('getBarrelFiles', () => {
 
   it('generates hierarchical barrels when nested is true', () => {
     const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
-    const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', nested: true })
+    const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', nested: true })]
 
     expect(barrels.map((b) => b.path)).toEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
   })
 
   it('generates per-subdirectory barrels when recursive is true', () => {
     const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
-    const barrels = getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', recursive: true })
+    const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', recursive: true })]
 
     expect(barrels.map((b) => b.path)).toEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
   })

--- a/packages/middleware-barrel/src/utils.ts
+++ b/packages/middleware-barrel/src/utils.ts
@@ -99,9 +99,10 @@ type LeafWalkParams = {
 }
 
 /**
- * Post-order walk that emits a barrel per visited directory.
+ * Post-order walk that yields a barrel per visited directory.
+ * Returns the list of leaf file paths collected in this subtree (used by the parent call).
  */
-function walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean, out: Array<FileNode>): Array<string> {
+function* walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean): Generator<FileNode, string[]> {
   const subtreeLeaves: Array<string> = []
 
   for (const child of node.children) {
@@ -110,7 +111,7 @@ function walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean
       continue
     }
 
-    const childLeaves = walkAllOrNamed(child, params, false, out)
+    const childLeaves = yield* walkAllOrNamed(child, params, false)
     for (const leaf of childLeaves) subtreeLeaves.push(leaf)
   }
 
@@ -119,17 +120,17 @@ function walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean
   const exports = subtreeLeaves.flatMap((leafPath) => params.strategy({ dirPath: node.path, leafPath, sourceFile: params.sourceFiles.get(leafPath) }))
 
   if (exports.length > 0) {
-    out.push(makeBarrel(node.path, exports))
+    yield makeBarrel(node.path, exports)
   }
 
   return subtreeLeaves
 }
 
 /**
- * Recursive walk that emits one barrel per directory, re-exporting files and sub-barrels.
+ * Recursive walk that yields one barrel per directory, re-exporting files and sub-barrels.
  * Used when nested: true.
  */
-function walkNested(node: BuildTree, out: Array<FileNode>): void {
+function* walkNested(node: BuildTree): Generator<FileNode> {
   const exports: Array<ExportNode> = []
 
   for (const child of node.children) {
@@ -139,12 +140,12 @@ function walkNested(node: BuildTree, out: Array<FileNode>): void {
       continue
     }
 
-    walkNested(child, out)
+    yield* walkNested(child)
     exports.push(createExport({ path: toRelativeModulePath(node.path, `${child.path}${BARREL_SUFFIX}`) }))
   }
 
   if (exports.length > 0) {
-    out.push(makeBarrel(node.path, exports))
+    yield makeBarrel(node.path, exports)
   }
 }
 
@@ -204,26 +205,32 @@ type GetBarrelFilesParams = {
 }
 
 /**
- * Generates barrel `FileNode`s for the directory rooted at `outputPath`.
+ * Yields barrel `FileNode`s for the directory rooted at `outputPath`.
+ *
+ * @example
+ * ```ts
+ * for (const file of getBarrelFiles({ outputPath, files, barrelType })) {
+ *   upsertFile(file)
+ * }
+ * // or collect into an array
+ * const barrels = [...getBarrelFiles({ outputPath, files, barrelType })]
+ * ```
  */
-export function getBarrelFiles({ outputPath, files, barrelType, nested = false, recursive = false }: GetBarrelFilesParams): Array<FileNode> {
+export function* getBarrelFiles({ outputPath, files, barrelType, nested = false, recursive = false }: GetBarrelFilesParams): Generator<FileNode> {
   const { sourceFiles, paths } = indexRelevantFiles(files, outputPath)
-  if (paths.length === 0) return []
+  if (paths.length === 0) return
 
   const tree = buildTree(outputPath, paths)
-  const result: Array<FileNode> = []
 
-  // Use nested walk for hierarchical barrel structure
   if (nested) {
-    walkNested(tree, result)
-    return result
+    yield* walkNested(tree)
+    return
   }
 
   const strategy = LEAF_STRATEGIES.get(barrelType)
-  if (!strategy) return result
+  if (!strategy) return
 
-  walkAllOrNamed(tree, { sourceFiles, strategy, recursive }, true, result)
-  return result
+  yield* walkAllOrNamed(tree, { sourceFiles, strategy, recursive }, true)
 }
 
 /**


### PR DESCRIPTION
## Summary

- **`buildTree`**: replaced `Map<BuildTree, …>` with `WeakMap<BuildTree, …>` — directory nodes become GC-eligible after the tree is discarded
- **`context`**: replaced both module-level `Map<symbol, …>` with `WeakMap<symbol, …>` — context keys created by short-lived plugin runs in the agent HTTP server can be collected between builds instead of accumulating indefinitely
- **`middleware-barrel`**: converted `walkAllOrNamed`, `walkNested`, and `getBarrelFiles` to generator functions — barrel `FileNode`s are yielded one at a time, and the middleware upserts them incrementally via `for…of`, eliminating the temporary accumulator array

## Breaking change

`getBarrelFiles` now returns `Generator<FileNode>` instead of `Array<FileNode>`. Update call sites:

```ts
// before
const files = getBarrelFiles({ ... })
upsertFile(...files)

// after
for (const file of getBarrelFiles({ ... })) {
  upsertFile(file)
}
// or spread to get an array
const files = [...getBarrelFiles({ ... })]
```

## Test plan

- [ ] `pnpm --filter @kubb/middleware-barrel test` — all 11 tests pass
- [ ] `pnpm --filter @internals/utils test` — all 196 tests pass
- [ ] `pnpm typecheck` — no new errors
