### PR TITLE
ci(release): re-enable npm provenance for v4 publishes

### DIFF
--- a/.changeset/re-enable-npm-provenance.md
+++ b/.changeset/re-enable-npm-provenance.md
@@ -1,0 +1,5 @@
+---
+"@kubb/core": patch
+---
+
+Re-enable npm provenance for published packages. Restores `NPM_CONFIG_PROVENANCE: true` and the `id-token: write` permission in the release workflow so subsequent v4 releases are published with provenance attestations again.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   actions: write
   contents: write
+  id-token: write
   models: read
   packages: write
   pull-requests: write
@@ -65,6 +66,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish ${{ inputs.tag || 'canary' }}
@@ -73,6 +75,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
           git checkout main


### PR DESCRIPTION
## Summary

Re-enables npm provenance for kubb v4 releases, as discussed in #3338. Provenance was temporarily removed in 61e0405 to unblock a v4 publish; this PR restores it and ships a changeset so the next v4 release picks up the change.

## Changes

- `.github/workflows/release.yml`:
  - Restore the `id-token: write` workflow permission (required for npm OIDC provenance).
  - Add `NPM_CONFIG_PROVENANCE: true` back to both the changesets publish step and the canary publish step, alongside the existing `NODE_AUTH_TOKEN`/`NPM_TOKEN`-based auth.
- `.changeset/re-enable-npm-provenance.md`: patch bump on `@kubb/core` so a new v4 version is cut and published with provenance enabled again.

Closes #3338

## Test plan

- [ ] Merge to `v4`, confirm the changesets "Version Packages" PR contains the patch bump.
- [ ] On release, verify the npm registry shows a provenance attestation on the new `@kubb/*` versions (the green "Provenance" badge / `npm view <pkg> --json` `dist.attestations`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UShVhmBjD6vNNMCoVq5GHQ)_