### PR TITLE
Dedupe changeset

### DIFF
--- a/.changeset/add-code-ast-nodes.md
+++ b/.changeset/add-code-ast-nodes.md
@@ -2,15 +2,4 @@
 "@kubb/ast": minor
 ---
 
-Add structured AST nodes for code generation.
-
-New node types:
-- `ConstNode` — variable declarations with `as const`
-- `TypeNode` — type alias declarations
-- `FunctionNode` — function declarations
-- `ArrowFunctionNode` — arrow function expressions
-- `ParamsTypeNode` — function parameter type annotations with `reference`, `struct`, and `member` variants
-
-New factory functions: `createConst`, `createType`, `createParamsType`, `createFunction`, `createArrowFunction`.
-
-`SourceNode` now supports an optional `nodes` field for structured AST children.
+Add structured AST nodes for code generation: `ConstNode`, `TypeNode`, `FunctionNode`, `ArrowFunctionNode`, `ParamsTypeNode`. New factory functions: `createConst`, `createType`, `createParamsType`, `createFunction`, `createArrowFunction`. `SourceNode` now supports an optional `nodes` field.

--- a/.changeset/add-collect-lazy-generator.md
+++ b/.changeset/add-collect-lazy-generator.md
@@ -3,10 +3,6 @@
 '@kubb/adapter-oas': patch
 ---
 
-Use generator functions for lazy AST traversal.
+Export `collectLazy()` from `@kubb/ast` — a generator version of `collect()` that yields results one at a time without materializing an intermediate array.
 
-`collectLazy()` is now exported from `@kubb/ast`. It is a generator version of `collect()` that yields results one by one without materializing an intermediate array. `collect()` is unchanged and still returns `Array<T>`.
-
-`getChildren()` and `collectRefs()` are converted to generators internally, removing per-node temporary array allocations during traversal.
-
-`containsCircularRef()` uses `collectLazy()` with an early-exit loop and stops at the first matching circular ref instead of traversing the full subtree.
+`getChildren()` and `collectRefs()` are now generators internally. `containsCircularRef()` uses `collectLazy()` with early exit to stop at the first matching circular ref.

--- a/.changeset/add-core-mocks-subpath.md
+++ b/.changeset/add-core-mocks-subpath.md
@@ -2,21 +2,4 @@
 "@kubb/core": minor
 ---
 
-Add `@kubb/core/mocks` subpath export for testing utilities.
-
-New exports:
-- `createMockedPluginDriver(options)` — create a minimal PluginDriver mock
-- `createMockedAdapter(options)` — create a minimal Adapter mock
-- `createMockedPlugin(params)` — create a minimal Plugin mock
-- `renderGeneratorSchema(generator, node, opts)` — render a generator's schema method
-- `renderGeneratorOperation(generator, node, opts)` — render a generator's operation method
-- `renderGeneratorOperations(generator, nodes, opts)` — render a generator's operations method
-
-```ts
-import {
-  createMockedAdapter,
-  createMockedPlugin,
-  createMockedPluginDriver,
-  renderGeneratorSchema,
-} from '@kubb/core/mocks'
-```
+Add `@kubb/core/mocks` subpath export with testing utilities: `createMockedPluginDriver`, `createMockedAdapter`, `createMockedPlugin`, `renderGeneratorSchema`, `renderGeneratorOperation`, and `renderGeneratorOperations`.

--- a/.changeset/add-create-operation-params.md
+++ b/.changeset/add-create-operation-params.md
@@ -2,8 +2,4 @@
 "@kubb/ast": minor
 ---
 
-Add `createOperationParams` utility for converting operations to function parameters.
-
-- `createOperationParams(node, options)` converts an `OperationNode` into a `FunctionParametersNode`
-- `TypeNode` now has a `reference` variant for plain type name strings
-- `FunctionParameterNode.type` and `ParameterGroupNode.type` now require `TypeNode` instead of accepting strings
+Add `createOperationParams(node, options)` to convert an `OperationNode` into a `FunctionParametersNode`. `TypeNode` gains a `reference` variant. `FunctionParameterNode.type` and `ParameterGroupNode.type` now require `TypeNode` instead of strings.

--- a/.changeset/add-file-processor-stream.md
+++ b/.changeset/add-file-processor-stream.md
@@ -2,46 +2,8 @@
 "@kubb/core": minor
 ---
 
-Add `FileProcessor.stream()` and per-plugin incremental file flushing.
+Add `FileProcessor.stream()` — an async generator that yields one `ParsedFile` at a time. `run()` now delegates to `stream()` internally, removing the `mode: 'sequential' | 'parallel'` option and the `p-limit` dependency.
 
-## `FileProcessor.stream()`
+`safeBuild()` now flushes files after each plugin rather than all at once at the end, so parsed strings from plugin N are eligible for GC before plugin N+1 begins.
 
-New async generator that yields one `ParsedFile` at a time instead of batching all files through `pLimit` + `AsyncEventEmitter`.
-
-`run()` now delegates to `stream()` internally, removing duplicated parse logic and the `mode: 'sequential' | 'parallel'` option (the concurrency cap has been removed along with the `p-limit` dependency).
-
-```ts
-import { FileProcessor, type ParsedFile } from '@kubb/core'
-
-const fp = new FileProcessor()
-
-for await (const { file, source, processed, total } of fp.stream(files)) {
-  console.log(`[${processed}/${total}] ${file.path}`)
-  if (source) await storage.setItem(file.path, source)
-}
-```
-
-New exports:
-- `stream(files, options?)` — async generator on `FileProcessor`
-- `ParsedFile` — type yielded by `stream`: `{ file, source, processed, total, percentage }`
-
-## Per-plugin incremental flushing
-
-`safeBuild()` now flushes files after each plugin rather than once at the end. A path snapshot is taken before each plugin runs; after the plugin completes (including `kubb:plugin:end` handlers), only files whose paths were not in the snapshot are written. Files shared across plugins remain in the queue and are written at the final flush.
-
-For a 4-plugin, 200-files-per-plugin build this means parsed strings from plugin N are eligible for GC before plugin N+1 begins.
-
-## Performance vs the previous `run()` parallel approach (petStore + 4 plugins, `memoryStorage`)
-
-| Metric | before | after | delta |
-|---|---|---|---|
-| Throughput (ops/s) | 257,431 | 297,416 | **+15.5%** |
-| Mean latency (ms) | 0.0039 | 0.0034 | **−13%** |
-| First-write latency (ops/s) | 234,442 | 280,272 | **+19.6%** |
-| p999 tail latency (ms) | 0.0575 | 0.0374 | **−35%** |
-
-## Removed
-
-- `p-limit` dependency from `@kubb/core` (and its bundled `yocto-queue`)
-- `PARALLEL_CONCURRENCY_LIMIT` constant
-- `mode: 'sequential' | 'parallel'` option from `FileProcessor.run()`
+Removed: `p-limit` dependency, `PARALLEL_CONCURRENCY_LIMIT` constant, `mode` option from `FileProcessor.run()`.

--- a/.changeset/add-find-circular-schemas.md
+++ b/.changeset/add-find-circular-schemas.md
@@ -2,9 +2,4 @@
 '@kubb/ast': minor
 ---
 
-Added shared schema-graph helpers to `@kubb/ast` so plugins can stop reimplementing reference traversal and cycle detection:
-
-- `resolveRefName(node)` — extracts the referenced schema name from a `ref` node (with sensible fallbacks).
-- `collectReferencedSchemaNames(node)` — collects every schema name reachable via `ref` edges.
-- `findCircularSchemas(schemas)` — returns the set of named schemas that participate in a reference cycle (direct self-loops or indirect cycles such as `Pet → Cat → Pet`).
-- `containsCircularRef(node, { circularSchemas, excludeName? })` — checks whether a schema (or any nested node) references a circular schema, with optional self-name exclusion.
+Add schema-graph helpers to `@kubb/ast`: `resolveRefName`, `collectReferencedSchemaNames`, `findCircularSchemas`, and `containsCircularRef`. These replace per-plugin reimplementations of reference traversal and cycle detection.

--- a/.changeset/add-generator-context-api.md
+++ b/.changeset/add-generator-context-api.md
@@ -2,38 +2,6 @@
 '@kubb/core': minor
 ---
 
-Add typed generator context and lifecycle hooks.
+Add typed `GeneratorContext<TOptions>` so generators receive `adapter` and `rootNode` via a typed `this` context. Add `mergeGenerators(generators)` to combine multiple generators. Plugins augment `Kubb.PluginRegistry` for automatic typing in `getPlugin`.
 
-### `GeneratorContext<TOptions>`
-
-Generators now receive a typed `this` context where `adapter` and `rootNode` are always present:
-
-```ts
-export const myGenerator = defineGenerator<PluginMyPlugin>({
-  async schema(node, options) {
-    const { adapter, rootNode } = this // always present
-  },
-})
-```
-
-### `mergeGenerators(generators)`
-
-Combine multiple generators into one. Each hook runs in sequence:
-
-```ts
-const mergedGenerator = mergeGenerators([generatorA, generatorB])
-```
-
-### `PluginRegistry` augmentation
-
-Plugins now augment `Kubb.PluginRegistry` for automatic typing in `getPlugin`:
-
-```ts
-const tsPlugin = context.getPlugin('plugin-ts') // typed as PluginTs
-```
-
-### Renamed hooks
-
-- `renderHookResult` → `applyHookResult`
-- `install` → `buildStart`
-- New `buildEnd` hook runs after all files are written
+Renamed hooks: `renderHookResult` → `applyHookResult`, `install` → `buildStart`. New `buildEnd` hook runs after all files are written.

--- a/.changeset/add-generator-run-helpers.md
+++ b/.changeset/add-generator-run-helpers.md
@@ -2,11 +2,4 @@
 "@kubb/core": minor
 ---
 
-Add generator dispatch helpers.
-
-New functions exported from `@kubb/core`:
-- `runGeneratorSchema(node, ctx)` — dispatch a schema node to all generators
-- `runGeneratorOperation(node, ctx)` — dispatch an operation node to all generators
-- `runGeneratorOperations(nodes, ctx)` — batch-dispatch operation nodes
-
-All accept `RunGeneratorContext<TOptions>` and handle option resolution and null-checking.
+Add generator dispatch helpers: `runGeneratorSchema`, `runGeneratorOperation`, and `runGeneratorOperations`. All accept `RunGeneratorContext<TOptions>` and handle option resolution and null-checking.

--- a/.changeset/add-per-package-yaml-metadata.md
+++ b/.changeset/add-per-package-yaml-metadata.md
@@ -4,10 +4,4 @@
 "@kubb/parser-ts": minor
 ---
 
-Each package now ships an `extension.yaml` file with its npm release.
-
-- `adapter-oas` → `extension.yaml` (`kind: adapter`)
-- `middleware-barrel` → `extension.yaml` (`kind: middleware`)
-- `parser-ts` → `extension.yaml` (`kind: parser`)
-
-Each file is a self-contained extension manifest: it describes the package's options, examples, and resources, and references the unified `extension.json` schema for IDE validation. Third-party adapters, middlewares, and parsers follow the same pattern — one `extension.yaml` per package with the appropriate `kind` field.
+Ship an `extension.yaml` manifest with each package (`adapter-oas`, `middleware-barrel`, `parser-ts`). Each file describes the package's kind, options, examples, and resources and references the shared `extension.json` schema for IDE validation.

--- a/.changeset/add-renderer-jsx-package.md
+++ b/.changeset/add-renderer-jsx-package.md
@@ -3,12 +3,4 @@
 "@kubb/core": patch
 ---
 
-Add `@kubb/renderer-jsx` package.
-
-A lightweight JSX renderer for Kubb plugins:
-- Custom JSX runtime (`jsx-runtime`, `jsx-dev-runtime`)
-- `createRenderer` to render JSX trees into `FileNode` arrays
-- Built-in components: `File`, `Const`, `Function`, `Type`, `Root`
-- Context helpers: `KubbContext`, `OasContext`
-
-Replaces `@kubb/react-fabric` as the rendering layer inside Kubb plugins.
+Add `@kubb/renderer-jsx` — a lightweight JSX renderer for Kubb plugins with a custom JSX runtime, `createRenderer`, and built-in components (`File`, `Const`, `Function`, `Type`, `Root`). Replaces `@kubb/react-fabric` as the rendering layer.

--- a/.changeset/add-resolver-and-transformer-helpers.md
+++ b/.changeset/add-resolver-and-transformer-helpers.md
@@ -3,13 +3,4 @@
 "@kubb/core": minor
 ---
 
-Add resolver and transformer composition helpers.
-
-### `@kubb/core`
-
-- `Resolver` base type now includes `name: string`
-- `mergeResolvers(...resolvers)` combines multiple resolvers (last wins)
-
-### `@kubb/ast`
-
-- `composeTransformers(...visitors)` combines multiple `Visitor` objects into one, piping each node kind through all visitors sequentially
+Add `mergeResolvers(...resolvers)` to `@kubb/core` (last wins) and `composeTransformers(...visitors)` to `@kubb/ast` for combining multiple `Visitor` objects into a single sequential pipeline. `Resolver.name` is now required.

--- a/.changeset/add-type-helper-nodes.md
+++ b/.changeset/add-type-helper-nodes.md
@@ -4,19 +4,4 @@
 "@kubb/core": patch
 ---
 
-Add type helper nodes and options.
-
-### `@kubb/ast`
-
-- Add `never` to `PrimitiveSchemaType`
-- Add `UrlSchemaNode` with Express-style `path` field
-- Add `applyParamsCasing` helper
-
-### `@kubb/adapter-oas`
-
-- Add `unknownType` and `emptySchemaType` options to `convertSchema`
-- Add `url` special-type handling in the parser
-
-### `@kubb/core`
-
-- `OverrideItem.options` typed as `Omit<Partial<TOptions>, 'override'>` to prevent recursive overrides
+Add AST helpers: `UrlSchemaNode` with Express-style `path`, `applyParamsCasing`, and `never` to `PrimitiveSchemaType`. Add `unknownType` and `emptySchemaType` options to `convertSchema`. `OverrideItem.options` is now `Omit<Partial<TOptions>, 'override'>`.

--- a/.changeset/agent-dynamic-plugin-resolution.md
+++ b/.changeset/agent-dynamic-plugin-resolution.md
@@ -2,61 +2,8 @@
 "@kubb/agent": minor
 ---
 
-Align `@kubb/agent` with the Kubb v5 adapter/middleware model and Studio protocol.
+Resolve plugins and middlewares at runtime via dynamic `import()`. The agent no longer bundles any `@kubb/plugin-*` packages as dependencies — any package installed in the Docker image is loadable.
 
-### Dynamic plugin and middleware resolution
+`JSONKubbConfig` accepts `middleware` and `adapter` fields alongside `plugins`. The `KUBB_PACKAGES` Docker build ARG controls which packages are pre-installed.
 
-Plugins and middlewares are now resolved at runtime via dynamic `import()`. The agent no longer bundles any `@kubb/plugin-*` packages as direct dependencies. Any package installed in the Docker image is loadable — both `@kubb/*` scoped and third-party packages.
-
-Factory resolution tries three strategies in order: camelCase named export (e.g. `pluginReactQuery`), `default` export, then the first exported function.
-
-When a package cannot be imported, the agent throws a clear error:
-
-```
-Plugin "@kubb/plugin-ts" could not be loaded. Make sure it is installed: `npm install @kubb/plugin-ts`
-```
-
-### Middleware support in Studio config
-
-The `JSONKubbConfig` type now accepts a `middleware` array alongside `plugins`. Studio can send middleware entries by package name; the agent loads and instantiates each one before passing them to `createKubb`.
-
-```ts
-// Studio payload
-{
-  plugins: [{ name: '@kubb/plugin-ts', options: { output: { path: './types' } } }],
-  middleware: [{ name: '@kubb/middleware-barrel', options: {} }]
-}
-```
-
-When `middleware` is absent from the Studio payload, the agent falls back to the `middleware` array from the disk `kubb.config.ts`.
-
-### Adapter forwarding
-
-`JSONKubbConfig` now accepts an optional `adapter` field. The agent forwards it unchanged to `createKubb` — the adapter factory validates its own options.
-
-```ts
-// Studio payload
-{
-  adapter: { serverIndex: 1, contentType: 'application/json' }
-}
-```
-
-### KUBB_PACKAGES Docker build ARG
-
-The Dockerfile exposes a `KUBB_PACKAGES` build ARG that controls which packages are pre-installed in the image. Override it at build time to add plugins, middlewares, or third-party packages:
-
-```sh
-docker build \
-  --build-arg KUBB_PACKAGES="kubb @kubb/core @kubb/plugin-ts @kubb/middleware-barrel my-custom-plugin" \
-  .
-```
-
-Because Stage 2 is distroless (no shell or package manager), only packages baked in at build time are ever resolvable at runtime.
-
-### Peer dependency check at startup
-
-The agent calls `checkPeerDependencies()` on startup and logs a clear warning when `@kubb/renderer-jsx` is missing — all v5 plugins require it.
-
-```
-[warn] Missing peer dependency @kubb/renderer-jsx. Install it alongside kubb plugins.
-```
+A peer dependency check runs at startup and warns when `@kubb/renderer-jsx` is missing.

--- a/.changeset/ast-helper-reorganization.md
+++ b/.changeset/ast-helper-reorganization.md
@@ -3,17 +3,4 @@
 "@kubb/adapter-oas": patch
 ---
 
-Reorganize schema helper modules into clearer categories.
-
-### `@kubb/ast`
-
-Schema helpers are now split across three modules:
-- `transformers.ts` — schema transformation helpers (`setDiscriminatorEnum`, `mergeAdjacentObjects`, `simplifyUnion`, `setEnumName`, `resolveNames`)
-- `resolvers.ts` — lookup and derivation helpers (`findDiscriminator`, `childName`, `enumPropName`, `collectImports`)
-- `utils.ts` — generic utilities (`isStringType`, `caseParams`, `syncOptionality`)
-
-Deprecated alias exports for old names have been removed.
-
-### `@kubb/adapter-oas`
-
-Fix named import shape regression in adapter import resolution. `adapter.getImports(...)` now correctly returns `KubbFile.Import` entries with `name` as `string[]`.
+Split `@kubb/ast` schema helpers into `transformers.ts`, `resolvers.ts`, and `utils.ts`. Remove deprecated alias exports. Fix `adapter.getImports()` returning `name` as `string[]` correctly.

--- a/.changeset/backend-refactor-dedupe.md
+++ b/.changeset/backend-refactor-dedupe.md
@@ -5,11 +5,4 @@
 "@kubb/parser-ts": patch
 ---
 
-Internal cleanup: dedupe backend code and drop unused exports.
-
-- `@kubb/parser-ts`: add `src/constants.ts` (regex + path-prefix literals); dedupe `printFunction`/`printArrowFunction` via `formatGenerics` / `formatReturnType`; dedupe the import/export path resolution inside `parserTs.parse` into `resolveOutputPath`.
-- `@kubb/core`: collapse `FileManager#add` and `FileManager#upsert` onto a shared private `#store` helper (`mergeFilesByPath`); drop unused `DEFAULT_CONCURRENCY` / `PATH_SEPARATORS` constants.
-- `@kubb/ast`: drop unused `parameterLocations` and `DEFAULT_STATUS_CODE` constants.
-- `@kubb/cli`: remove unreferenced `GENERATE_FLAGS` / `VALIDATE_FLAGS` / `INIT_FLAGS` / `AGENT_START_FLAGS` / `ARGS` sets; rename `QUITE_FLAGS` → `QUIET_FLAGS`.
-- `@internals/utils`: un-export internal `randomColors` constant (only used by `randomCliColor`).
-- Tests: extract `createSetupCtxStub` in `definePlugin.test.ts` to kill three copies of the same setup-ctx literal.
+Internal cleanup: dedupe backend code and drop unused exports across `@kubb/parser-ts`, `@kubb/core`, `@kubb/ast`, `@kubb/cli`, and `@internals/utils`. Rename `QUITE_FLAGS` → `QUIET_FLAGS` in CLI.

--- a/.changeset/barrel-root-type-and-cli-v5-init.md
+++ b/.changeset/barrel-root-type-and-cli-v5-init.md
@@ -4,19 +4,4 @@
 "@kubb/core": patch
 ---
 
-Add `RootBarrelType`, restrict `'propagate'` to per-plugin config, update `npx kubb init` for v5, and fix `output.format` JSDoc default.
-
-### `@kubb/middleware-barrel`
-
-- Added `RootBarrelType = Exclude<BarrelType, 'propagate'>` — exported alongside `BarrelType`.
-- `config.output.barrelType` (global) is now typed as `RootBarrelType | false`. Setting it to `'propagate'` is a type error; use `'all'` or `'named'` at the root level.
-- Per-plugin `output.barrelType` continues to accept the full `BarrelType` (`'all' | 'named' | 'propagate'`).
-
-### `@kubb/cli`
-
-- `npx kubb init` now reflects the v5 plugin ecosystem: removed `plugin-oas` (handled automatically by `defineConfig`), `plugin-solid-query`, `plugin-svelte-query`, and `plugin-swr`; added `plugin-mcp`, `plugin-cypress`, and `plugin-redoc`.
-- Default scaffolded plugins list is now `['plugin-ts']`.
-
-### `@kubb/core`
-
-- `output.format` JSDoc `@default` corrected from `'prettier'` to `'auto'` — matches the existing `output.lint` convention and the actual auto-detection behaviour.
+Add `RootBarrelType = Exclude<BarrelType, 'propagate'>` — `config.output.barrelType` (global) is now typed as `RootBarrelType | false`. Update `npx kubb init` to reflect the v5 plugin ecosystem. Fix `output.format` JSDoc `@default` to `'auto'`.

--- a/.changeset/clever-cases-deny.md
+++ b/.changeset/clever-cases-deny.md
@@ -2,4 +2,4 @@
 "@kubb/middleware-barrel": patch
 ---
 
-Cleanup logic to also use excluded
+Include excluded files in barrel cleanup logic.

--- a/.changeset/core-getmode-static-cleanup.md
+++ b/.changeset/core-getmode-static-cleanup.md
@@ -4,21 +4,4 @@
 
 `getMode` is now a static method on `PluginDriver` instead of a standalone export.
 
-**Before:**
-```ts
-import { getMode } from '@kubb/core'
-getMode('src/gen/types.ts') // 'single'
-```
-
-**After:**
-```ts
-import { PluginDriver } from '@kubb/core'
-PluginDriver.getMode('src/gen/types.ts') // 'single'
-```
-
-The following utilities have also been removed from `@kubb/core`'s public API as they are internal post-processing helpers used only by CLI/agent tooling:
-- `formatters` — moved to `@internals/utils`
-- `linters` — moved to `@internals/utils`
-- `detectFormatter` — moved to `@internals/utils`
-- `detectLinter` — moved to `@internals/utils`
-- `satisfiesDependency` — internal only, no longer exported
+The following are also removed from `@kubb/core`'s public API: `formatters`, `linters`, `detectFormatter`, `detectLinter` (moved to `@internals/utils`), and `satisfiesDependency` (internal only).

--- a/.changeset/ctx-param-in-define-resolver.md
+++ b/.changeset/ctx-param-in-define-resolver.md
@@ -2,12 +2,6 @@
 "@kubb/core": patch
 ---
 
-Replace `this` with explicit `ctx` parameter in `defineResolver` builder.
-
-### `@kubb/core`
-
-- `ResolverBuilder<T>` now receives the assembled resolver as `ctx` instead of using `ThisType<T['resolver']>`.
-- `defaultResolveFile` accepts the resolver as an explicit `ctx: Resolver` third parameter instead of a `this` receiver.
-- `defineResolver` creates the resolver shell first and passes it to the builder, so `ctx` methods resolve lazily and include any builder overrides.
+Replace `this` with explicit `ctx` parameter in `defineResolver` builders. `ResolverBuilder<T>` now receives the assembled resolver as `ctx`; `defaultResolveFile` takes it as a third parameter instead of a `this` receiver.
 
 Migration: replace `this.xxx(...)` calls inside `defineResolver` builders with `ctx.xxx(...)`.

--- a/.changeset/fiery-books-report.md
+++ b/.changeset/fiery-books-report.md
@@ -2,4 +2,4 @@
 "@kubb/agent": patch
 ---
 
-fix(agent): copy full jiti package in nitro compiled hook so dist/babel.cjs is available in Docker
+Fix agent Docker build: copy full jiti package so `dist/babel.cjs` is available at runtime.

--- a/.changeset/fix-barrel-non-ts-and-non-indexable.md
+++ b/.changeset/fix-barrel-non-ts-and-non-indexable.md
@@ -2,10 +2,4 @@
 "@kubb/middleware-barrel": patch
 ---
 
-Fix barrel-generation bugs in `@kubb/middleware-barrel`.
-
-**Bug 1 — Non-TypeScript files produced malformed barrel exports**: `getBarrelFiles()` included every file in the output directory (`.json`, `.html`, etc.). `toRelativeModulePath` strips the extension, so `.mcp.json` became `.mcp` and the TypeScript printer turned that into `./mcp/.ts` or `./.js`. Fixed by filtering `relevantFiles` to only `.ts`, `.tsx`, `.js`, and `.jsx` files.
-
-**Bug 2 — Files with `isIndexable: false` still appeared in barrels**: `getBarrelFilesNamed()` fell back to `export *` for files whose sources all had `isIndexable: false`, causing internal files like `.kubb/config.ts` to appear in every root barrel. Fixed by skipping such files entirely; the wildcard fallback is now only used when a file has *no* sources at all (i.e. its exports are unknown). The same skip logic is now also applied in `getBarrelFilesAll()`.
-
-**Bug 3 — `output.extension` mapping not applied to barrel export paths**: `toRelativeModulePath` was stripping the `.ts` extension from every export path, so `@kubb/parser-ts` never saw an extension to map (e.g. `.ts` → `.js` for ESM output). Fixed by preserving the source extension in `toRelativeModulePath`. The `collectPropagatedBarrels` helper was also updated to reference sub-directory barrel files as `index.ts` (via `BARREL_FILENAME`) instead of the extensionless `index` (via `BARREL_BASENAME`), so the same mapping is applied correctly in propagate mode.
+Fix three barrel-generation bugs: non-TypeScript files (`.json`, `.html`) no longer produce malformed exports; files with `isIndexable: false` are skipped from all barrel types instead of falling back to `export *`; `output.extension` mapping is now correctly applied to barrel export paths.

--- a/.changeset/fix-bunx-argv-stripping.md
+++ b/.changeset/fix-bunx-argv-stripping.md
@@ -1,5 +1,5 @@
 ---
-'@internals/utils': patch
+'@kubb/cli': patch
 ---
 
 Fix `bunx kubb` (and other non-Node runtimes) incorrectly using the runtime executable path as the OpenAPI input.

--- a/.changeset/fix-include-filter-schema-scoping.md
+++ b/.changeset/fix-include-filter-schema-scoping.md
@@ -5,34 +5,4 @@
 
 Fix `include` filter not preventing generation of component schemas from excluded operations.
 
-When `include` contains operation-based filters (`tag`, `operationId`, `path`, `method`, or `contentType`), only the schemas transitively referenced by the included operations are now generated. Schemas that are only used by excluded operations are silently skipped.
-
-**New `@kubb/ast` export: `collectUsedSchemaNames`**
-
-```ts
-import { collectUsedSchemaNames } from '@kubb/ast'
-
-// Returns the set of top-level schema names reachable from the given operations.
-const allowed = collectUsedSchemaNames(includedOperations, inputNode.schemas)
-```
-
-**Before** (all schemas generated regardless of `include`):
-
-```
-types/
-├── ItemStatus.ts     ✅
-├── ItemsResponse.ts  ✅
-├── OrderStatus.ts    ❌ generated even though getOrders is excluded
-└── OrdersResponse.ts ❌ generated even though getOrders is excluded
-```
-
-**After** (only schemas reachable from included operations):
-
-```
-types/
-├── ItemStatus.ts     ✅
-└── ItemsResponse.ts  ✅
-```
-
-> [!NOTE]
-> When `include` contains a `schemaName` filter alongside operation filters, the new schema-scoping logic is disabled and `schemaName` rules apply instead.
+When `include` contains operation-based filters, only schemas transitively referenced by the included operations are now generated. New `@kubb/ast` export: `collectUsedSchemaNames(operations, schemas)`.

--- a/.changeset/perf-generator-functions-optimization.md
+++ b/.changeset/perf-generator-functions-optimization.md
@@ -7,7 +7,7 @@
 
 Performance improvements for large OpenAPI specs.
 
-- **`@kubb/ast`**: Add `mergeAdjacentObjectsLazy` generator for lazy stateful merging of adjacent allOf object schemas. Memoize `collectReferencedSchemaNames` with a `WeakMap` so repeated callers pay the tree-walk cost only once per schema node.
-- **`@kubb/core`**: Parallelize per-node generator dispatch with `Promise.all` so schema and operation generators run concurrently. Defer file writes to a single flush after all plugins complete instead of flushing after each plugin. Convert `fsStorage` directory walk to an async generator for streaming filesystem traversal.
-- **`@kubb/adapter-oas`**: Replace `flatMap` content-type loop with a `for`/`push` pattern (7× faster for the typical 2–4 content-type case).
-- **`@kubb/parser-ts`**: Fix British-English spellings in JSDoc comments (`normalising` → `normalizing`, `neutralise` → `neutralize`).
+- **`@kubb/ast`**: Add `mergeAdjacentObjectsLazy` for lazy stateful merging of adjacent allOf schemas. Memoize `collectReferencedSchemaNames` with a `WeakMap`.
+- **`@kubb/core`**: Parallelize per-node generator dispatch with `Promise.all`. Convert `fsStorage` directory walk to an async generator.
+- **`@kubb/adapter-oas`**: Replace `flatMap` content-type loop with `for`/`push` (7× faster for typical 2–4 content types).
+- **`@kubb/parser-ts`**: Fix British-English spellings in JSDoc comments.

--- a/.changeset/perf-renderer-jsx-legacyroot-sync.md
+++ b/.changeset/perf-renderer-jsx-legacyroot-sync.md
@@ -2,38 +2,4 @@
 "@kubb/renderer-jsx": patch
 ---
 
-JSX rendering is now 2–4× faster with `jsxRendererSync`
-
-Two new optimisations in `@kubb/renderer-jsx` cut render time significantly with no changes required to existing generators.
-
-**`jsxRendererSync`: React-free recursive renderer**
-
-A new `jsxRendererSync` factory replaces React's fiber scheduler with a lightweight recursive tree walk. Because all Kubb components are pure functions, the full React work loop is unnecessary overhead. Swap `jsxRenderer` for `jsxRendererSync` in any generator and it just gets faster:
-
-```ts
-import { jsxRendererSync } from '@kubb/renderer-jsx'
-
-export const myGenerator = defineGenerator({
-  renderer: jsxRendererSync, // was: jsxRenderer
-  // ...
-})
-```
-
-Measured improvement on a 150-file schema: **12.9 ms → 5.6 ms**.
-
-**`jsxRendererSync().stream()`: process files as they are rendered**
-
-For generators that produce many files, the new `stream()` method yields each `FileNode` as soon as it is ready, before the rest of the element tree is processed, so downstream work can start immediately:
-
-```ts
-const renderer = jsxRendererSync()
-for await (const file of renderer.stream(element)) {
-  await writeFile(file) // starts before the next file is rendered
-}
-```
-
-**Lower memory use**
-
-Node attributes now use plain objects instead of `Map`, eliminating ~300 bytes of V8 overhead per virtual DOM node. The three separate tree walks previously done per file element (sources, exports, imports) are now a single generator pass.
-
-`jsxRenderer` is unchanged and all new APIs are purely additive.
+Add `jsxRendererSync` — a React-free recursive renderer 2–4× faster than `jsxRenderer`. Add `stream()` for incremental file processing. Node attributes use plain objects instead of `Map`. `jsxRenderer` is unchanged; all new APIs are additive.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,7 +2,6 @@
   "mode": "pre",
   "tag": "beta",
   "initialVersions": {
-    "@internals/utils": "0.0.0",
     "@kubb/adapter-oas": "5.0.0-alpha.74",
     "@kubb/agent": "5.0.0-alpha.74",
     "@kubb/ast": "5.0.0-alpha.74",
@@ -13,8 +12,7 @@
     "@kubb/middleware-barrel": "5.0.0-alpha.74",
     "@kubb/parser-ts": "5.0.0-alpha.74",
     "@kubb/renderer-jsx": "5.0.0-alpha.74",
-    "unplugin-kubb": "5.0.0-alpha.74",
-    "@internals/shared": "0.0.0"
+    "unplugin-kubb": "5.0.0-alpha.74"
   },
   "changesets": [
     "adapter-oas-integer-type-bigint-default",
@@ -43,6 +41,7 @@
     "add-resolve-file-to-resolvers",
     "add-resolve-options-helper",
     "add-resolver-and-transformer-helpers",
+    "add-symbol-dispose-resource-management",
     "add-type-helper-nodes",
     "agent-add-parser-ts-to-docker",
     "agent-dynamic-plugin-resolution",
@@ -56,6 +55,7 @@
     "clever-cases-deny",
     "cli-esm-bin-multi-runtime",
     "cli-runners-per-folder-refactor",
+    "cool-jokes-pump",
     "core-getmode-static-cleanup",
     "create-kubb-user-config-signature",
     "ctx-param-in-define-resolver",
@@ -101,6 +101,7 @@
     "parser-ts-extract-utils",
     "perf-generator-functions-optimization",
     "perf-ref-cache-storage",
+    "perf-renderer-jsx-legacyroot-sync",
     "preserve-union-kind-semantics",
     "reduce-kubb-install-size",
     "reduce-memory-fs-caching",

--- a/.changeset/preserve-union-kind-semantics.md
+++ b/.changeset/preserve-union-kind-semantics.md
@@ -3,32 +3,4 @@
 "@kubb/adapter-oas": patch
 ---
 
-Preserve `oneOf` and `anyOf` semantics in union schema nodes.
-
-### Problem
-
-The OAS adapter previously treated `oneOf` and `anyOf` schemas identically, combining their members into a single union type without distinguishing between them. This prevented plugins from implementing proper validation:
-- `oneOf` requires exactly one schema to be valid
-- `anyOf` allows any number of schemas to be valid
-
-### Solution
-
-Add `strategy?: 'one' | 'any'` field to `UnionSchemaNode` to preserve which keyword was used in the original OpenAPI schema. This enables plugins (like Zod) to implement proper validation logic.
-
-### Changes
-
-**@kubb/ast**
-- Add optional `strategy` field to `UnionSchemaNode` type definition to track union semantics
-
-**@kubb/adapter-oas**
-- Update `convertUnion()` parser function to set `strategy` based on whether `oneOf` or `anyOf` is present
-- Prioritize `'one'` (oneOf) when both keywords are present in the same schema
-- Add comprehensive tests for `strategy` behavior
-
-### Impact
-
-Plugins can now check `unionNode.strategy` to determine validation strategy:
-- `'one'` (oneOf): Enforce exactly one member matches
-- `'any'` (anyOf): Allow any number of members to match
-
-Backward compatible - `strategy` is optional and defaults to `undefined`.
+Add optional `strategy?: 'one' | 'any'` field to `UnionSchemaNode` to preserve `oneOf` vs `anyOf` semantics from the original OpenAPI schema. The adapter sets this field during parsing so plugins can implement appropriate validation logic.

--- a/.changeset/reduce-memory-fs-caching.md
+++ b/.changeset/reduce-memory-fs-caching.md
@@ -6,34 +6,8 @@
 
 Reduce peak memory by leaning on the existing `Storage` abstraction.
 
-`BuildOutput.sources`, `Kubb.sources`, and the `kubb:generation:end` hook payload no longer expose an in-memory `Map<string, string>` containing every rendered source string. They now expose a read-through `Storage` view scoped to the files written during the build and backed by `config.storage` (defaults to `fsStorage()`), so generated source bytes are not duplicated in memory.
+`BuildOutput.sources` is replaced by `BuildOutput.storage` — a read-through `Storage` view backed by `config.storage` (defaults to `fsStorage()`). Generated source bytes are no longer duplicated in memory.
 
-Read a generated source on demand with the existing `Storage` API:
+`FileProcessor` now exposes a typed `events` property (`AsyncEventEmitter<FileProcessorEvents>`) with `start`, `update`, and `end` events. The previous `onStart`, `onUpdate`, and `onEnd` callback options have been removed.
 
-```ts
-const { storage } = await kubb.safeBuild()
-const code = await storage.getItem('src/gen/api/getPets.ts')
-const paths = await storage.getKeys()
-```
-
-`FileManager.dispose()` — clears the per-build FileNode cache. `PluginDriver.dispose()` calls it (and clears `inputNode`) at the end of every build so the parsed adapter graph is released once `kubb:build:end` has fired.
-
-`FileProcessor` now exposes a typed `events` property (`AsyncEventEmitter<FileProcessorEvents>`) with `start`, `update`, and `end` events. The previous `onStart`, `onUpdate`, and `onEnd` callback options have been removed. Subscribe once before calling `run()`:
-
-```ts
-fileProcessor.events.on('update', ({ file, source }) => {
-  // called for every file written
-})
-await fileProcessor.run(files, parseOptions)
-```
-
-`Kubb.driver` and `Kubb.config` now throw if accessed before `setup()` has been called, instead of returning `undefined`. Both properties are no longer typed as `| undefined`.
-
-Migration:
-
-- `BuildOutput.sources` → `BuildOutput.storage` (type changes from `Map<string, string>` to `Storage`).
-- `KubbGenerationEndContext.files` has been removed; use `await storage.getKeys()` to enumerate the generated file paths.
-- Listeners of `kubb:generation:end` that previously called `sources.get(path)` synchronously must now `await storage.getItem(path)`.
-- The `kubb:generation:end` WebSocket payload (agent) no longer includes `files`; file paths are available as `Object.keys(storage)`.
-- `FileProcessor.run()` no longer accepts `onStart`, `onUpdate`, or `onEnd` options; attach listeners via `fileProcessor.events.on(...)` before calling `run()`.
-- `Kubb.driver` and `Kubb.config` are now non-optional — accessing them before `setup()` throws `Error('[kubb] setup() must be called before accessing …')`.
+`Kubb.driver` and `Kubb.config` now throw if accessed before `setup()` instead of returning `undefined`.

--- a/.changeset/reduce-memory-snapshot-cache.md
+++ b/.changeset/reduce-memory-snapshot-cache.md
@@ -2,9 +2,8 @@
 '@kubb/core': patch
 ---
 
-Further reduce peak memory and redundant work during code generation.
+Further reduce peak memory during code generation.
 
-- **Per-plugin streaming writes**: files are written to `config.storage` after each plugin completes instead of all at once at the end of the build. Already-written files are skipped on subsequent flushes via a `writtenPaths` set.
-- **`PARALLEL_CONCURRENCY_LIMIT` lowered from 100 → 16** — each flush only processes the files one plugin generated. 16 in-flight tasks bounds the number of `CodeNode` trees alive during rendering; I/O latency is the bottleneck so higher values offer no meaningful throughput improvement.
-- **`PluginDriver.dispose()` now clears `#resolvers` and `#defaultResolvers`** so resolver closures (which may capture plugin options) are released when the driver is disposed at the end of a build.
-- **`createSourcesView.getKeys(base)` avoids materialising the full key array** before filtering — it now iterates the `Set` directly and only allocates the result array.
+- Files are written to `config.storage` after each plugin completes, not all at once. Already-written files are skipped via a `writtenPaths` set.
+- `PluginDriver.dispose()` now clears `#resolvers` and `#defaultResolvers` so resolver closures are released at end of build.
+- `createSourcesView.getKeys(base)` iterates the `Set` directly instead of materialising the full key array.

--- a/.changeset/refactor-barrel-config-api.md
+++ b/.changeset/refactor-barrel-config-api.md
@@ -2,42 +2,8 @@
 "@kubb/middleware-barrel": major
 ---
 
-Refactor middleware-barrel API from string-based `barrelType` to object-based `barrel` configuration.
+Replace string-based `barrelType` with an object-based `barrel` configuration.
 
-**Breaking Changes:**
-
-- `barrelType` option replaced with `barrel` object at both config and plugin levels
-- `barrelType: 'propagate'` replaced with `barrel: { type: 'all' | 'named', nested: true }`
 - Root config: `barrel?: { type: 'all' | 'named' } | false`
 - Plugin level: `barrel?: { type: 'all' | 'named', nested?: boolean } | false`
-
-**Migration Guide:**
-
-```ts
-// Before
-export default defineConfig({
-  output: { path: 'src/gen', barrelType: 'named' },
-  plugins: [
-    pluginTs({ output: { path: 'types', barrelType: 'all' } }),
-    pluginZod({ output: { path: 'schemas', barrelType: 'propagate' } }),
-  ],
-  middleware: [middlewareBarrel()],
-})
-
-// After
-export default defineConfig({
-  output: { path: 'src/gen', barrel: { type: 'named' } },
-  plugins: [
-    pluginTs({ output: { path: 'types', barrel: { type: 'all' } } }),
-    pluginZod({ output: { path: 'schemas', barrel: { type: 'all', nested: true } } }),
-  ],
-  middleware: [middlewareBarrel()],
-})
-```
-
-**New Features:**
-
-- Explicit `nested` option for hierarchical barrel generation at plugin level
-- Clearer separation of export strategy (`type`) from structure (`nested`)
-- Better type safety with distinct `BarrelConfig` and `PluginBarrelConfig` types
-- `nested` parameter in `getBarrelFiles` for fine-grained control
+- `barrelType: 'propagate'` replaced with `barrel: { type: 'all' | 'named', nested: true }`

--- a/.changeset/remove-legacy-plugin-types.md
+++ b/.changeset/remove-legacy-plugin-types.md
@@ -2,36 +2,6 @@
 "@kubb/core": minor
 ---
 
-Remove legacy plugin infrastructure now that all plugins use `definePlugin`.
+Remove legacy plugin types `NormalizedPlugin`, `PluginContext`, `SchemaHook`, `OperationHook`, and `OperationsHook` from the public API. Use `Plugin` and `GeneratorContext` instead.
 
-### Removed types
-
-- `NormalizedPlugin` — internal plugin state is no longer part of the public API. Use `Plugin` for all external-facing plugin references.
-- `PluginContext` — replaced by the standalone `GeneratorContext` type.
-- `SchemaHook`, `OperationHook`, `OperationsHook` — unused hook type aliases.
-
-### Renamed types
-
-- The internal `InternalPlugin` type (never public) was renamed to `NormalizedPlugin` for clarity, but this type is marked `@internal` and should not be used by plugin authors.
-
-### Improved types
-
-- `ResolveOptionsContext` — marked `@internal`.
-- `FileMetaBase` — marked `@internal`.
-- `FileProcessor` — marked `@internal`.
-- `PluginDriver.registerPluginHooks` — marked `@internal`.
-- `PluginDriver.dispose` — marked `@internal`.
-- `PluginDriver` constructor now requires `hooks` (was optional but always threw when absent).
-- `InternalPlugin` (now `NormalizedPlugin`) moved from `PluginDriver.ts` to `types.ts` with proper root-level imports.
-
-### Migration
-
-If you were importing `NormalizedPlugin` or `PluginContext` from `@kubb/core`, switch to `Plugin` and `GeneratorContext` respectively:
-
-```ts
-// Before
-import type { NormalizedPlugin, PluginContext } from '@kubb/core'
-
-// After
-import type { Plugin, GeneratorContext } from '@kubb/core'
-```
+`PluginDriver` constructor now requires `hooks`. Several internal types are marked `@internal`.

--- a/.changeset/rich-zebras-end.md
+++ b/.changeset/rich-zebras-end.md
@@ -2,4 +2,4 @@
 "@kubb/core": patch
 ---
 
-add ThisType to resolver type
+Add `ThisType` to core resolver type.

--- a/.changeset/strict-mails-unite.md
+++ b/.changeset/strict-mails-unite.md
@@ -2,4 +2,4 @@
 "@kubb/ast": patch
 ---
 
-Resolve this for ast
+Fix `ThisType` augmentation in AST resolver type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,49 +90,7 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Add `FileProcessor.stream()` and per-plugin incremental file flushing.
-  
-  ## `FileProcessor.stream()`
-  
-  New async generator that yields one `ParsedFile` at a time instead of batching all files through `pLimit` + `AsyncEventEmitter`.
-  
-  `run()` now delegates to `stream()` internally, removing duplicated parse logic and the `mode: 'sequential' | 'parallel'` option (the concurrency cap has been removed along with the `p-limit` dependency).
-  
-  ```ts
-  import { FileProcessor, type ParsedFile } from '@kubb/core'
-  
-  const fp = new FileProcessor()
-  
-  for await (const { file, source, processed, total } of fp.stream(files)) {
-    console.log(`[${processed}/${total}] ${file.path}`)
-    if (source) await storage.setItem(file.path, source)
-  }
-  ```
-  
-  New exports:
-  - `stream(files, options?)` — async generator on `FileProcessor`
-  - `ParsedFile` — type yielded by `stream`: `{ file, source, processed, total, percentage }`
-  
-  ## Per-plugin incremental flushing
-  
-  `safeBuild()` now flushes files after each plugin rather than once at the end. A path snapshot is taken before each plugin runs; after the plugin completes (including `kubb:plugin:end` handlers), only files whose paths were not in the snapshot are written. Files shared across plugins remain in the queue and are written at the final flush.
-  
-  For a 4-plugin, 200-files-per-plugin build this means parsed strings from plugin N are eligible for GC before plugin N+1 begins.
-  
-  ## Performance vs the previous `run()` parallel approach (petStore + 4 plugins, `memoryStorage`)
-  
-  | Metric | before | after | delta |
-  |---|---|---|---|
-  | Throughput (ops/s) | 257,431 | 297,416 | **+15.5%** |
-  | Mean latency (ms) | 0.0039 | 0.0034 | **−13%** |
-  | First-write latency (ops/s) | 234,442 | 280,272 | **+19.6%** |
-  | p999 tail latency (ms) | 0.0575 | 0.0374 | **−35%** |
-  
-  ## Removed
-  
-  - `p-limit` dependency from `@kubb/core` (and its bundled `yocto-queue`)
-  - `PARALLEL_CONCURRENCY_LIMIT` constant
-  - `mode: 'sequential' | 'parallel'` option from `FileProcessor.run()` ([#3310](https://github.com/kubb-labs/kubb/pull/3310), [`7dffff1`](https://github.com/kubb-labs/kubb/commit/7dffff1b4e980be28dab7018264437c494155cc3))
+- Add `FileProcessor.stream()` — an async generator that yields one `ParsedFile` at a time. `run()` now delegates to `stream()` internally, removing the `mode: 'sequential' | 'parallel'` option and the `p-limit` dependency. `safeBuild()` now flushes files after each plugin rather than all at once. ([#3310](https://github.com/kubb-labs/kubb/pull/3310), [`7dffff1`](https://github.com/kubb-labs/kubb/commit/7dffff1b4e980be28dab7018264437c494155cc3))
 
 ### Contributors
 
@@ -146,20 +104,25 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Performance improvements for large OpenAPI specs.
-  
-  - **`@kubb/ast`**: Add `mergeAdjacentObjectsLazy` generator for lazy stateful merging of adjacent allOf object schemas. Memoize `collectReferencedSchemaNames` with a `WeakMap` so repeated callers pay the tree-walk cost only once per schema node.
-  - **`@kubb/core`**: Parallelize per-node generator dispatch with `Promise.all` so schema and operation generators run concurrently. Defer file writes to a single flush after all plugins complete instead of flushing after each plugin. Convert `fsStorage` directory walk to an async generator for streaming filesystem traversal.
-  - **`@kubb/adapter-oas`**: Replace `flatMap` content-type loop with a `for`/`push` pattern (7× faster for the typical 2–4 content-type case).
-  - **`@kubb/parser-ts`**: Fix British-English spellings in JSDoc comments (`normalising` → `normalizing`, `neutralise` → `neutralize`). ([#3305](https://github.com/kubb-labs/kubb/pull/3305), [`62f72dd`](https://github.com/kubb-labs/kubb/commit/62f72dde26cc2da6f77b24ca54c9ca74a32c577f))
+- Performance improvements for large OpenAPI specs: add `mergeAdjacentObjectsLazy` for lazy stateful merging of adjacent allOf schemas; memoize `collectReferencedSchemaNames` with a `WeakMap`. ([#3305](https://github.com/kubb-labs/kubb/pull/3305), [`62f72dd`](https://github.com/kubb-labs/kubb/commit/62f72dde26cc2da6f77b24ca54c9ca74a32c577f))
+
+### @kubb/adapter-oas
+
+#### Bug Fixes
+
+- Replace `flatMap` content-type loop with `for`/`push` (7× faster for typical 2–4 content types). ([#3305](https://github.com/kubb-labs/kubb/pull/3305), [`62f72dd`](https://github.com/kubb-labs/kubb/commit/62f72dde26cc2da6f77b24ca54c9ca74a32c577f))
+
+### @kubb/core
+
+#### Features
+
+- Parallelize per-node generator dispatch with `Promise.all`. Convert `fsStorage` directory walk to an async generator for streaming traversal. ([#3305](https://github.com/kubb-labs/kubb/pull/3305), [`62f72dd`](https://github.com/kubb-labs/kubb/commit/62f72dde26cc2da6f77b24ca54c9ca74a32c577f))
 
 ### @kubb/cli
 
 #### Bug Fixes
 
-- Show live progress for formatter, linter, and custom hooks in the CLI.
-  
-  Previously, hook commands (linting, formatting, and custom `hooks.done`) ran with no visible indication of activity — the CLI showed only a "started" intro and a "completed" outro, with the actual execution blocking silently between them. The clack logger now renders a live `taskLog` per hook that streams the subprocess output while it runs, and finalizes with a duration on success or keeps the log open with the error on failure. ([#3306](https://github.com/kubb-labs/kubb/pull/3306), [`dfa488a`](https://github.com/kubb-labs/kubb/commit/dfa488a42d5fac355b2f3312e56aa084ffffe653))
+- Show live progress for formatter, linter, and custom hooks in the CLI. The clack logger now renders a live `taskLog` per hook that streams subprocess output while it runs. ([#3306](https://github.com/kubb-labs/kubb/pull/3306), [`dfa488a`](https://github.com/kubb-labs/kubb/commit/dfa488a42d5fac355b2f3312e56aa084ffffe653))
 
 ### Contributors
 
@@ -173,13 +136,7 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Use generator functions for lazy AST traversal.
-  
-  `collectLazy()` is now exported from `@kubb/ast`. It is a generator version of `collect()` that yields results one by one without materializing an intermediate array. `collect()` is unchanged and still returns `Array<T>`.
-  
-  `getChildren()` and `collectRefs()` are converted to generators internally, removing per-node temporary array allocations during traversal.
-  
-  `containsCircularRef()` uses `collectLazy()` with an early-exit loop and stops at the first matching circular ref instead of traversing the full subtree. ([#3301](https://github.com/kubb-labs/kubb/pull/3301), [`647207f`](https://github.com/kubb-labs/kubb/commit/647207f135ae95f3b5bfcb67815eeea46954cfb8))
+- Export `collectLazy()` — a generator version of `collect()` that yields results one at a time without materializing an intermediate array. `getChildren()` and `collectRefs()` are now generators internally. `containsCircularRef()` exits at the first match. ([#3301](https://github.com/kubb-labs/kubb/pull/3301), [`647207f`](https://github.com/kubb-labs/kubb/commit/647207f135ae95f3b5bfcb67815eeea46954cfb8))
 
 ### Contributors
 
@@ -193,32 +150,13 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- Fix multiple configs in `defineConfig` array stopping after the first failure.
-  
-  Two bugs caused only one schema to be processed when using `defineConfig` with an array of configs:
-  
-  1. **`@kubb/cli`**: `process.exit(1)` was called immediately when any config failed, killing the process before remaining configs could run. Each config is now processed independently; the process exits with code 1 after all configs complete if any failed.
-  
-  2. **`@kubb/core`**: Middleware hooks registered during `setup()` were never removed from the shared `hooks` instance between config runs, causing N middleware instances to fire for the N-th config and producing duplicate output. Middleware listeners are now tracked and removed via `SetupResult.dispose()` at the end of each build. ([#3297](https://github.com/kubb-labs/kubb/pull/3297), [`d66969f`](https://github.com/kubb-labs/kubb/commit/d66969f52bb22ea417d931dc608c885a733c086b))
+- Fix multiple configs in `defineConfig` array stopping after the first failure. Each config is now processed independently; the process exits with code 1 after all configs complete if any failed. Middleware listeners are tracked and removed via `SetupResult.dispose()` between runs to prevent duplicate output. ([#3297](https://github.com/kubb-labs/kubb/pull/3297), [`d66969f`](https://github.com/kubb-labs/kubb/commit/d66969f52bb22ea417d931dc608c885a733c086b))
 
 ### @kubb/middleware-barrel
 
 #### Features
 
-- `getBarrelFiles` now returns a `Generator<FileNode>` instead of `Array<FileNode>`.
-  
-  Iterate with `for...of` or spread into an array to preserve existing behaviour:
-  
-  ```ts
-  // before
-  const files = getBarrelFiles({ ... })
-  
-  // after — iterate incrementally
-  for (const file of getBarrelFiles({ ... })) { ... }
-  
-  // after — spread to get an array
-  const files = [...getBarrelFiles({ ... })]
-  ``` ([#3294](https://github.com/kubb-labs/kubb/pull/3294), [`164881b`](https://github.com/kubb-labs/kubb/commit/164881b1cb18849b9f5491019971cf3f34c4f5ea))
+- `getBarrelFiles` now returns a `Generator<FileNode>` instead of `Array<FileNode>`. Iterate with `for...of` or spread with `[...getBarrelFiles({ ... })]`. ([#3294](https://github.com/kubb-labs/kubb/pull/3294), [`164881b`](https://github.com/kubb-labs/kubb/commit/164881b1cb18849b9f5491019971cf3f34c4f5ea))
 
 ### Contributors
 
@@ -232,9 +170,7 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- **Performance: memoize `$ref` resolution within `parse()`**
-  
-  `resolvedRefCache` — within a single `parse()` call, each `$ref` is now resolved at most once. Previously, a shared schema referenced from dozens of top-level schemas caused exponential sub-tree re-expansion. Stripe (~1 400 schemas) went from OOM at 8 GB to ~840 ms / ~15 MB. ([#3293](https://github.com/kubb-labs/kubb/pull/3293), [`3f5504b`](https://github.com/kubb-labs/kubb/commit/3f5504b689106063480f72fd1d18bca742613189))
+- Memoize `$ref` resolution within `parse()` so each `$ref` is resolved at most once. Stripe (~1 400 schemas) went from OOM at 8 GB to ~840 ms / ~15 MB. ([#3293](https://github.com/kubb-labs/kubb/pull/3293), [`3f5504b`](https://github.com/kubb-labs/kubb/commit/3f5504b689106063480f72fd1d18bca742613189))
 
 ### Contributors
 
@@ -248,50 +184,13 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Reduce peak memory by leaning on the existing `Storage` abstraction.
-  
-  `BuildOutput.sources`, `Kubb.sources`, and the `kubb:generation:end` hook payload no longer expose an in-memory `Map<string, string>` containing every rendered source string. They now expose a read-through `Storage` view scoped to the files written during the build and backed by `config.storage` (defaults to `fsStorage()`), so generated source bytes are not duplicated in memory.
-  
-  Read a generated source on demand with the existing `Storage` API:
-  
-  ```ts
-  const { storage } = await kubb.safeBuild()
-  const code = await storage.getItem('src/gen/api/getPets.ts')
-  const paths = await storage.getKeys()
-  ```
-  
-  `FileManager.dispose()` — clears the per-build FileNode cache. `PluginDriver.dispose()` calls it (and clears `inputNode`) at the end of every build so the parsed adapter graph is released once `kubb:build:end` has fired.
-  
-  `FileProcessor` now exposes a typed `events` property (`AsyncEventEmitter<FileProcessorEvents>`) with `start`, `update`, and `end` events. The previous `onStart`, `onUpdate`, and `onEnd` callback options have been removed. Subscribe once before calling `run()`:
-  
-  ```ts
-  fileProcessor.events.on('update', ({ file, source }) => {
-    // called for every file written
-  })
-  await fileProcessor.run(files, parseOptions)
-  ```
-  
-  `Kubb.driver` and `Kubb.config` now throw if accessed before `setup()` has been called, instead of returning `undefined`. Both properties are no longer typed as `| undefined`.
-  
-  Migration:
-  
-  - `BuildOutput.sources` → `BuildOutput.storage` (type changes from `Map<string, string>` to `Storage`).
-  - `KubbGenerationEndContext.files` has been removed; use `await storage.getKeys()` to enumerate the generated file paths.
-  - Listeners of `kubb:generation:end` that previously called `sources.get(path)` synchronously must now `await storage.getItem(path)`.
-  - The `kubb:generation:end` WebSocket payload (agent) no longer includes `files`; file paths are available as `Object.keys(storage)`.
-  - `FileProcessor.run()` no longer accepts `onStart`, `onUpdate`, or `onEnd` options; attach listeners via `fileProcessor.events.on(...)` before calling `run()`.
-  - `Kubb.driver` and `Kubb.config` are now non-optional — accessing them before `setup()` throws `Error('[kubb] setup() must be called before accessing …')`. ([#3285](https://github.com/kubb-labs/kubb/pull/3285), [`ec10ea8`](https://github.com/kubb-labs/kubb/commit/ec10ea83338d1b316402ea3a3040d8c177b3f3a9))
+- Reduce peak memory by leaning on the existing `Storage` abstraction. `BuildOutput.sources` is replaced by `BuildOutput.storage` — a read-through `Storage` view backed by `config.storage`. `FileProcessor` now exposes a typed `events` property with `start`, `update`, and `end` events; the previous `onStart`, `onUpdate`, and `onEnd` callback options are removed. `Kubb.driver` and `Kubb.config` now throw if accessed before `setup()` instead of returning `undefined`. ([#3285](https://github.com/kubb-labs/kubb/pull/3285), [`ec10ea8`](https://github.com/kubb-labs/kubb/commit/ec10ea83338d1b316402ea3a3040d8c177b3f3a9))
 
 ### @kubb/core
 
 #### Bug Fixes
 
-- Further reduce peak memory and redundant work during code generation.
-  
-  - **Per-plugin streaming writes**: files are written to `config.storage` after each plugin completes instead of all at once at the end of the build. Already-written files are skipped on subsequent flushes via a `writtenPaths` set.
-  - **`PARALLEL_CONCURRENCY_LIMIT` lowered from 100 → 16** — each flush only processes the files one plugin generated. 16 in-flight tasks bounds the number of `CodeNode` trees alive during rendering; I/O latency is the bottleneck so higher values offer no meaningful throughput improvement.
-  - **`PluginDriver.dispose()` now clears `#resolvers` and `#defaultResolvers`** so resolver closures (which may capture plugin options) are released when the driver is disposed at the end of a build.
-  - **`createSourcesView.getKeys(base)` avoids materialising the full key array** before filtering — it now iterates the `Set` directly and only allocates the result array. ([#3285](https://github.com/kubb-labs/kubb/pull/3285), [`0752d86`](https://github.com/kubb-labs/kubb/commit/0752d86904b11a52ec69dfc34e4dd21b01a8db6e))
+- Further reduce peak memory: files are written after each plugin completes and already-written files are skipped via a `writtenPaths` set. `PluginDriver.dispose()` clears `#resolvers` and `#defaultResolvers`. `createSourcesView.getKeys` iterates the `Set` directly instead of materialising the full key array. ([#3285](https://github.com/kubb-labs/kubb/pull/3285), [`0752d86`](https://github.com/kubb-labs/kubb/commit/0752d86904b11a52ec69dfc34e4dd21b01a8db6e))
 
 ### Contributors
 
@@ -305,7 +204,7 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- Resolve this for ast ([`7a6ba31`](https://github.com/kubb-labs/kubb/commit/7a6ba31b03dd4ccb313a37a273a153e85ce0ed44))
+- Fix `ThisType` augmentation in AST resolver type. ([`7a6ba31`](https://github.com/kubb-labs/kubb/commit/7a6ba31b03dd4ccb313a37a273a153e85ce0ed44))
 
 ### Contributors
 
@@ -319,7 +218,7 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- add ThisType to resolver type ([`54e54b4`](https://github.com/kubb-labs/kubb/commit/54e54b449f71badb0af72f65c3686ffb2168aad5))
+- Add `ThisType` to core resolver type. ([`54e54b4`](https://github.com/kubb-labs/kubb/commit/54e54b449f71badb0af72f65c3686ffb2168aad5))
 
 ### Contributors
 
@@ -339,19 +238,7 @@ Thanks to everyone who contributed to this release:
 
 #### Breaking Changes
 
-- Remove `createRenderer` export from `@kubb/renderer-jsx`. Use `jsxRenderer()` directly to obtain a renderer instance instead.
-  
-  ```ts
-  // Before
-  import { createRenderer } from '@kubb/renderer-jsx'
-  const renderer = createRenderer()
-  
-  // After
-  import { jsxRenderer } from '@kubb/renderer-jsx'
-  const renderer = jsxRenderer()
-  ```
-  
-  `jsxRenderer` is now a plain factory function with no dependency on `@kubb/core`, which resolves the circular package dependency between `@kubb/renderer-jsx` and `@kubb/core`. ([`0558297`](https://github.com/kubb-labs/kubb/commit/0558297712facdcd821529d8cdc0dc160b405c90))
+- Remove `createRenderer` export. Use `jsxRenderer()` directly to obtain a renderer instance. `jsxRenderer` is now a plain factory function with no dependency on `@kubb/core`, resolving the circular package dependency. ([`0558297`](https://github.com/kubb-labs/kubb/commit/0558297712facdcd821529d8cdc0dc160b405c90))
 
 ### Contributors
 
@@ -365,7 +252,7 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- Refactor CLI runners into per-command folders (`runners/generate/`, `runners/validate/`, `runners/agent/`, `runners/init/`, `runners/mcp/`), each with a dedicated `run.ts` and `utils.ts`. Fixes `import.meta.resolve` build warning in CJS output and corrects a faulty path-traversal guard in `hasPackageJson` that caused CI test failures. ([#3268](https://github.com/kubb-labs/kubb/pull/3268), [`5030b03`](https://github.com/kubb-labs/kubb/commit/5030b030f68cc6a56987ef2ff2a2bcbb295bebd6))
+- Refactor CLI runners into per-command folders (`runners/generate/`, `runners/validate/`, etc.), each with a dedicated `run.ts` and `utils.ts`. Fixes `import.meta.resolve` build warning and a faulty path-traversal guard in `hasPackageJson`. ([#3268](https://github.com/kubb-labs/kubb/pull/3268), [`5030b03`](https://github.com/kubb-labs/kubb/commit/5030b030f68cc6a56987ef2ff2a2bcbb295bebd6))
 
 ### @kubb/middleware-barrel
 
@@ -389,51 +276,32 @@ Thanks to everyone who contributed to this release:
 
 #### Breaking Changes
 
-- **Breaking change for `@kubb/adapter-oas`**: Remove `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API — these are implementation details that should not be exposed. Use `adapter.validate(input, options?)` instead for validation.
-  
-  **New feature for `@kubb/core`**: Add required `validate` method to the `Adapter<T>` type so all adapters must implement validation support.
-  
-  **Internal change for `@kubb/cli`**: Update the `kubb validate` command to use `adapterOas().validate()` instead of the removed standalone functions. ([#3249](https://github.com/kubb-labs/kubb/pull/3249), [`8a666d7`](https://github.com/kubb-labs/kubb/commit/8a666d76519017d0abe25ed35fbce87dbe311815))
+- Remove `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API. Use `adapter.validate(input, options?)` instead. ([#3249](https://github.com/kubb-labs/kubb/pull/3249), [`8a666d7`](https://github.com/kubb-labs/kubb/commit/8a666d76519017d0abe25ed35fbce87dbe311815))
 
 ### @kubb/agent
 
 #### Bug Fixes
 
-- fix(agent): copy full jiti package in nitro compiled hook so dist/babel.cjs is available in Docker ([`62fb218`](https://github.com/kubb-labs/kubb/commit/62fb218baff1829310a3f423fe8f829808159a4b))
+- Fix agent Docker build: copy full jiti package so `dist/babel.cjs` is available at runtime. ([`62fb218`](https://github.com/kubb-labs/kubb/commit/62fb218baff1829310a3f423fe8f829808159a4b))
 
 ### @kubb/cli
 
 #### Bug Fixes
 
-- **Breaking change for `@kubb/adapter-oas`**: Remove `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API — these are implementation details that should not be exposed. Use `adapter.validate(input, options?)` instead for validation.
-  
-  **New feature for `@kubb/core`**: Add required `validate` method to the `Adapter<T>` type so all adapters must implement validation support.
-  
-  **Internal change for `@kubb/cli`**: Update the `kubb validate` command to use `adapterOas().validate()` instead of the removed standalone functions. ([#3249](https://github.com/kubb-labs/kubb/pull/3249), [`8a666d7`](https://github.com/kubb-labs/kubb/commit/8a666d76519017d0abe25ed35fbce87dbe311815))
-- **@kubb/mcp**: Replace `@modelcontextprotocol/sdk` with `tmcp` for full TypeScript inference from Zod schemas. Add `validate` and `init` MCP tools alongside the existing `generate` tool. Export `createMcpServer` for platform integration. Add HTTP transport support via `--port` flag.
-  
-  **@kubb/cli**: Add `--port` (`-p`) and `--host` options to the `mcp` command for HTTP MCP server mode (omit both for stdio). ([#3254](https://github.com/kubb-labs/kubb/pull/3254), [`5fa651a`](https://github.com/kubb-labs/kubb/commit/5fa651a2fac316b621fe27beb78e6241c8c00fb0))
-- Make `@kubb/adapter-oas` an optional peer dependency of `@kubb/cli` for the `kubb validate` command.
-  
-  The CLI now lazy-loads `@kubb/adapter-oas` only when validation runs and shows install guidance when that package is not available. ([#3247](https://github.com/kubb-labs/kubb/pull/3247), [`38f92e9`](https://github.com/kubb-labs/kubb/commit/38f92e97ea1af1cac2539edb9378d468c4c42588))
+- Make `@kubb/adapter-oas` an optional peer dependency for the `kubb validate` command — lazy-loaded only when validation runs. ([#3247](https://github.com/kubb-labs/kubb/pull/3247), [`38f92e9`](https://github.com/kubb-labs/kubb/commit/38f92e97ea1af1cac2539edb9378d468c4c42588))
+- Add `--port` (`-p`) and `--host` options to the `mcp` command for HTTP MCP server mode. ([#3254](https://github.com/kubb-labs/kubb/pull/3254), [`5fa651a`](https://github.com/kubb-labs/kubb/commit/5fa651a2fac316b621fe27beb78e6241c8c00fb0))
 
 ### @kubb/core
 
 #### Features
 
-- **Breaking change for `@kubb/adapter-oas`**: Remove `parseDocument`, `parseFromConfig`, and `validateDocument` from the public API — these are implementation details that should not be exposed. Use `adapter.validate(input, options?)` instead for validation.
-  
-  **New feature for `@kubb/core`**: Add required `validate` method to the `Adapter<T>` type so all adapters must implement validation support.
-  
-  **Internal change for `@kubb/cli`**: Update the `kubb validate` command to use `adapterOas().validate()` instead of the removed standalone functions. ([#3249](https://github.com/kubb-labs/kubb/pull/3249), [`8a666d7`](https://github.com/kubb-labs/kubb/commit/8a666d76519017d0abe25ed35fbce87dbe311815))
+- Add required `validate` method to the `Adapter<T>` type so all adapters must implement validation support. ([#3249](https://github.com/kubb-labs/kubb/pull/3249), [`8a666d7`](https://github.com/kubb-labs/kubb/commit/8a666d76519017d0abe25ed35fbce87dbe311815))
 
 ### @kubb/mcp
 
 #### Features
 
-- **@kubb/mcp**: Replace `@modelcontextprotocol/sdk` with `tmcp` for full TypeScript inference from Zod schemas. Add `validate` and `init` MCP tools alongside the existing `generate` tool. Export `createMcpServer` for platform integration. Add HTTP transport support via `--port` flag.
-  
-  **@kubb/cli**: Add `--port` (`-p`) and `--host` options to the `mcp` command for HTTP MCP server mode (omit both for stdio). ([#3254](https://github.com/kubb-labs/kubb/pull/3254), [`5fa651a`](https://github.com/kubb-labs/kubb/commit/5fa651a2fac316b621fe27beb78e6241c8c00fb0))
+- Replace `@modelcontextprotocol/sdk` with `tmcp` for full TypeScript inference from Zod schemas. Add `validate` and `init` MCP tools. Export `createMcpServer`. Add HTTP transport support via `--port` flag. ([#3254](https://github.com/kubb-labs/kubb/pull/3254), [`5fa651a`](https://github.com/kubb-labs/kubb/commit/5fa651a2fac316b621fe27beb78e6241c8c00fb0))
 
 ### Contributors
 
@@ -447,23 +315,21 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- Add `@kubb/parser-ts` to the default `KUBB_PACKAGES` build ARG in the agent Dockerfile.
-  
-  `kubb.config.ts` files that import `@kubb/parser-ts` (e.g. to use `parserTs`) would fail at runtime inside the Docker container with `Cannot find package '@kubb/parser-ts'` because the package was not explicitly listed in the installer stage. It is now included alongside the other Kubb packages. ([#3233](https://github.com/kubb-labs/kubb/pull/3233), [`23d60be`](https://github.com/kubb-labs/kubb/commit/23d60bef6ac3d14100efd7b39de85f1b4cc23cce))
-- Fix Docker build failure on distroless image by replacing `RUN chown` (requires a shell) with `--chown` flags on `COPY` instructions. ([#3231](https://github.com/kubb-labs/kubb/pull/3231), [`2fe62b5`](https://github.com/kubb-labs/kubb/commit/2fe62b5d8ae26f14acb44fe072608a2945736cbf))
-- Replace `unrun` with `jiti` for loading TypeScript config files at runtime. `jiti` is pure JavaScript (no native binaries), eliminating platform-specific `.node` binding errors when running on `linux-arm64` or other architectures that differ from the build host. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
+- Add `@kubb/parser-ts` to the default `KUBB_PACKAGES` build ARG in the agent Dockerfile. ([#3233](https://github.com/kubb-labs/kubb/pull/3233), [`23d60be`](https://github.com/kubb-labs/kubb/commit/23d60bef6ac3d14100efd7b39de85f1b4cc23cce))
+- Fix Docker build failure on distroless image by replacing `RUN chown` with `--chown` flags on `COPY` instructions. ([#3231](https://github.com/kubb-labs/kubb/pull/3231), [`2fe62b5`](https://github.com/kubb-labs/kubb/commit/2fe62b5d8ae26f14acb44fe072608a2945736cbf))
+- Replace `unrun` with `jiti` for loading TypeScript config files at runtime — pure JavaScript, no native binaries. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
 
 ### @kubb/cli
 
 #### Bug Fixes
 
-- Replace `unrun` with `jiti` for loading TypeScript config files at runtime. `jiti` is pure JavaScript (no native binaries), eliminating platform-specific `.node` binding errors when running on `linux-arm64` or other architectures that differ from the build host. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
+- Replace `unrun` with `jiti` for loading TypeScript config files at runtime. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
 
 ### @kubb/mcp
 
 #### Bug Fixes
 
-- Replace `unrun` with `jiti` for loading TypeScript config files at runtime. `jiti` is pure JavaScript (no native binaries), eliminating platform-specific `.node` binding errors when running on `linux-arm64` or other architectures that differ from the build host. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
+- Replace `unrun` with `jiti` for loading TypeScript config files at runtime. ([`ea3233b`](https://github.com/kubb-labs/kubb/commit/ea3233b3aaba0c713eaddd94be787dfe2af9ead4))
 
 ### Contributors
 
@@ -477,69 +343,25 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Each package now ships an `extension.yaml` file with its npm release.
-  
-  - `adapter-oas` → `extension.yaml` (`kind: adapter`)
-  - `middleware-barrel` → `extension.yaml` (`kind: middleware`)
-  - `parser-ts` → `extension.yaml` (`kind: parser`)
-  
-  Each file is a self-contained extension manifest: it describes the package's options, examples, and resources, and references the unified `extension.json` schema for IDE validation. Third-party adapters, middlewares, and parsers follow the same pattern — one `extension.yaml` per package with the appropriate `kind` field. ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
+- Ship an `extension.yaml` manifest (`kind: adapter`) describing the package's options, examples, and resources. References the shared `extension.json` schema for IDE validation. ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
 
 ### @kubb/core
 
 #### Features
 
-- Make `adapter` and `input` optional in `Config` and `UserConfig` to support plugin-only mode.
-  
-  When `adapter` is omitted, Kubb skips the spec parse phase and runs in plugin-only mode:
-  - `kubb:plugin:setup` fires normally — `injectFile` works as usual
-  - Files injected via `injectFile` are written through storage as usual
-  - `kubb:build:start` is **not** emitted (no `inputNode`)
-  - `kubb:generate:schema` / `kubb:generate:operation` are never emitted
-  
-  This enables scripts that use Kubb purely for its file-management layer without needing a dummy OpenAPI spec.
-  
-  ```ts
-  // before — a dummy spec was required even for file-injection-only scripts
-  export default defineConfig({
-    input: { path: './dummy.yaml' },
-    output: { path: '.' },
-    adapter: adapterOas(),
-    plugins: [myFilePlugin()],
-  })
-  
-  // after — adapter and input can be omitted entirely
-  export default defineConfig({
-    output: { path: '.' },
-    plugins: [myFilePlugin()],
-  })
-  ```
-  
-  When `adapter` is set but `input` is omitted, a clear runtime error is thrown: `[kubb] input is required when using an adapter`. ([#3226](https://github.com/kubb-labs/kubb/pull/3226), [`81fbfae`](https://github.com/kubb-labs/kubb/commit/81fbfae1347bd63e1f91b2aca1f9fb14d157f85f))
+- Make `adapter` and `input` optional in `Config` to support plugin-only mode. When `adapter` is omitted, Kubb skips the spec parse phase and runs using only its file-management layer. ([#3226](https://github.com/kubb-labs/kubb/pull/3226), [`81fbfae`](https://github.com/kubb-labs/kubb/commit/81fbfae1347bd63e1f91b2aca1f9fb14d157f85f))
 
 ### @kubb/middleware-barrel
 
 #### Features
 
-- Each package now ships an `extension.yaml` file with its npm release.
-  
-  - `adapter-oas` → `extension.yaml` (`kind: adapter`)
-  - `middleware-barrel` → `extension.yaml` (`kind: middleware`)
-  - `parser-ts` → `extension.yaml` (`kind: parser`)
-  
-  Each file is a self-contained extension manifest: it describes the package's options, examples, and resources, and references the unified `extension.json` schema for IDE validation. Third-party adapters, middlewares, and parsers follow the same pattern — one `extension.yaml` per package with the appropriate `kind` field. ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
+- Ship an `extension.yaml` manifest (`kind: middleware`). ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
 
 ### @kubb/parser-ts
 
 #### Features
 
-- Each package now ships an `extension.yaml` file with its npm release.
-  
-  - `adapter-oas` → `extension.yaml` (`kind: adapter`)
-  - `middleware-barrel` → `extension.yaml` (`kind: middleware`)
-  - `parser-ts` → `extension.yaml` (`kind: parser`)
-  
-  Each file is a self-contained extension manifest: it describes the package's options, examples, and resources, and references the unified `extension.json` schema for IDE validation. Third-party adapters, middlewares, and parsers follow the same pattern — one `extension.yaml` per package with the appropriate `kind` field. ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
+- Ship an `extension.yaml` manifest (`kind: parser`). ([#3224](https://github.com/kubb-labs/kubb/pull/3224), [`0542031`](https://github.com/kubb-labs/kubb/commit/054203191e62b5035a1f731a1e1d2d13e1b174f0))
 
 ### Contributors
 
@@ -553,33 +375,19 @@ Thanks to everyone who contributed to this release:
 
 #### Bug Fixes
 
-- Fixed `combineImports` producing duplicate object-named import specifiers.
-  
-  `Set`-based deduplication failed for object import names (e.g. `{ propertyName: 'fakerDE', name: 'faker' }`) because JavaScript compares objects by reference. When the same aliased specifier appeared in multiple `ImportNode`s for the same path, the merged result contained duplicate entries.
-  
-  The fix memoizes object import names inside `combineImports` so that identical `(propertyName, name)` pairs always reuse the same object reference, allowing `Set.add` to correctly recognise and skip duplicates. ([#3217](https://github.com/kubb-labs/kubb/pull/3217), [`4759c9c`](https://github.com/kubb-labs/kubb/commit/4759c9c2cc83e60a93c8dacec4fc9da18852e027))
+- Fix `combineImports` producing duplicate object-named import specifiers. `Set`-based deduplication failed for object import names because objects are compared by reference; the fix memoizes `(propertyName, name)` pairs so identical specifiers reuse the same object reference. ([#3217](https://github.com/kubb-labs/kubb/pull/3217), [`4759c9c`](https://github.com/kubb-labs/kubb/commit/4759c9c2cc83e60a93c8dacec4fc9da18852e027))
 
 ### @kubb/cli
 
 #### Bug Fixes
 
-- Reduce default install size by moving `@kubb/agent` and `@kubb/mcp` to optional `peerDependencies`. The CLI never imports them at runtime — they expose their own `kubb-mcp` / agent entry points. Install them explicitly when needed:
-  
-  ```bash
-  npm i @kubb/mcp     # for the MCP server
-  npm i @kubb/agent   # for the HTTP agent
-  ``` ([#3215](https://github.com/kubb-labs/kubb/pull/3215), [`9ecce54`](https://github.com/kubb-labs/kubb/commit/9ecce5432a26a3e3e91addb2af3f76fb2554e621))
+- Move `@kubb/agent` and `@kubb/mcp` to optional `peerDependencies` to reduce default install size. ([#3215](https://github.com/kubb-labs/kubb/pull/3215), [`9ecce54`](https://github.com/kubb-labs/kubb/commit/9ecce5432a26a3e3e91addb2af3f76fb2554e621))
 
 ### kubb
 
 #### Bug Fixes
 
-- Reduce default install size by moving `@kubb/agent` and `@kubb/mcp` to optional `peerDependencies`. The CLI never imports them at runtime — they expose their own `kubb-mcp` / agent entry points. Install them explicitly when needed:
-  
-  ```bash
-  npm i @kubb/mcp     # for the MCP server
-  npm i @kubb/agent   # for the HTTP agent
-  ``` ([#3215](https://github.com/kubb-labs/kubb/pull/3215), [`9ecce54`](https://github.com/kubb-labs/kubb/commit/9ecce5432a26a3e3e91addb2af3f76fb2554e621))
+- Move `@kubb/agent` and `@kubb/mcp` to optional `peerDependencies` to reduce default install size. ([#3215](https://github.com/kubb-labs/kubb/pull/3215), [`9ecce54`](https://github.com/kubb-labs/kubb/commit/9ecce5432a26a3e3e91addb2af3f76fb2554e621))
 
 ### Contributors
 
@@ -593,135 +401,29 @@ Thanks to everyone who contributed to this release:
 
 #### Features
 
-- Change the default value of `integerType` from `'number'` to `'bigint'`.
-  
-  `int64` fields in OpenAPI specs are now mapped to `bigint` by default. To preserve the previous behaviour, set `integerType: 'number'` explicitly in your adapter options. ([#3209](https://github.com/kubb-labs/kubb/pull/3209), [`9e90cbb`](https://github.com/kubb-labs/kubb/commit/9e90cbb2d0ded12d839739b9a13ab15532d38541))
+- Change the default value of `integerType` from `'number'` to `'bigint'`. `int64` fields are now mapped to `bigint` by default; set `integerType: 'number'` to preserve the previous behaviour. ([#3209](https://github.com/kubb-labs/kubb/pull/3209), [`9e90cbb`](https://github.com/kubb-labs/kubb/commit/9e90cbb2d0ded12d839739b9a13ab15532d38541))
 
 ### @kubb/ast
 
 #### Features
 
-- Fix `include` filter not preventing generation of component schemas from excluded operations.
-  
-  When `include` contains operation-based filters (`tag`, `operationId`, `path`, `method`, or `contentType`), only the schemas transitively referenced by the included operations are now generated. Schemas that are only used by excluded operations are silently skipped.
-  
-  **New `@kubb/ast` export: `collectUsedSchemaNames`**
-  
-  ```ts
-  import { collectUsedSchemaNames } from '@kubb/ast'
-  
-  // Returns the set of top-level schema names reachable from the given operations.
-  const allowed = collectUsedSchemaNames(includedOperations, inputNode.schemas)
-  ```
-  
-  **Before** (all schemas generated regardless of `include`):
-  
-  ```
-  types/
-  ├── ItemStatus.ts     ✅
-  ├── ItemsResponse.ts  ✅
-  ├── OrderStatus.ts    ❌ generated even though getOrders is excluded
-  └── OrdersResponse.ts ❌ generated even though getOrders is excluded
-  ```
-  
-  **After** (only schemas reachable from included operations):
-  
-  ```
-  types/
-  ├── ItemStatus.ts     ✅
-  └── ItemsResponse.ts  ✅
-  ```
-  
-  > [!NOTE]
-  > When `include` contains a `schemaName` filter alongside operation filters, the new schema-scoping logic is disabled and `schemaName` rules apply instead. ([#3208](https://github.com/kubb-labs/kubb/pull/3208), [`3cd3a09`](https://github.com/kubb-labs/kubb/commit/3cd3a0984c5cd6c77bc771d791b401e134f2003a))
+- Fix `include` filter not preventing generation of component schemas from excluded operations. Only schemas transitively referenced by included operations are now generated. New export: `collectUsedSchemaNames(operations, schemas)`. ([#3208](https://github.com/kubb-labs/kubb/pull/3208), [`3cd3a09`](https://github.com/kubb-labs/kubb/commit/3cd3a0984c5cd6c77bc771d791b401e134f2003a))
 
 #### Bug Fixes
 
-- Fixed `combineImports` incorrectly tree-shaking aliased named imports.
-  
-  When an import uses a local alias (e.g. `import { fakerDE as faker } from '@faker-js/faker'`), the used-check now tests the alias (`faker`) rather than the original export name (`fakerDE`). Previously, any aliased import whose propertyName did not appear verbatim in the generated source was silently dropped, leaving files with no import at all. ([#3212](https://github.com/kubb-labs/kubb/pull/3212), [`0e5bfaa`](https://github.com/kubb-labs/kubb/commit/0e5bfaabbced0e67ba560fda5bf6b3c380b63258))
+- Fix `combineImports` incorrectly tree-shaking aliased named imports — the used-check now tests the alias rather than the original export name. ([#3212](https://github.com/kubb-labs/kubb/pull/3212), [`0e5bfaa`](https://github.com/kubb-labs/kubb/commit/0e5bfaabbced0e67ba560fda5bf6b3c380b63258))
 
 ### @kubb/core
 
 #### Bug Fixes
 
-- Fix `include` filter not preventing generation of component schemas from excluded operations.
-  
-  When `include` contains operation-based filters (`tag`, `operationId`, `path`, `method`, or `contentType`), only the schemas transitively referenced by the included operations are now generated. Schemas that are only used by excluded operations are silently skipped.
-  
-  **New `@kubb/ast` export: `collectUsedSchemaNames`**
-  
-  ```ts
-  import { collectUsedSchemaNames } from '@kubb/ast'
-  
-  // Returns the set of top-level schema names reachable from the given operations.
-  const allowed = collectUsedSchemaNames(includedOperations, inputNode.schemas)
-  ```
-  
-  **Before** (all schemas generated regardless of `include`):
-  
-  ```
-  types/
-  ├── ItemStatus.ts     ✅
-  ├── ItemsResponse.ts  ✅
-  ├── OrderStatus.ts    ❌ generated even though getOrders is excluded
-  └── OrdersResponse.ts ❌ generated even though getOrders is excluded
-  ```
-  
-  **After** (only schemas reachable from included operations):
-  
-  ```
-  types/
-  ├── ItemStatus.ts     ✅
-  └── ItemsResponse.ts  ✅
-  ```
-  
-  > [!NOTE]
-  > When `include` contains a `schemaName` filter alongside operation filters, the new schema-scoping logic is disabled and `schemaName` rules apply instead. ([#3208](https://github.com/kubb-labs/kubb/pull/3208), [`3cd3a09`](https://github.com/kubb-labs/kubb/commit/3cd3a0984c5cd6c77bc771d791b401e134f2003a))
+- Fix `include` filter scoping: only schemas reachable from included operations are generated. ([#3208](https://github.com/kubb-labs/kubb/pull/3208), [`3cd3a09`](https://github.com/kubb-labs/kubb/commit/3cd3a0984c5cd6c77bc771d791b401e134f2003a))
 
 ### @kubb/middleware-barrel
 
 #### Breaking Changes
 
-- Refactor middleware-barrel API from string-based `barrelType` to object-based `barrel` configuration.
-  
-  **Breaking Changes:**
-  
-  - `barrelType` option replaced with `barrel` object at both config and plugin levels
-  - `barrelType: 'propagate'` replaced with `barrel: { type: 'all' | 'named', nested: true }`
-  - Root config: `barrel?: { type: 'all' | 'named' } | false`
-  - Plugin level: `barrel?: { type: 'all' | 'named', nested?: boolean } | false`
-  
-  **Migration Guide:**
-  
-  ```ts
-  // Before
-  export default defineConfig({
-    output: { path: 'src/gen', barrelType: 'named' },
-    plugins: [
-      pluginTs({ output: { path: 'types', barrelType: 'all' } }),
-      pluginZod({ output: { path: 'schemas', barrelType: 'propagate' } }),
-    ],
-    middleware: [middlewareBarrel()],
-  })
-  
-  // After
-  export default defineConfig({
-    output: { path: 'src/gen', barrel: { type: 'named' } },
-    plugins: [
-      pluginTs({ output: { path: 'types', barrel: { type: 'all' } } }),
-      pluginZod({ output: { path: 'schemas', barrel: { type: 'all', nested: true } } }),
-    ],
-    middleware: [middlewareBarrel()],
-  })
-  ```
-  
-  **New Features:**
-  
-  - Explicit `nested` option for hierarchical barrel generation at plugin level
-  - Clearer separation of export strategy (`type`) from structure (`nested`)
-  - Better type safety with distinct `BarrelConfig` and `PluginBarrelConfig` types
-  - `nested` parameter in `getBarrelFiles` for fine-grained control ([#3200](https://github.com/kubb-labs/kubb/pull/3200), [`3519370`](https://github.com/kubb-labs/kubb/commit/35193705080f85f60bbb20d4e525724a9f19a3c4))
+- Replace string-based `barrelType` with an object-based `barrel` configuration. Root config: `barrel?: { type: 'all' | 'named' } | false`. Plugin level: `barrel?: { type: 'all' | 'named', nested?: boolean } | false`. `barrelType: 'propagate'` becomes `barrel: { type: 'all' | 'named', nested: true }`. ([#3200](https://github.com/kubb-labs/kubb/pull/3200), [`3519370`](https://github.com/kubb-labs/kubb/commit/35193705080f85f60bbb20d4e525724a9f19a3c4))
 
 ### Contributors
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,57 +12,13 @@
 
 #### Bug Fixes
 
-- Add `Symbol.dispose` support and fix resource cleanup.
-  
-  `FileManager` and `PluginDriver` now implement `[Symbol.dispose]()`, making them compatible with TypeScript's `using` declaration. `safeBuild()` internally uses `using` instead of a `try/finally` block to guarantee `SetupResult` teardown on all exit paths.
-  
-  Three genuine resource leaks are also fixed:
-  
-  - **Watch mode**: the chokidar watcher is now closed on `SIGINT`/`SIGTERM` (previously the process would hang after Ctrl-C)
-  - **Studio WebSocket**: the `message` event listener is now removed in `cleanup()` alongside the other listeners
-  - **MCP HTTP server**: `SIGINT`/`SIGTERM` now trigger a graceful `server.close()`
-  
-  No API changes — all existing `dispose()` calls continue to work unchanged. ([#3321](https://github.com/kubb-labs/kubb/pull/3321), [`03ad8ce`](https://github.com/kubb-labs/kubb/commit/03ad8ce7757bdbe408ed291185424b2f2d9fe5ed))
+- Add `Symbol.dispose` support: `FileManager` and `PluginDriver` implement `[Symbol.dispose]()`. `safeBuild()` uses `using` instead of `try/finally`. Fix resource leaks: chokidar watcher closes on `SIGINT`/`SIGTERM`; Studio WebSocket `message` listener removed in `cleanup()`; MCP HTTP server closes gracefully on signal. ([#3321](https://github.com/kubb-labs/kubb/pull/3321), [`03ad8ce`](https://github.com/kubb-labs/kubb/commit/03ad8ce7757bdbe408ed291185424b2f2d9fe5ed))
 
 ### @kubb/renderer-jsx
 
 #### Bug Fixes
 
-- JSX rendering is now 2–4× faster with `jsxRendererSync`
-  
-  Two new optimisations in `@kubb/renderer-jsx` cut render time significantly with no changes required to existing generators.
-  
-  **`jsxRendererSync`: React-free recursive renderer**
-  
-  A new `jsxRendererSync` factory replaces React's fiber scheduler with a lightweight recursive tree walk. Because all Kubb components are pure functions, the full React work loop is unnecessary overhead. Swap `jsxRenderer` for `jsxRendererSync` in any generator and it just gets faster:
-  
-  ```ts
-  import { jsxRendererSync } from '@kubb/renderer-jsx'
-  
-  export const myGenerator = defineGenerator({
-    renderer: jsxRendererSync, // was: jsxRenderer
-    // ...
-  })
-  ```
-  
-  Measured improvement on a 150-file schema: **12.9 ms → 5.6 ms**.
-  
-  **`jsxRendererSync().stream()`: process files as they are rendered**
-  
-  For generators that produce many files, the new `stream()` method yields each `FileNode` as soon as it is ready, before the rest of the element tree is processed, so downstream work can start immediately:
-  
-  ```ts
-  const renderer = jsxRendererSync()
-  for await (const file of renderer.stream(element)) {
-    await writeFile(file) // starts before the next file is rendered
-  }
-  ```
-  
-  **Lower memory use**
-  
-  Node attributes now use plain objects instead of `Map`, eliminating ~300 bytes of V8 overhead per virtual DOM node. The three separate tree walks previously done per file element (sources, exports, imports) are now a single generator pass.
-  
-  `jsxRenderer` is unchanged and all new APIs are purely additive. ([#3319](https://github.com/kubb-labs/kubb/pull/3319), [`6ab3a5e`](https://github.com/kubb-labs/kubb/commit/6ab3a5e97750e7a572a61ffadfb3ccb2ad2b0fe1))
+- Add `jsxRendererSync` — a React-free recursive renderer 2–4× faster than `jsxRenderer`. Add `stream()` for incremental file processing. Node attributes use plain objects instead of `Map`. `jsxRenderer` is unchanged; all new APIs are additive. ([#3319](https://github.com/kubb-labs/kubb/pull/3319), [`6ab3a5e`](https://github.com/kubb-labs/kubb/commit/6ab3a5e97750e7a572a61ffadfb3ccb2ad2b0fe1))
 
 ### Contributors
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `FileManager` and `PluginDriver` now implement `[Symbol.dispose]()`, making them compatible with TypeScript's `using` declaration
- `safeBuild()` uses `using` internally instead of `try/finally` to guarantee `SetupResult` teardown on all exit paths
- Fix three resource leaks: chokidar watcher now closes on `SIGINT`/`SIGTERM`; Studio WebSocket `message` listener is removed in `cleanup()`; MCP HTTP server closes gracefully on `SIGINT`/`SIGTERM`
- Shorten and deduplicate all changeset descriptions; remove contradictory bullets
- Fix `fix-bunx-argv-stripping` changeset: package was `@internals/utils`, corrected to `@kubb/cli`
- Remove `@internals/utils` and `@internals/shared` from `pre.json` `initialVersions`
- Add three missing changesets to `pre.json`: `add-symbol-dispose-resource-management`, `cool-jokes-pump`, `perf-renderer-jsx-legacyroot-sync`

## Test plan

- [ ] `pnpm typecheck` — no errors
- [ ] `pnpm test` — no regressions
- [ ] Watch mode: run `kubb generate --watch`, send `SIGINT` — process exits cleanly
- [ ] Verify `pre.json` has no `@internals` entries

https://claude.ai/code/session_01WWG8mQBTxGdoLD4zA8x8Ka
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WWG8mQBTxGdoLD4zA8x8Ka)_