### PR TITLE
feat(kubb): add @kubb/mcp as direct dependency

### DIFF
--- a/.changeset/add-kubb-mcp-dependency.md
+++ b/.changeset/add-kubb-mcp-dependency.md
@@ -1,5 +1,6 @@
 ---
 "kubb": minor
+"@kubb/cli": patch
 ---
 
 Add `@kubb/mcp` as a direct dependency so `kubb mcp` works out of the box without a separate install step.

--- a/.changeset/add-kubb-mcp-dependency.md
+++ b/.changeset/add-kubb-mcp-dependency.md
@@ -1,0 +1,5 @@
+---
+"kubb": minor
+---
+
+Add `@kubb/mcp` as a direct dependency so `kubb mcp` works out of the box without a separate install step.

--- a/packages/cli/src/runners/mcp/run.ts
+++ b/packages/cli/src/runners/mcp/run.ts
@@ -21,26 +21,8 @@ type McpOptions = {
   host?: string
 }
 
-/**
- * Starts the Kubb MCP server using `@kubb/mcp`.
- * Exits the process with code 1 if `@kubb/mcp` is not installed.
- */
 export async function run({ version, port, host }: McpOptions): Promise<void> {
-  let mod: typeof McpModule
-  try {
-    mod = (await import('@kubb/mcp')) as typeof McpModule
-  } catch (_e) {
-    console.error(styleText('red', 'The @kubb/mcp package is not installed.'))
-    console.error('')
-    console.error('Install it with:')
-    console.error(styleText('cyan', '  npm install @kubb/mcp'))
-    console.error(styleText('cyan', '  # or'))
-    console.error(styleText('cyan', '  pnpm install @kubb/mcp'))
-    console.error('')
-    process.exit(1)
-  }
-
-  const { run: startMcpServer } = mod
+  const { run: startMcpServer } = (await import('@kubb/mcp')) as typeof McpModule
   const hrStart = process.hrtime()
   const report = (status: 'success' | 'failed') => sendTelemetry(buildTelemetryEvent({ command: 'mcp', kubbVersion: version, hrStart, status }))
   try {

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -68,6 +68,7 @@
     "@kubb/adapter-oas": "workspace:*",
     "@kubb/cli": "workspace:*",
     "@kubb/core": "workspace:*",
+    "@kubb/mcp": "workspace:*",
     "@kubb/middleware-barrel": "workspace:*",
     "@kubb/parser-ts": "workspace:*",
     "@kubb/renderer-jsx": "workspace:*"
@@ -77,14 +78,10 @@
     "typescript": "catalog:"
   },
   "peerDependencies": {
-    "@kubb/agent": "workspace:*",
-    "@kubb/mcp": "workspace:*"
+    "@kubb/agent": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@kubb/agent": {
-      "optional": true
-    },
-    "@kubb/mcp": {
       "optional": true
     }
   },


### PR DESCRIPTION
## Summary

- Move `@kubb/mcp` from optional `peerDependencies` to `dependencies` in the `kubb` package
- Remove `@kubb/mcp` from `peerDependenciesMeta`
- Simplify the MCP CLI runner — drop the "not installed" error guard since the package is now always bundled with `kubb`
- Add a minor changeset for `kubb`

## Why

Users can now run `kubb mcp` immediately after installing `kubb` with no extra install step required.

## Test plan

- [ ] `pnpm install` completes without errors
- [ ] `kubb mcp` starts the MCP server without prompting to install `@kubb/mcp`
- [ ] CI (lint, typecheck, tests) passes

https://claude.ai/code/session_01KzyyoKnZrzFVapLbDeHaur

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzyyoKnZrzFVapLbDeHaur)_