### PR TITLE
fix: process all defineConfig array entries even when one fails

### DIFF
--- a/.changeset/fix-multiple-config-defineconfig.md
+++ b/.changeset/fix-multiple-config-defineconfig.md
@@ -1,0 +1,12 @@
+---
+'@kubb/cli': patch
+'@kubb/core': patch
+---
+
+Fix multiple configs in `defineConfig` array stopping after the first failure.
+
+Two bugs caused only one schema to be processed when using `defineConfig` with an array of configs:
+
+1. **`@kubb/cli`**: `process.exit(1)` was called immediately when any config failed, killing the process before remaining configs could run. Each config is now processed independently; the process exits with code 1 after all configs complete if any failed.
+
+2. **`@kubb/core`**: Middleware hooks registered during `setup()` were never removed from the shared `hooks` instance between config runs, causing N middleware instances to fire for the N-th config and producing duplicate output. Middleware listeners are now tracked and removed via `SetupResult.dispose()` at the end of each build.

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -117,7 +117,7 @@ async function runToolPass({
   }
 }
 
-async function generate(options: GenerateProps): Promise<void> {
+async function generate(options: GenerateProps): Promise<boolean> {
   const { input, hooks, logLevel, makeSink } = options
 
   const hrStart = process.hrtime()
@@ -163,7 +163,7 @@ async function generate(options: GenerateProps): Promise<void> {
     })
 
     await reportTelemetry('failed')
-    process.exit(1)
+    return false
   }
 
   await hooks.emit('kubb:success', { message: 'Generation succeeded', info: inputPath })
@@ -207,6 +207,7 @@ async function generate(options: GenerateProps): Promise<void> {
   await hooks.emit('kubb:generation:summary', { config, failedPlugins, filesCreated: files.length, status: 'success', hrStart, pluginTimings })
 
   await reportTelemetry('success')
+  return true
 }
 
 type GenerateCommandOptions = {
@@ -252,6 +253,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch }: G
     await hooks.emit('kubb:config:end', { configs })
     await hooks.emit('kubb:lifecycle:start', { version })
 
+    let anyFailed = false
     for (const config of configs) {
       if (isInputPath(config) && watch) {
         await startWatcher(
@@ -264,11 +266,21 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch }: G
           { info: (msg) => clack.log.info(msg), error: (msg) => clack.log.error(msg) },
         )
       } else {
-        await generate({ input, config, logLevel, hooks, makeSink })
+        try {
+          const succeeded = await generate({ input, config, logLevel, hooks, makeSink })
+          if (!succeeded) anyFailed = true
+        } catch (configError) {
+          await hooks.emit('kubb:error', { error: toError(configError) })
+          anyFailed = true
+        }
       }
     }
 
     await hooks.emit('kubb:lifecycle:end')
+
+    if (anyFailed) {
+      process.exit(1)
+    }
   } catch (error) {
     await hooks.emit('kubb:error', { error: toError(error) })
     process.exit(1)

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -777,6 +777,7 @@ type SetupResult = {
   driver: PluginDriver
   storage: Storage
   config: Config
+  dispose: () => void
 }
 
 /**
@@ -901,10 +902,15 @@ async function setup(userConfig: UserConfig, options: SetupOptions = {}): Promis
   // Register middleware hooks after all plugin hooks are registered.
   // Because AsyncEventEmitter calls listeners in registration order,
   // middleware hooks for any event fire after all plugin hooks for that event.
+  // Handlers are tracked so they can be removed after each build (disposeMiddleware),
+  // preventing accumulation when multiple configs share the same hooks instance.
+  const middlewareListeners: Array<[keyof KubbHooks & string, (...args: never[]) => void | Promise<void>]> = []
+
   function registerMiddlewareHook<K extends keyof KubbHooks & string>(event: K, middlewareHooks: Middleware['hooks']) {
     const handler = middlewareHooks[event]
     if (handler) {
       hooks.on(event, handler)
+      middlewareListeners.push([event, handler as (...args: never[]) => void | Promise<void>])
     }
   }
 
@@ -940,6 +946,12 @@ async function setup(userConfig: UserConfig, options: SetupOptions = {}): Promis
     hooks,
     driver,
     storage,
+    dispose: () => {
+      driver.dispose()
+      for (const [event, handler] of middlewareListeners) {
+        hooks.off(event, handler as never)
+      }
+    },
   }
 }
 
@@ -1239,7 +1251,7 @@ async function safeBuild(setupResult: SetupResult): Promise<BuildOutput> {
       storage,
     }
   } finally {
-    driver.dispose()
+    setupResult.dispose()
   }
 }
 


### PR DESCRIPTION
## Summary

- **`@kubb/cli`**: `process.exit(1)` inside `generate()` killed the process on the first config failure, preventing any subsequent configs in a `defineConfig` array from running. Each config is now processed independently in a per-config try/catch; the process exits with code 1 only after all configs complete.
- **`@kubb/core`**: Middleware hooks registered during `setup()` were never removed from the shared `hooks` instance between config runs. By the N-th config, N copies of each middleware handler fired, causing duplicate barrel file writes and other repeated side-effects. Middleware listeners are now tracked alongside plugin listeners and cleaned up via a unified `SetupResult.dispose()` at the end of each build.

## Test plan

- [ ] Run `kubb generate` against a `kubb.config.js` that exports an array of 2+ configs — all should now generate, not just the first
- [ ] Confirm that when one config fails (e.g. bad input path), remaining configs still run and the exit code is still 1
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (72 files, 1329 tests)

https://claude.ai/code/session_013EmDgG1zySo2k84FMFjnxN

---
_Generated by [Claude Code](https://claude.ai/code/session_013EmDgG1zySo2k84FMFjnxN)_