### PR TITLE
fix: pin plugin oas to 4.37.5 in setup wizard

### DIFF
--- a/.changeset/swift-trains-chew.md
+++ b/.changeset/swift-trains-chew.md
@@ -1,0 +1,5 @@
+---
+"@kubb/cli": patch
+---
+
+Pin version of plugin-oas to 4.37.5 if plugin is required.

--- a/packages/cli/src/runners/init.ts
+++ b/packages/cli/src/runners/init.ts
@@ -257,7 +257,15 @@ export async function runInit({ yes, version }: InitOptions): Promise<void> {
     }
 
     // Install packages
-    const packagesToInstall = ['@kubb/core', '@kubb/cli', '@kubb/agent', ...selectedPlugins.map((p) => p.packageName)]
+    // Pin @kubb/plugin-oas to its last published version (4.37.5) because it
+    // was deprecated and no longer receives releases, so npm cannot resolve a
+    // version matching the newer CLI/core packages (see https://github.com/kubb-labs/kubb/issues/3296).
+    const packagesToInstall = [
+      '@kubb/core',
+      '@kubb/cli',
+      '@kubb/agent',
+      ...selectedPlugins.map((p) => (p.value === 'plugin-oas' ? '@kubb/plugin-oas@4.37.5' : p.packageName)),
+    ]
 
     const spinner = clack.spinner()
     spinner.start(`Installing ${packagesToInstall.length} packages with ${packageManager.name}`)


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
This PR pins the version of plugin-oas used in the init wizard. Otherwise, it would try to find a plugin-oas matching current version even if it doesn't exist.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

Fix #3296 