### PR TITLE
fix(ci): ensure NPM_TOKEN is used for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,11 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+      - name: Configure npm auth
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> "${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish
         id: changesets
         uses: changesets/action@v1
@@ -76,6 +81,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           RELEASE_TAG: ${{ inputs.tag || 'canary' }}
         run: |
           git checkout main


### PR DESCRIPTION
## Summary

- The `Setup Tools` action (which uses `actions/setup-node` internally) sets `NPM_CONFIG_USERCONFIG` to a temp `.npmrc` that authenticates via `NODE_AUTH_TOKEN`
- The `changesets/action` creates `~/.npmrc` with `NPM_TOKEN`, but npm ignores `~/.npmrc` when `NPM_CONFIG_USERCONFIG` is set — so publish was hitting npm with the wrong credential, causing E404 on every package
- Add a **Configure npm auth** step that appends the publish token to whichever `.npmrc` file npm actually reads (`$NPM_CONFIG_USERCONFIG`, or `~/.npmrc` as fallback)
- Pass `NPM_TOKEN` explicitly to both the changesets Publish step and the canary Publish step

## Test plan

- [ ] Verify the next release run no longer produces `E404 Not Found - PUT https://registry.npmjs.org/...` errors
- [ ] Verify canary publishes also succeed (the auth file is outside the git tree so `git checkout main` does not clobber it)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GavSdp84rxx3Jnu5oQqgKx)_