### PR TITLE
fix(cli,core): pass full CLIOptions to user-defined config functions

### DIFF
--- a/.changeset/cli-options-passed-to-define-config.md
+++ b/.changeset/cli-options-passed-to-define-config.md
@@ -1,0 +1,18 @@
+---
+'@kubb/cli': patch
+'@kubb/core': patch
+---
+
+Pass the full CLI options to user-defined config functions.
+
+`defineConfig(({ watch, logLevel, config }) => ...)` now actually receives `watch`, `logLevel`, and `config` at runtime. Previously the CLI runner cast `{ input }` to `CLIOptions`, so the other fields were silently `undefined` even though the type promised otherwise.
+
+`CLIOptions.input` is now a documented field (so the cast disappears) and `CLIOptions.logLevel` adds the missing `'verbose'` value to match the CLI's `--logLevel` flag.
+
+```ts
+// Now works as expected
+export default defineConfig(({ watch }) => ({
+  input: { path: './petStore.yaml' },
+  output: { path: './src/gen', clean: !watch },
+}))
+```

--- a/.changeset/define-config-defaults-jsdoc.md
+++ b/.changeset/define-config-defaults-jsdoc.md
@@ -1,0 +1,5 @@
+---
+'kubb': patch
+---
+
+Correct the JSDoc on `defineConfig`: `output.format` and `output.lint` default to `false`, not `'auto'`. The code already applies `false` when the user does not set either option; only the comment was wrong.

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -5,7 +5,7 @@ import { styleText } from 'node:util'
 import * as clack from '@clack/prompts'
 import type { AsyncEventEmitter } from '@internals/utils'
 import { AsyncEventEmitter as AsyncEventEmitterClass, detectFormatter, detectLinter, executeIfOnline, formatters, linters, toError } from '@internals/utils'
-import { type Config, createKubb, isInputPath, type KubbHooks, logLevel as logLevelMap } from '@kubb/core'
+import { type CLIOptions, type Config, createKubb, isInputPath, type KubbHooks, logLevel as logLevelMap } from '@kubb/core'
 import { version } from '../../../package.json'
 import { KUBB_NPM_PACKAGE_URL } from '../../constants.ts'
 import { setupLogger, type HookSinkFactory } from '../../loggers/utils.ts'
@@ -271,7 +271,12 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch }: G
   try {
     await hooks.emit('kubb:config:start')
 
-    const { configs, configPath: resolvedConfigPath } = await getConfigs({ configPath, input })
+    const { configs, configPath: resolvedConfigPath } = await getConfigs({
+      configPath,
+      input,
+      watch,
+      logLevel: logLevelKey as CLIOptions['logLevel'],
+    })
     const relativeConfigPath = path.relative(process.cwd(), resolvedConfigPath)
 
     await hooks.emit('kubb:info', { message: 'Config loaded', info: relativeConfigPath })

--- a/packages/cli/src/runners/generate/utils.ts
+++ b/packages/cli/src/runners/generate/utils.ts
@@ -76,6 +76,14 @@ type GetConfigsOptions = {
    * Optional OpenAPI input path that overrides `config.input.path` for this run.
    */
   input?: string
+  /**
+   * Watch flag forwarded to the user's `defineConfig` function.
+   */
+  watch?: boolean
+  /**
+   * Log level forwarded to the user's `defineConfig` function.
+   */
+  logLevel?: CLIOptions['logLevel']
 }
 
 type GetConfigsResult = {
@@ -93,9 +101,10 @@ type GetConfigsResult = {
  * Discovers the Kubb config via cosmiconfig and resolves it into a normalized array of configs.
  * Every config in the result is guaranteed to have a `plugins` array.
  */
-export async function getConfigs({ configPath, input }: GetConfigsOptions): Promise<GetConfigsResult> {
+export async function getConfigs({ configPath, input, watch, logLevel }: GetConfigsOptions): Promise<GetConfigsResult> {
   const result = await getCosmiConfig(configPath)
-  const resolved = await (typeof result.config === 'function' ? result.config({ input } as CLIOptions) : result.config)
+  const cli: CLIOptions = { config: configPath, input, watch, logLevel }
+  const resolved = await (typeof result.config === 'function' ? result.config(cli) : result.config)
   const userConfigs = Array.isArray(resolved) ? resolved : [resolved]
 
   return {

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -822,15 +822,20 @@ export type CLIOptions = {
    */
   config?: string
   /**
+   * OpenAPI input path passed as the positional argument to `kubb generate`.
+   * Overrides `config.input.path` when set.
+   */
+  input?: string
+  /**
    * Re-run generation whenever input files change.
    */
   watch?: boolean
   /**
    * Controls how much output the CLI prints.
    *
-   * @default 'silent'
+   * @default 'info'
    */
-  logLevel?: 'silent' | 'info' | 'debug'
+  logLevel?: 'silent' | 'info' | 'verbose' | 'debug'
 }
 
 /**

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -22,8 +22,8 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
  * - `middleware` defaults to `[middlewareBarrel()]`
  * - `output.barrel` defaults to `{ type: 'named' }` **only when `middlewareBarrel` is part of `middleware`**.
  *   When the user provides a custom middleware list without `middlewareBarrel`, `barrel` is left untouched.
- * - `output.format` defaults to `'auto'`
- * - `output.lint` defaults to `'auto'`
+ * - `output.format` defaults to `false`
+ * - `output.lint` defaults to `false`
  */
 function applyDefaults<TInput>(config: UserConfig<TInput>): UserConfig<TInput> {
   const middleware = config.middleware?.length ? config.middleware : [middlewareBarrel()]


### PR DESCRIPTION
## Summary

While auditing kubb.dev docs against the source, three drifts surfaced in `@kubb/cli`, `@kubb/core`, and the `kubb` meta-package. This PR brings the runtime behavior back in line with the typed public contract.

### 1. CLI runner did not pass watch/logLevel/config to `defineConfig`

`packages/cli/src/runners/generate/utils.ts:98` called `result.config({ input } as CLIOptions)`. Everything except `input` was silently `undefined` at runtime — including in the upstream example `defineConfig(({ watch }) => ({ output: { clean: !watch } }))`, where `watch` was always `undefined` and `!watch` always `true`. The cast also hid the fact that `input` was not declared on `CLIOptions`.

Fix: thread the real flags through `getConfigs` and build a typed `CLIOptions` object before invocation.

### 2. `CLIOptions.logLevel` was missing `'verbose'`

`CLIOptions.logLevel` was typed as `'silent' | 'info' | 'debug'`, but `kubb generate --logLevel <value>` accepts a fourth value `'verbose'`. Add it to the union.

### 3. `CLIOptions.input` was undocumented

The CLI passed `input` at runtime even though it was not a field on `CLIOptions`. Make it part of the public type so the cast disappears and users can destructure it from `defineConfig(({ input }) => ...)` without a `// @ts-expect-error`.

### 4. Stale defaults in `defineConfig` JSDoc

`packages/kubb/src/defineConfig.ts` claimed `output.format` and `output.lint` default to `'auto'`, but `applyDefaults` sets both to `false`. The kubb.dev configuration reference already shows `false`. Update the JSDoc to match the code.

## Files

- `packages/core/src/createKubb.ts` — add `input` to `CLIOptions`, add `'verbose'` to `logLevel`.
- `packages/cli/src/runners/generate/run.ts` — pass `watch` and `logLevel` to `getConfigs`.
- `packages/cli/src/runners/generate/utils.ts` — accept the new options, build a real `CLIOptions` object, drop the cast.
- `packages/kubb/src/defineConfig.ts` — JSDoc says `false` for `output.format` and `output.lint`.

Companion docs PR in `kubb-labs/platform` updates the `Context parameters` table in `apps/kubb.dev/docs/5.x/reference/configuration.md`.

## Test plan

- [ ] `pnpm format && pnpm lint:fix`
- [ ] `pnpm typecheck`
- [ ] `pnpm test --filter=@kubb/cli --filter=@kubb/core --filter=kubb`
- [ ] Smoke test: scaffold a config with `({ watch }) => ({ output: { clean: !watch } })` and run `kubb generate --watch`; confirm `output.clean` is `false` during the watch pass and `true` on a one-shot `kubb generate`.

https://claude.ai/code/session_01M2iao3gc9Smat8zXKMH3uq

---
_Generated by [Claude Code](https://claude.ai/code/session_01M2iao3gc9Smat8zXKMH3uq)_