### PR TITLE
feat(agent): forward full Kubb lifecycle event set to Studio

### DIFF
--- a/.changeset/agent-studio-event-parity.md
+++ b/.changeset/agent-studio-event-parity.md
@@ -1,0 +1,7 @@
+---
+'@kubb/agent': minor
+---
+
+Forward additional Kubb lifecycle events to Studio for full event parity with `@kubb/core`.
+
+The agent now relays `kubb:lifecycle:start`, `kubb:lifecycle:end`, `kubb:build:start`, `kubb:build:end`, `kubb:format:start`, `kubb:format:end`, `kubb:lint:start`, `kubb:lint:end`, and `kubb:generation:summary` over the Studio WebSocket. Studio can now render a complete build timeline (per-config build span, format/lint phases) and final generation summary (duration, file count, failed plugins).

--- a/packages/agent/server/types/agent.ts
+++ b/packages/agent/server/types/agent.ts
@@ -45,6 +45,8 @@ export type JSONKubbConfig = {
 export type KubbHooks = {
   'kubb:plugin:start': [ctx: { plugin: { name: string } }]
   'kubb:plugin:end': [ctx: { plugin: { name: string }; duration: number; success: boolean }]
+  'kubb:build:start': [ctx: { config: { name?: string }; adapter: { name: string } }]
+  'kubb:build:end': [ctx: { files: Array<{ path: string; name: string }>; outputDir: string }]
   'kubb:files:processing:start': [ctx: { total: number }]
   'kubb:files:processing:update': [
     ctx: {
@@ -63,7 +65,13 @@ export type KubbHooks = {
   'kubb:error': [ctx: { message: string; stack?: string }]
   'kubb:generation:start': [ctx: { name?: string; plugins: number }]
   'kubb:generation:end': [ctx: { config: Config; storage: Record<string, string> }]
+  'kubb:generation:summary': [ctx: { duration: number; fileCount: number; failedPlugins: number; status: 'success' | 'failed' }]
+  'kubb:lifecycle:start': []
   'kubb:lifecycle:end': []
+  'kubb:format:start': []
+  'kubb:format:end': []
+  'kubb:lint:start': []
+  'kubb:lint:end': []
 }
 
 export type KubbHook = keyof KubbHooks

--- a/packages/agent/server/utils/ws.ts
+++ b/packages/agent/server/utils/ws.ts
@@ -62,6 +62,22 @@ export function setupEventsStream(ws: WebSocket, hooks: AsyncEventEmitter<KubbHo
     })
   })
 
+  hooks.on('kubb:build:start', ({ config, adapter }) => {
+    sendDataMessage({
+      type: 'kubb:build:start',
+      data: [{ config: { name: config.name }, adapter: { name: adapter.name } }],
+      timestamp: Date.now(),
+    })
+  })
+
+  hooks.on('kubb:build:end', ({ files, outputDir }) => {
+    sendDataMessage({
+      type: 'kubb:build:end',
+      data: [{ files: files.map((file) => ({ path: file.path, name: file.name })), outputDir }],
+      timestamp: Date.now(),
+    })
+  })
+
   hooks.on('kubb:files:processing:start', ({ files }) => {
     sendDataMessage({
       type: 'kubb:files:processing:start',
@@ -159,5 +175,40 @@ export function setupEventsStream(ws: WebSocket, hooks: AsyncEventEmitter<KubbHo
       ],
       timestamp: Date.now(),
     })
+  })
+
+  hooks.on('kubb:generation:summary', ({ failedPlugins, status, hrStart, filesCreated }) => {
+    const [seconds, nanoseconds] = process.hrtime(hrStart)
+    const duration = Math.round(seconds * 1000 + nanoseconds / 1_000_000)
+
+    sendDataMessage({
+      type: 'kubb:generation:summary',
+      data: [{ duration, fileCount: filesCreated, failedPlugins: failedPlugins.size, status }],
+      timestamp: Date.now(),
+    })
+  })
+
+  hooks.on('kubb:lifecycle:start', () => {
+    sendDataMessage({ type: 'kubb:lifecycle:start', data: [], timestamp: Date.now() })
+  })
+
+  hooks.on('kubb:lifecycle:end', () => {
+    sendDataMessage({ type: 'kubb:lifecycle:end', data: [], timestamp: Date.now() })
+  })
+
+  hooks.on('kubb:format:start', () => {
+    sendDataMessage({ type: 'kubb:format:start', data: [], timestamp: Date.now() })
+  })
+
+  hooks.on('kubb:format:end', () => {
+    sendDataMessage({ type: 'kubb:format:end', data: [], timestamp: Date.now() })
+  })
+
+  hooks.on('kubb:lint:start', () => {
+    sendDataMessage({ type: 'kubb:lint:start', data: [], timestamp: Date.now() })
+  })
+
+  hooks.on('kubb:lint:end', () => {
+    sendDataMessage({ type: 'kubb:lint:end', data: [], timestamp: Date.now() })
   })
 }


### PR DESCRIPTION
## Summary

Implements gaps 2 and 3 of [`plans/studio-event-parity.md`](https://github.com/kubb-labs/kubb/blob/main/plans/studio-event-parity.md) — the agent now forwards the full set of relevant `KubbHooks` events from `@kubb/core` to Studio over WebSocket.

### Added forwarders (`packages/agent/server/utils/ws.ts`)
- `kubb:lifecycle:start` / `kubb:lifecycle:end` — bracket the format/lint/hooks phase
- `kubb:build:start` / `kubb:build:end` — per-config-entry build span with adapter name, file list, and output directory
- `kubb:format:start` / `kubb:format:end` — formatter timeline span
- `kubb:lint:start` / `kubb:lint:end` — linter timeline span
- `kubb:generation:summary` — final summary with duration (ms), file count, failed-plugin count, and status

### Type additions (`packages/agent/server/types/agent.ts`)
Matching `KubbHooks` entries with JSON-serializable shapes so Studio can type its consumers.

### Skipped (per plan)
`kubb:generate:schema` / `kubb:generate:operation(s)`, `kubb:plugin:setup`, `kubb:plugins:end`, `kubb:debug`, `kubb:config:*`, `kubb:hook(s):*`, and `kubb:version:new` — all too granular or CLI-only for the Studio UI.

## Test plan

- [x] `pnpm --filter @kubb/agent test` — 95 tests pass
- [x] `pnpm --filter @kubb/agent typecheck` — clean
- [ ] Verify Studio receives the new events end-to-end after the matching Studio PR (kubb-labs/platform#claude/update-kubb-studio-PJuzi) merges
- [ ] Confirm `kubb:generation:summary` numbers match what the CLI's own summary prints

https://claude.ai/code/session_01DrTrAuYikDjcGdMiNhZz5T

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrTrAuYikDjcGdMiNhZz5T)_