### PR TITLE
feat: remove publish command from agent WebSocket protocol

### DIFF
--- a/packages/agent/server/plugins/studio.ts
+++ b/packages/agent/server/plugins/studio.ts
@@ -29,7 +29,7 @@ function getErrorMessage(error: unknown): string {
  * so each Studio user gets their own isolated WebSocket session.
  */
 export default defineNitroPlugin(async (nitro) => {
-  const { studioUrl, token, configPath, resolvedConfigPath, retryInterval, heartbeatInterval, root, allowAll, allowWrite, allowPublish, poolSize, hasSecret } =
+  const { studioUrl, token, configPath, resolvedConfigPath, retryInterval, heartbeatInterval, root, allowAll, allowWrite, poolSize, hasSecret } =
     resolveStudioRuntimeConfig(process.env)
 
   if (!token) {
@@ -55,7 +55,6 @@ export default defineNitroPlugin(async (nitro) => {
       resolvedConfigPath,
       allowAll,
       allowWrite,
-      allowPublish,
       root,
       retryInterval,
       heartbeatInterval,

--- a/packages/agent/server/types/agent.ts
+++ b/packages/agent/server/types/agent.ts
@@ -67,20 +67,6 @@ export type KubbHooks = {
 export type KubbHook = keyof KubbHooks
 
 /**
- * Payload for the publish command, sent from Studio to the Agent.
- * The agent uses the command field to run the publish shell command.
- * If command is omitted, the agent falls back to the KUBB_AGENT_PUBLISH_COMMAND
- * env var and then to 'npm publish'.
- */
-export type PublishCommandPayload = {
-  publisher: 'npm'
-  /** Optional shell command override, e.g. 'npm publish --access public' */
-  command?: string
-  /** Arbitrary metadata stored in Studio (name, version, scope, …) */
-  meta?: Record<string, unknown>
-}
-
-/**
  * Command message sent from Studio to Agent
  * Triggers actions like code generation or connection establishment
  */
@@ -92,10 +78,8 @@ export type CommandMessage =
       permissions: {
         allowAll: boolean
         allowWrite: boolean
-        allowPublish: boolean
       }
     }
-  | { type: 'command'; command: 'publish'; payload: PublishCommandPayload }
 
 export type ConnectMessagePayload = {
   version: string
@@ -104,7 +88,6 @@ export type ConnectMessagePayload = {
   permissions: {
     allowAll: boolean
     allowWrite: boolean
-    allowPublish: boolean
   }
 }
 
@@ -165,7 +148,6 @@ export type DataMessagePayload<T extends KubbHook = KubbHook> = {
   type: T
   data: KubbHooks[T]
   timestamp: number
-  source?: 'generate' | 'publish'
 }
 
 /**
@@ -229,8 +211,4 @@ export function isStatusMessage(msg: AgentMessage): msg is StatusMessage {
 
 export function isDisconnectMessage(msg: AgentMessage): msg is DisconnectMessage {
   return msg.type === 'disconnect'
-}
-
-export function isPublishCommandMessage(msg: AgentMessage): msg is CommandMessage & { command: 'publish' } {
-  return msg.type === 'command' && (msg as CommandMessage & { command: string }).command === 'publish'
 }

--- a/packages/agent/server/utils/connectStudio.test.ts
+++ b/packages/agent/server/utils/connectStudio.test.ts
@@ -92,7 +92,6 @@ describe('connectToStudio', () => {
       resolvedConfigPath: '/project/kubb.config.ts',
       allowAll: false,
       allowWrite: false,
-      allowPublish: false,
       root: '/project',
       retryInterval: 100,
       nitro: { hooks: { hook: vi.fn() } } as any,
@@ -430,7 +429,6 @@ describe('connectToStudio', () => {
           permissions: {
             allowAll: false,
             allowWrite: true,
-            allowPublish: false,
           },
         }),
       }),
@@ -451,7 +449,6 @@ describe('connectToStudio', () => {
           permissions: {
             allowAll: true,
             allowWrite: true,
-            allowPublish: false,
           },
         }),
       }),
@@ -476,7 +473,6 @@ describe('connectToStudio', () => {
           permissions: {
             allowAll: false,
             allowWrite: false,
-            allowPublish: false,
           },
         }),
       }),

--- a/packages/agent/server/utils/connectStudio.ts
+++ b/packages/agent/server/utils/connectStudio.ts
@@ -2,14 +2,13 @@ import { formatMs, maskString, serializePluginOptions } from '@internals/utils'
 import { AsyncEventEmitter, fsStorage, type KubbHooks, memoryStorage } from '@kubb/core'
 import type { NitroApp } from 'nitropack/types'
 import { version } from '~~/package.json'
-import { type AgentConnectResponse, type AgentMessage, isCommandMessage, isDisconnectMessage, isPongMessage, isPublishCommandMessage } from '../types/agent.ts'
+import { type AgentConnectResponse, type AgentMessage, isCommandMessage, isDisconnectMessage, isPongMessage } from '../types/agent.ts'
 import { getLatestStudioConfigFromStorage, saveStudioConfigToStorage } from './agentCache.ts'
 import { createAgentSession, disconnect } from './api.ts'
 import { generate } from './generate.ts'
 import { loadConfig } from './loadConfig.ts'
 import { logger } from './logger.ts'
 import { mergePlugins } from './mergePlugins.ts'
-import { publish } from './publish.ts'
 import { resolveMiddlewares } from './resolvePlugins.ts'
 import { setupHookListener } from './setupHookListener.ts'
 import { createWebsocket, sendAgentMessage, setupEventsStream } from './ws.ts'
@@ -21,7 +20,6 @@ export type ConnectToStudioOptions = {
   resolvedConfigPath: string
   allowAll: boolean
   allowWrite: boolean
-  allowPublish: boolean
   root: string
   retryInterval: number
   heartbeatInterval?: number
@@ -42,7 +40,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
     resolvedConfigPath,
     allowAll,
     allowWrite,
-    allowPublish,
     root,
     retryInterval,
     heartbeatInterval = 30_000,
@@ -53,7 +50,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
   // Each connection gets its own isolated event emitter so generation events
   // from one session do not bleed into another session's WebSocket stream.
   const hooks = new AsyncEventEmitter<KubbHooks>()
-  let currentSource: 'generate' | 'publish' | undefined
 
   async function reconnect() {
     logger.info(`Retrying connection in ${formatMs(retryInterval)} to Kubb Studio ...`)
@@ -75,7 +71,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
     // Effective permissions: always disabled in sandbox mode
     const effectiveAllowAll = isSandbox ? false : allowAll
     const effectiveWrite = isSandbox ? false : allowWrite
-    const effectivePublish = isSandbox ? false : allowPublish
 
     // Tracks whether the studio server explicitly disconnected us (no reconnect needed)
     let serverDisconnected = false
@@ -139,7 +134,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
 
     heartbeatTimer = setInterval(() => sendAgentMessage(ws, { type: 'ping' }), heartbeatInterval)
 
-    setupEventsStream(ws, hooks, () => currentSource)
+    setupEventsStream(ws, hooks)
 
     ws.addEventListener('message', async (message) => {
       try {
@@ -172,7 +167,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
 
         if (isCommandMessage(data)) {
           if (data.command === 'generate') {
-            currentSource = 'generate'
             const config = await loadConfig(resolvedConfigPath)
 
             // Message payload takes priority over previously saved studio config
@@ -206,7 +200,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
 
             const generationHooks = new AsyncEventEmitter<KubbHooks>()
             setupHookListener(generationHooks, root)
-            setupEventsStream(ws, generationHooks, () => currentSource)
+            setupEventsStream(ws, generationHooks)
 
             await generate({
               config: {
@@ -227,7 +221,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             })
 
             logger.success(`[${maskedSessionId}] Completed "${data.type}" from Studio`)
-            currentSource = undefined
 
             return
           }
@@ -243,7 +236,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
                 permissions: {
                   allowAll: effectiveAllowAll,
                   allowWrite: effectiveWrite,
-                  allowPublish: effectivePublish,
                 },
                 config: {
                   plugins: config.plugins.map((plugin) => ({
@@ -255,31 +247,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             })
 
             logger.success(`[${maskedSessionId}] Completed "${data.type}" from Studio`)
-
-            return
-          }
-
-          if (isPublishCommandMessage(data)) {
-            if (!effectivePublish) {
-              logger.warn(`[${maskedSessionId}] Publish command rejected — KUBB_AGENT_ALLOW_PUBLISH is not enabled`)
-              return
-            }
-
-            currentSource = 'publish'
-            const config = await loadConfig(resolvedConfigPath)
-
-            // Command priority: WS payload → env var → default
-            const resolvedCommand = data.payload.command ?? process.env.KUBB_AGENT_PUBLISH_COMMAND ?? 'npm publish'
-
-            await publish({
-              command: resolvedCommand,
-              outputPath: config.output.path,
-              root,
-              hooks,
-            })
-
-            logger.success(`[${maskedSessionId}] Completed "${data.command}" from Studio`)
-            currentSource = undefined
 
             return
           }

--- a/packages/agent/server/utils/runtimeConfig.ts
+++ b/packages/agent/server/utils/runtimeConfig.ts
@@ -28,7 +28,6 @@ export type StudioRuntimeConfig = {
   root: string
   allowAll: boolean
   allowWrite: boolean
-  allowPublish: boolean
   poolSize: number
   hasSecret: boolean
 }
@@ -51,7 +50,6 @@ export function resolveStudioRuntimeConfig(env: NodeJS.ProcessEnv = process.env,
     root,
     allowAll,
     allowWrite: allowAll || parseBooleanEnv(env.KUBB_AGENT_ALLOW_WRITE),
-    allowPublish: allowAll || parseBooleanEnv(env.KUBB_AGENT_ALLOW_PUBLISH),
     poolSize: parsePositiveIntegerEnv(env.KUBB_AGENT_POOL_SIZE, agentDefaults.poolSize),
     hasSecret: Boolean(env.KUBB_AGENT_SECRET),
   }

--- a/packages/agent/server/utils/ws.ts
+++ b/packages/agent/server/utils/ws.ts
@@ -38,11 +38,11 @@ export function sendAgentMessage(ws: WebSocket, message: AgentMessage): void {
 /**
  * Forwards selected Kubb lifecycle events to Studio as data messages for the active session.
  */
-export function setupEventsStream(ws: WebSocket, hooks: AsyncEventEmitter<KubbHooks>, getSource?: () => 'generate' | 'publish' | undefined): void {
+export function setupEventsStream(ws: WebSocket, hooks: AsyncEventEmitter<KubbHooks>): void {
   function sendDataMessage(payload: DataMessagePayload) {
     sendAgentMessage(ws, {
       type: 'data',
-      payload: { ...payload, source: getSource?.() },
+      payload,
     })
   }
 


### PR DESCRIPTION
## Summary\n\n- Remove `PublishCommandPayload` type and the `publish` command variant from `CommandMessage`\n- Remove `allowPublish` from `ConnectMessagePayload`, `ConnectToStudioOptions`, and `StudioRuntimeConfig`\n- Remove `isPublishCommandMessage` guard and the publish command handler block in `connectStudio.ts`\n- Remove the `getSource` callback and `source` field from `DataMessagePayload` / `setupEventsStream` — no longer needed without publish\n- Update `connectStudio.test.ts` to remove `allowPublish` from options and permission assertions\n\n## Test plan\n\n- [ ] Run `packages/agent` unit tests — all pass with no `allowPublish` references\n- [ ] Verify TypeScript compiles cleanly across all changed files\n- [ ] Confirm `generate` and `connect` commands still work end-to-end against Studio

---
_Generated by [Claude Code](https://claude.ai/code/session_014ws9hHrLaia33fDcVSW8C2)_