### PR TITLE
feat: keep format info in schema

### DIFF
--- a/.changeset/cool-jokes-pump.md
+++ b/.changeset/cool-jokes-pump.md
@@ -1,0 +1,5 @@
+---
+"@kubb/adapter-oas": patch
+---
+
+Add format property to SchemaNodeBase.

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -588,6 +588,93 @@ describe('parseSchema contentMediaType (OAS 3.1)', () => {
   })
 })
 
+describe('parseSchema format preservation', () => {
+  const ctx = { document: emptyDocument }
+
+  it('preserves known format on uuid schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'uuid' },
+    })
+
+    expect(node.type).toBe('uuid')
+    expect(node.format).toBe('uuid')
+  })
+
+  it('preserves known format on email schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'email' },
+    })
+
+    expect(node.type).toBe('email')
+    expect(node.format).toBe('email')
+  })
+
+  it('preserves known format on datetime schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'date-time' },
+    })
+
+    expect(node.type).toBe('datetime')
+    expect(node.format).toBe('date-time')
+  })
+
+  it('preserves format when dateType is false (falls through to string)', () => {
+    const node = parseSchema(
+      ctx,
+      { schema: { type: 'string', format: 'date-time' } },
+      { dateType: false },
+    )
+
+    expect(node.type).toBe('string')
+    expect(node.format).toBe('date-time')
+  })
+
+  it('preserves unknown format on string schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'custom-format' },
+    })
+
+    expect(node.type).toBe('string')
+    expect(node.format).toBe('custom-format')
+  })
+
+  it('preserves unknown format with minLength constraint inference', () => {
+    const node = parseSchema(ctx, {
+      schema: { format: 'custom-format', minLength: 1 },
+    })
+
+    expect(node.type).toBe('string')
+    expect(node.format).toBe('custom-format')
+  })
+
+  it('preserves format on numeric schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'number', format: 'double' },
+    })
+
+    expect(node.type).toBe('number')
+    expect(node.format).toBe('double')
+  })
+
+  it('preserves format on int64 schema (default integerType bigint)', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'integer', format: 'int64' },
+    })
+
+    expect(node.type).toBe('bigint')
+    expect(node.format).toBe('int64')
+  })
+
+  it('preserves format on enum schema', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'custom-enum', enum: ['a', 'b'] },
+    })
+
+    expect(node.type).toBe('enum')
+    expect(node.format).toBe('custom-enum')
+  })
+})
+
 describe('parseSchema allOf', () => {
   const ctx = { document: emptyDocument }
 

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -619,11 +619,7 @@ describe('parseSchema format preservation', () => {
   })
 
   it('preserves format when dateType is false (falls through to string)', () => {
-    const node = parseSchema(
-      ctx,
-      { schema: { type: 'string', format: 'date-time' } },
-      { dateType: false },
-    )
+    const node = parseSchema(ctx, { schema: { type: 'string', format: 'date-time' } }, { dateType: false })
 
     expect(node.type).toBe('string')
     expect(node.format).toBe('date-time')

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -169,6 +169,7 @@ function createSchemaParser(ctx: OasParserContext) {
         default: mergedDefault,
         example: schema.example ?? memberNode.example,
         pattern: schema.pattern ?? ('pattern' in memberNode ? memberNode.pattern : undefined),
+        format: schema.format ?? memberNode.format,
       } as ast.DistributiveOmit<ast.SchemaNode, 'kind'>)
     }
 
@@ -359,6 +360,7 @@ function createSchemaParser(ctx: OasParserContext) {
         title: schema.title,
         description: schema.description,
         deprecated: schema.deprecated,
+        format: schema.format,
       })
     }
 
@@ -489,6 +491,7 @@ function createSchemaParser(ctx: OasParserContext) {
       writeOnly: schema.writeOnly,
       default: enumDefault,
       example: schema.example,
+      format: schema.format,
     }
 
     const extensionKey = enumExtensionKeys.find((key) => key in schema)
@@ -702,6 +705,7 @@ function createSchemaParser(ctx: OasParserContext) {
       description: schema.description,
       deprecated: schema.deprecated,
       nullable,
+      format: schema.format,
     })
   }
 
@@ -795,6 +799,7 @@ function createSchemaParser(ctx: OasParserContext) {
       name,
       title: schema.title,
       description: schema.description,
+      format: schema.format,
     })
   }
 

--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -121,6 +121,7 @@ describe('buildSchemaNode', () => {
       readOnly: true,
       writeOnly: false,
       example: 42,
+      format: 'email',
     }
     const node = buildSchemaNode(schema, 'myName', true, 'defaultVal')
 
@@ -134,6 +135,7 @@ describe('buildSchemaNode', () => {
       writeOnly: false,
       default: 'defaultVal',
       example: 42,
+      format: 'email',
     })
   })
 
@@ -144,6 +146,7 @@ describe('buildSchemaNode', () => {
     expect(node.nullable).toBeUndefined()
     expect(node.title).toBeUndefined()
     expect(node.default).toBeUndefined()
+    expect(node.format).toBeUndefined()
   })
 
   it('return type has name and nullable fields', () => {

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -512,6 +512,7 @@ export function buildSchemaNode(schema: SchemaObject, name: string | null | unde
     writeOnly: schema.writeOnly,
     default: defaultValue,
     example: schema.example,
+    format: schema.format,
   } as const
 }
 

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -154,6 +154,10 @@ type SchemaNodeBase = BaseNode & {
    * For example, this is `'string'` for a `uuid` schema.
    */
   primitive?: PrimitiveSchemaType
+  /**
+   * Schema `format` value.
+   */
+  format?: string
 }
 
 /**


### PR DESCRIPTION
## 🎯 Changes

<!-- What changes are made in this PR? Describe the change and its motivation. -->
Add a new property `format` to `SchemaNodeBase` which contains the original `format` value. This will allow downstream plugins to consume the generated format.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

Related https://github.com/kubb-labs/plugins/issues/167