### PR TITLE
docs(extensions): rewrite extension YAMLs and sync JSDoc

### DIFF
--- a/packages/adapter-oas/extension.yaml
+++ b/packages/adapter-oas/extension.yaml
@@ -96,7 +96,7 @@ options:
               servers:
                 - url: http://petstore.swagger.io/api
                 - url: http://localhost:3000
-      - name: "Use the production server"
+      - name: 'Use the production server'
         files:
           - lang: typescript
             twoslash: false
@@ -110,7 +110,7 @@ options:
                 adapter: adapterOas({ serverIndex: 0 }),
                 plugins: [],
               })
-      - name: "Use the localhost server"
+      - name: 'Use the localhost server'
         files:
           - lang: typescript
             twoslash: false

--- a/packages/adapter-oas/extension.yaml
+++ b/packages/adapter-oas/extension.yaml
@@ -2,7 +2,7 @@ $schema: https://kubb.dev/schemas/extension.json
 kind: adapter
 id: adapter-oas
 name: OpenAPI
-description: Parse and convert OpenAPI 2.0, 3.0, and 3.1 specifications into Kubb's universal AST with full support for discriminators, date types, and server configuration.
+description: Parse and convert OpenAPI 2.0, 3.0, and 3.1 specifications into Kubb's universal AST. Handles discriminators, date formats, and server URL resolution.
 category: openapi
 type: official
 npmPackage: '@kubb/adapter-oas'
@@ -29,63 +29,112 @@ featured: true
 icon:
   light: https://kubb.dev/feature/openapi.svg
 intro: |-
-  The OpenAPI adapter parses and converts your OpenAPI specification into Kubb's internal AST (Abstract Syntax Tree), which all downstream plugins consume.
+  The OpenAPI adapter is the bridge between your spec and every Kubb plugin. It reads the file at `input.path`, validates it, and converts every schema and operation into Kubb's universal AST that downstream plugins consume.
 
-  The adapter is configured once in `defineConfig` and applies globally to all plugins.
+  Configure it once on `defineConfig`. Its choices (date representation, integer width, server URL) apply to every plugin in the build.
 options:
   - name: validate
     type: boolean
     required: false
     default: 'true'
-    description: Validate the OpenAPI spec before parsing using `@readme/openapi-parser`.
+    description: |
+      Validates the OpenAPI spec with `@readme/openapi-parser` before parsing. Set to `false` only when you have a known-invalid spec that you still want to generate from.
+    examples:
+      - name: kubb.config.ts
+        files:
+          - lang: typescript
+            twoslash: false
+            code: |
+              import { defineConfig } from 'kubb'
+              import { adapterOas } from '@kubb/adapter-oas'
+
+              export default defineConfig({
+                input: { path: './petStore.yaml' },
+                output: { path: './src/gen' },
+                adapter: adapterOas({ validate: false }),
+                plugins: [],
+              })
+
   - name: contentType
     type: "'application/json' | string"
     required: false
-    description: Preferred content-type used when extracting request/response schemas from the spec. Defaults to the first valid JSON media type found in the spec.
+    description: |
+      Preferred media type when extracting request and response schemas. Operations with multiple media types fall back to this one.
+
+      Defaults to the first JSON-compatible media type found in the spec (`application/json`, `application/vnd.api+json`, any `*+json`).
     codeBlock:
       lang: typescript
       title: kubb.config.ts
       twoslash: false
       code: |-
+        import { defineConfig } from 'kubb'
         import { adapterOas } from '@kubb/adapter-oas'
 
-        adapterOas({ contentType: 'application/vnd.api+json' })
+        export default defineConfig({
+          input: { path: './petStore.yaml' },
+          output: { path: './src/gen' },
+          adapter: adapterOas({ contentType: 'application/vnd.api+json' }),
+          plugins: [],
+        })
+
   - name: serverIndex
     type: number
     required: false
-    description: Index into the `servers` array from your OpenAPI spec for computing `baseURL`.
-    tip: Defining the server here will make it possible to use that endpoint as `baseURL` in other plugins.
+    description: |
+      Index into the `servers` array from your OpenAPI spec, used to compute the base URL for plugins that need it (`@kubb/plugin-client`, `@kubb/plugin-msw`, ...).
+
+      Most projects pick `0` for the primary server. Use higher indices to point at staging or localhost when your spec defines multiple environments.
+    tip: |
+      Plugins read `baseURL` from this server unless they override it explicitly.
     examples:
-      - name: OpenAPI
+      - name: OpenAPI spec
         files:
           - lang: yaml
+            twoslash: false
             code: |-
               openapi: 3.0.3
               servers:
                 - url: http://petstore.swagger.io/api
                 - url: http://localhost:3000
-      - name: serverIndex 0
+      - name: "Use the production server"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
+              import { defineConfig } from 'kubb'
               import { adapterOas } from '@kubb/adapter-oas'
 
-              adapterOas({ serverIndex: 0 })
-      - name: serverIndex 1
+              export default defineConfig({
+                input: { path: './petStore.yaml' },
+                output: { path: './src/gen' },
+                adapter: adapterOas({ serverIndex: 0 }),
+                plugins: [],
+              })
+      - name: "Use the localhost server"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
+              import { defineConfig } from 'kubb'
               import { adapterOas } from '@kubb/adapter-oas'
 
-              adapterOas({ serverIndex: 1 })
+              export default defineConfig({
+                input: { path: './petStore.yaml' },
+                output: { path: './src/gen' },
+                adapter: adapterOas({ serverIndex: 1 }),
+                plugins: [],
+              })
+
   - name: serverVariables
     type: Record<string, string>
     required: false
-    description: Override values for `{variable}` placeholders in the selected server URL. Only used when `serverIndex` is set. Variables not provided fall back to their `default` value from the spec.
+    description: |
+      Values substituted into `{variable}` placeholders in the selected server URL. Only used when `serverIndex` is set. Variables you do not provide use their `default` value from the spec.
     examples:
-      - name: OpenAPI
+      - name: OpenAPI spec
         files:
           - lang: yaml
+            twoslash: false
             code: |-
               openapi: 3.0.3
               servers:
@@ -97,28 +146,41 @@ options:
       - name: kubb.config.ts
         files:
           - lang: typescript
+            twoslash: false
             code: |-
+              import { defineConfig } from 'kubb'
               import { adapterOas } from '@kubb/adapter-oas'
 
-              adapterOas({
-                serverIndex: 0,
-                serverVariables: { env: 'prod' },
+              export default defineConfig({
+                input: { path: './petStore.yaml' },
+                output: { path: './src/gen' },
+                adapter: adapterOas({
+                  serverIndex: 0,
+                  serverVariables: { env: 'prod' },
+                }),
+                plugins: [],
               })
-              // Results in baseURL: https://api.prod.example.com
+              // baseURL becomes: https://api.prod.example.com
+
   - name: discriminator
     type: "'strict' | 'inherit'"
     required: false
     default: "'strict'"
-    description: How the discriminator field is interpreted when processing `oneOf`/`anyOf` schemas.
+    description: |
+      How `discriminator` fields on `oneOf`/`anyOf` schemas are interpreted.
+
+      - `'strict'` (default) — child schemas stay exactly as written. The discriminator narrows types at the call site but child shapes are not modified.
+      - `'inherit'` — Kubb propagates the discriminator property with the appropriate literal value into each child schema, so each branch's `type` field is precisely typed.
     details:
       - title: strict
-        body: Uses `oneOf` schemas as written in the spec. The discriminator is used for type narrowing but child schemas are not modified.
+        body: 'Child schemas are emitted verbatim. The discriminator property has whatever type the OpenAPI spec gave it.'
       - title: inherit
-        body: Propagates the discriminator property with appropriate enum values into each child schema, ensuring type safety and enabling better code generation.
+        body: "Each child schema gets the discriminator value as a literal (`type: 'cat'`, `type: 'dog'`). Catches more bugs at compile time."
     examples:
-      - name: OpenAPI
+      - name: OpenAPI spec
         files:
           - lang: yaml
+            twoslash: false
             code: |-
               openapi: 3.0.3
               components:
@@ -148,9 +210,10 @@ options:
                         type: string
                       name:
                         type: string
-      - name: strict
+      - name: "'strict' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               export type Cat = {
                 type: string
@@ -163,9 +226,10 @@ options:
               }
 
               export type Animal = Cat | Dog
-      - name: inherit
+      - name: "'inherit'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               export type Cat = {
                 type: 'cat'
@@ -178,62 +242,70 @@ options:
               }
 
               export type Animal = Cat | Dog
+
   - name: dateType
     type: false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
     required: false
     default: "'string'"
-    description: "How `format: 'date-time'` schemas are represented in the generated AST and downstream output."
-    details:
-      - title: 'false'
-        body: Falls through to a plain `string` type.
-      - title: "'string'"
-        body: Emits a datetime string node (e.g. `z.string().datetime()`).
-      - title: "'stringOffset'"
-        body: 'Emits a datetime node with timezone offset (`{ offset: true }`).'
-      - title: "'stringLocal'"
-        body: 'Emits a local datetime node (`{ local: true }`).'
-      - title: "'date'"
-        body: Emits a `date` node (JavaScript `Date` object).
+    description: |
+      How `format: date-time` schemas are represented downstream.
+
+      - `false` — fall through to a plain `string` (no validation).
+      - `'string'` (default) — datetime string (`z.string().datetime()`, ISO 8601).
+      - `'stringOffset'` — datetime string with timezone offset.
+      - `'stringLocal'` — local datetime string (no timezone).
+      - `'date'` — JavaScript `Date` object. Best for client code; requires JSON parsing to revive.
     examples:
       - name: 'false'
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               // format: date-time → plain string
               type CreatedAt = string
       - name: "'string' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
-              // format: date-time → datetime string
-              type CreatedAt = string // validated as ISO 8601 datetime
+              // format: date-time → ISO 8601 datetime string
+              type CreatedAt = string
       - name: "'stringOffset'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
-              // format: date-time → datetime string with offset
-              type CreatedAt = string // validated as ISO 8601 datetime with offset
+              // format: date-time → ISO 8601 datetime with offset
+              type CreatedAt = string
       - name: "'stringLocal'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
-              // format: date-time → local datetime string
-              type CreatedAt = string // validated as local ISO 8601 datetime
+              // format: date-time → local ISO 8601 datetime
+              type CreatedAt = string
       - name: "'date'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               // format: date-time → JavaScript Date
               type CreatedAt = Date
+
   - name: integerType
     type: "'number' | 'bigint'"
     required: false
-    default: "'bigint'"
-    description: "Whether `type: 'integer'` and `format: 'int64'` produce `number` or `bigint` nodes."
+    default: "'number'"
+    description: |
+      How `type: integer` (and `format: int64`) maps to TypeScript.
+
+      - `'number'` (default) — fits most JSON APIs; loses precision above `Number.MAX_SAFE_INTEGER`.
+      - `'bigint'` — exact for 64-bit IDs, but `JSON.stringify`/`JSON.parse` cannot round-trip it. Use only when you also handle bigint serialization explicitly.
     examples:
       - name: "'number' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               type Pet = {
                 id: number
@@ -241,19 +313,25 @@ options:
       - name: "'bigint'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               type Pet = {
                 id: bigint
               }
+
   - name: unknownType
     type: "'any' | 'unknown' | 'void'"
     required: false
     default: "'any'"
-    description: AST type used when no schema type can be inferred from the OpenAPI spec.
+    description: |
+      AST type used when a schema's type cannot be inferred from the spec (`additionalProperties: true`, missing `type`, etc.).
+
+      Pick `'unknown'` to force callers to narrow before using the value. `'any'` is the loosest; `'void'` is rarely useful but matches some legacy APIs.
     examples:
       - name: "'any' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               type Pet = {
                 extra: any
@@ -261,6 +339,7 @@ options:
       - name: "'unknown'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               type Pet = {
                 extra: unknown
@@ -268,65 +347,73 @@ options:
       - name: "'void'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               type Pet = {
                 extra: void
               }
+
   - name: emptySchemaType
     type: "'any' | 'unknown' | 'void'"
     required: false
     default: unknownType | 'any'
-    description: AST type used for completely empty schemas (`{}`).
-    tip: When not set, `emptySchemaType` falls back to the value of `unknownType`. Set it explicitly only when you want a different type for empty schemas than for unresolvable ones.
+    description: |
+      AST type used for fully empty schemas (`{}`). Defaults to the value of `unknownType`. Override only when empty schemas should be treated differently from unresolvable ones.
+    tip: |
+      A common pattern: `unknownType: 'unknown'` for safety, `emptySchemaType: 'any'` to keep empty 204 response bodies frictionless to use.
     examples:
       - name: "'any' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               // empty schema {} → any
               type EmptyModel = any
       - name: "'unknown'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
               // empty schema {} → unknown
               type EmptyModel = unknown
+
   - name: enumSuffix
     type: string
     required: false
     default: "'enum'"
-    description: Suffix appended to derived enum names when building nested property schema names.
+    description: |
+      Suffix appended to derived enum names when Kubb has to invent one (typically for inline enums on object properties).
+
+      Inline enums on a `status` property would be named `statusEnum` with the default. Change this to align with your project's naming convention.
     examples:
       - name: "'enum' (default)"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
-              // property `status` with inline enum values
+              // Property `status` with inline enum values
               const statusEnum = { available: 'available', pending: 'pending' } as const
               type StatusEnum = (typeof statusEnum)[keyof typeof statusEnum]
       - name: "'type'"
         files:
           - lang: typescript
+            twoslash: false
             code: |-
-              // enumSuffix: 'type'
               const statusType = { available: 'available', pending: 'pending' } as const
               type StatusType = (typeof statusType)[keyof typeof statusType]
 examples:
   - name: kubb.config.ts
     files:
       - lang: typescript
+        twoslash: false
         code: |-
           import { defineConfig } from 'kubb'
           import { adapterOas } from '@kubb/adapter-oas'
           import { pluginTs } from '@kubb/plugin-ts'
 
           export default defineConfig({
-            input: {
-              path: './petStore.yaml',
-            },
-            output: {
-              path: './src/gen',
-            },
+            input: { path: './petStore.yaml' },
+            output: { path: './src/gen' },
             adapter: adapterOas({
               validate: true,
               serverIndex: 0,

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -10,15 +10,18 @@ import { createInputStream, preScan, resolveBaseUrl } from './stream.ts'
 import type { AdapterOas, Document } from './types.ts'
 
 /**
- * Stable string identifier for the OAS adapter used in Kubb's adapter registry.
+ * Canonical adapter name for `@kubb/adapter-oas`. Used for driver lookups.
  */
 export const adapterOasName = 'oas' satisfies AdapterOas['name']
 
 /**
- * Creates the default OpenAPI / Swagger adapter for Kubb.
+ * Default Kubb adapter for OpenAPI 2.0, 3.0, and 3.1 specifications. Reads the
+ * file at `input.path`, validates it, resolves the base URL, and converts every
+ * schema and operation into the universal AST that every downstream plugin
+ * consumes.
  *
- * Parses the spec, optionally validates it, resolves the base URL, and converts
- * everything into an `InputNode` that downstream plugins consume.
+ * Configure once on `defineConfig`. The adapter's choices (date representation,
+ * integer width, server URL) apply to every plugin in the build.
  *
  * @example
  * ```ts
@@ -27,8 +30,13 @@ export const adapterOasName = 'oas' satisfies AdapterOas['name']
  * import { pluginTs } from '@kubb/plugin-ts'
  *
  * export default defineConfig({
- *   adapter: adapterOas({ dateType: 'date', serverIndex: 0 }),
- *   input: { path: './openapi.yaml' },
+ *   input: { path: './petStore.yaml' },
+ *   output: { path: './src/gen' },
+ *   adapter: adapterOas({
+ *     serverIndex: 0,
+ *     discriminator: 'inherit',
+ *     dateType: 'date',
+ *   }),
  *   plugins: [pluginTs()],
  * })
  * ```

--- a/packages/adapter-oas/src/types.ts
+++ b/packages/adapter-oas/src/types.ts
@@ -123,8 +123,9 @@ export type ResponseObject = OASResponseObject
 export type MediaTypeObject = OASMediaTypeObject
 
 /**
- * Configuration options for the OpenAPI adapter.
- * Controls spec validation, content-type selection, and server URL resolution.
+ * Configuration options for the OpenAPI adapter. Controls spec validation,
+ * content-type selection, server URL resolution, and how types are derived
+ * from the spec.
  *
  * @example
  * ```ts
@@ -138,23 +139,28 @@ export type MediaTypeObject = OASMediaTypeObject
  */
 export type AdapterOasOptions = {
   /**
-   * Validate the OpenAPI spec before parsing.
+   * Validate the OpenAPI spec with `@readme/openapi-parser` before parsing.
+   * Set to `false` only when you have a known-invalid spec you still want to
+   * generate from.
+   *
    * @default true
    */
   validate?: boolean
   /**
-   * Preferred content-type used when extracting request/response schemas.
-   * Defaults to the first valid JSON media type found in the spec.
+   * Preferred media type when an operation defines several. Defaults to the
+   * first JSON-compatible media type found in the spec.
    */
   contentType?: ContentType
   /**
-   * Index into `oas.api.servers` for computing `baseURL`.
-   * `0` → first server, `1` → second server. Omit to leave `baseURL` undefined.
+   * Index into the `servers` array from your OpenAPI spec. Used to compute the
+   * base URL for plugins that need it. Most projects pick `0` for the primary
+   * server. Omit to leave `baseURL` undefined.
    */
   serverIndex?: number
   /**
    * Override values for `{variable}` placeholders in the selected server URL.
-   * Only used when `serverIndex` is set.
+   * Only used when `serverIndex` is set. Variables you do not provide use
+   * their `default` value from the spec.
    *
    * @example
    * ```ts
@@ -165,9 +171,13 @@ export type AdapterOasOptions = {
    */
   serverVariables?: Record<string, string>
   /**
-   * How the discriminator field is interpreted.
-   * - `'strict'`  — uses `oneOf` schemas as written in the spec.
-   * - `'inherit'` — propagates discriminator values into child schemas from `discriminator.mapping`.
+   * How the `discriminator` field on `oneOf`/`anyOf` schemas is interpreted.
+   * - `'strict'` — child schemas stay exactly as written; the discriminator
+   *   narrows types at the call site but child shapes are not modified.
+   * - `'inherit'` — Kubb propagates the discriminator property as a literal
+   *   value into each child schema, so each branch's discriminator field is
+   *   precisely typed.
+   *
    * @default 'strict'
    */
   discriminator?: 'strict' | 'inherit'

--- a/packages/ast/src/infer.ts
+++ b/packages/ast/src/infer.ts
@@ -20,15 +20,25 @@ import type {
  */
 export type ParserOptions = {
   /**
-   * How `format: 'date-time'` schemas are represented. `false` falls through to a plain string.
+   * How `format: 'date-time'` schemas are represented downstream.
+   * - `false` falls through to a plain `string` (no validation).
+   * - `'string'` emits a datetime string node.
+   * - `'stringOffset'` emits a datetime node with timezone offset.
+   * - `'stringLocal'` emits a local datetime node.
+   * - `'date'` emits a `date` node (JavaScript `Date` object).
    */
   dateType: false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
   /**
-   * Whether `type: 'integer'` and `format: 'int64'` produce `number` or `bigint` nodes.
+   * How `type: 'integer'` (and `format: 'int64'`) maps to TypeScript.
+   * - `'number'` fits most JSON APIs; loses precision above `Number.MAX_SAFE_INTEGER`.
+   * - `'bigint'` is exact for 64-bit IDs, but does not round-trip through JSON.
+   *
+   * @default 'number'
    */
   integerType?: 'number' | 'bigint'
   /**
-   * AST type used when no schema type can be inferred.
+   * AST type used when a schema's type cannot be inferred from the spec
+   * (`additionalProperties: true`, missing `type`, ...).
    */
   unknownType: 'any' | 'unknown' | 'void'
   /**
@@ -36,7 +46,8 @@ export type ParserOptions = {
    */
   emptySchemaType: 'any' | 'unknown' | 'void'
   /**
-   * Suffix appended to derived enum names when building property schema names.
+   * Suffix appended to derived enum names when Kubb has to invent one
+   * (typically for inline enums on object properties).
    */
   enumSuffix: 'enum' | (string & {})
 }

--- a/packages/middleware-barrel/extension.yaml
+++ b/packages/middleware-barrel/extension.yaml
@@ -2,7 +2,7 @@ $schema: https://kubb.dev/schemas/extension.json
 kind: middleware
 id: middleware-barrel
 name: Barrel
-description: Automatically generates barrel files (index.ts exports) for every plugin output directory. Ships with Kubb and is enabled by default.
+description: Generates `index.ts` re-export files for every plugin output and one root barrel. Ships with Kubb and is enabled by default.
 category: output
 type: official
 npmPackage: '@kubb/middleware-barrel'
@@ -26,9 +26,9 @@ resources:
   changelog: https://github.com/kubb-labs/kubb/blob/main/packages/middleware-barrel/CHANGELOG.md
 featured: true
 intro: |-
-  The barrel middleware automatically generates `index.ts` (and `index.js`) re-export files for every plugin output directory **and** a root barrel at `config.output.path/index.ts` after the build finishes.
+  `@kubb/middleware-barrel` generates an `index.ts` for every plugin output directory and one root barrel at `output.path/index.ts` after the build completes. The result is a single import surface for every consumer — `import { Pet, usePetByIdQuery, petMock } from './gen'`.
 
-  It ships with Kubb and is registered as a default middleware in `defineConfig`, so you get barrel files out of the box with no extra configuration. When `middlewareBarrel` is part of `config.middleware`, `defineConfig` also applies a default `output.barrel` of `{ type: 'named' }`. Custom middleware lists that omit `middlewareBarrel` leave `barrel` untouched.
+  The middleware ships with Kubb and is registered by default in `defineConfig`, so barrels appear out of the box with no extra configuration. When `middlewareBarrel` is part of `config.middleware`, `defineConfig` also applies a default `output.barrel` of `{ type: 'named' }`. Custom middleware lists that omit `middlewareBarrel` leave `barrel` untouched.
 
   Plugins inherit `output.barrel` from `config.output.barrel` when their own value is omitted. Setting `barrel: false` on a plugin disables that plugin's barrel **and** excludes its files from the root barrel.
 options:
@@ -37,18 +37,20 @@ options:
     required: false
     default: "{ type: 'named' }"
     description: |-
-      Re-export style for the generated barrel files. Configured via `output.barrel` in `defineConfig` (root level) or per plugin via the plugin's own `output.barrel`. This is not a middleware argument.
+      Re-export style used for every generated barrel file. Set via `output.barrel` in `defineConfig` (applies to all plugins and the root barrel) or per plugin via that plugin's own `output.barrel`. It is not an argument to the middleware itself.
 
       At the config level:
-      - `{ type: 'all' }` — `export * from '...'` for every generated file
-      - `{ type: 'named' }` — `export { name1, name2 } from '...'` using each file's named exports
-      - `false` — disables barrel generation entirely
 
-      At the plugin level, the `nested` flag is also available:
-      - `{ type: 'named', nested: true }` — generates a barrel for every directory, re-exporting only direct children, creating a chain for imports from any depth
-      - `false` — disables barrel generation for that plugin and excludes its files from the root barrel
+      - `{ type: 'all' }` — `export * from '...'` for every generated file.
+      - `{ type: 'named' }` — `export { Foo, Bar } from '...'` using each file's named exports.
+      - `false` — disables barrel generation entirely.
 
-      The `{ type: 'named' }` default is applied automatically by `defineConfig` only when `middlewareBarrel` is part of `config.middleware`.
+      At the plugin level you also get `nested`:
+
+      - `{ type: 'named', nested: true }` — generates a barrel for every subdirectory, re-exporting only direct children. Lets callers import from any depth.
+      - `false` — disables the plugin's barrel and removes its files from the root barrel.
+
+      The `{ type: 'named' }` default kicks in only when `middlewareBarrel` is part of `config.middleware`.
     codeBlock:
       lang: typescript
       title: kubb.config.ts
@@ -58,12 +60,13 @@ options:
         import { middlewareBarrel } from '@kubb/middleware-barrel'
 
         export default defineConfig({
-          input: { path: './petstore.yaml' },
+          input: { path: './petStore.yaml' },
           output: { path: './src/gen', barrel: { type: 'named' } },
           middleware: [middlewareBarrel()],
+          plugins: [],
         })
 examples:
-  - name: "barrel: { type: 'named' } (default)"
+  - name: "{ type: 'named' } (default)"
     files:
       - name: kubb.config.ts
         lang: typescript
@@ -72,10 +75,11 @@ examples:
           import { defineConfig } from 'kubb'
 
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen' },
+            plugins: [],
           })
-      - name: 'Generated output'
+      - name: Generated output
         lang: typescript
         twoslash: false
         code: |-
@@ -92,7 +96,7 @@ examples:
 
           // src/gen/api/types/index.ts
           export { User } from './User'
-  - name: "barrel: { type: 'all' }"
+  - name: "{ type: 'all' }"
     files:
       - name: kubb.config.ts
         lang: typescript
@@ -101,10 +105,11 @@ examples:
           import { defineConfig } from 'kubb'
 
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen', barrel: { type: 'all' } },
+            plugins: [],
           })
-      - name: 'Generated output'
+      - name: Generated output
         lang: typescript
         twoslash: false
         code: |-
@@ -121,7 +126,7 @@ examples:
 
           // src/gen/api/types/index.ts
           export * from './User'
-  - name: "barrel: { type: 'named', nested: true }"
+  - name: "{ type: 'named', nested: true }"
     files:
       - name: kubb.config.ts
         lang: typescript
@@ -130,10 +135,11 @@ examples:
           import { defineConfig } from 'kubb'
 
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen', barrel: { type: 'named', nested: true } },
+            plugins: [],
           })
-      - name: 'Generated output (chained structure)'
+      - name: Generated output (chained structure)
         lang: typescript
         twoslash: false
         code: |-
@@ -148,7 +154,7 @@ examples:
 
           // src/gen/api/types/index.ts (exports files)
           export * from './User'
-  - name: Disable barrel for a single plugin
+  - name: Disable the barrel for a single plugin
     files:
       - name: kubb.config.ts
         lang: typescript
@@ -158,17 +164,17 @@ examples:
           import { pluginTs } from '@kubb/plugin-ts'
           import { pluginZod } from '@kubb/plugin-zod'
 
-          // pluginZod opts out: no zod/index.ts is created
+          // pluginZod opts out: no zod/index.ts is created,
           // and zod files are excluded from the root index.ts.
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen' },
             plugins: [
               pluginTs(),
               pluginZod({ output: { barrel: false } }),
             ],
           })
-  - name: Disable the root barrel only
+  - name: Disable only the root barrel
     files:
       - name: kubb.config.ts
         lang: typescript
@@ -177,15 +183,16 @@ examples:
           import { defineConfig } from 'kubb'
 
           // No root index.ts is generated, but each plugin
-          // still gets its own barrel using its inherited barrel config.
+          // still gets its own barrel using its inherited config.
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen', barrel: false },
+            plugins: [],
           })
 notes:
   - type: tip
     body: |-
-      `middleware-barrel` is bundled with Kubb and enabled automatically when no `middleware` option is provided. You only need to install it explicitly when customising the barrel behaviour alongside other middlewares.
+      `middleware-barrel` ships with Kubb and is enabled automatically when no `middleware` option is provided. Install it explicitly only when customising barrel behaviour alongside other middlewares.
   - type: note
     body: |-
-      `output.barrel` is only auto-defaulted to `{ type: 'named' }` when `middlewareBarrel` is part of `config.middleware`. If you provide a custom middleware list without it, set `output.barrel` yourself if you still want a barrel.
+      `output.barrel` is auto-defaulted to `{ type: 'named' }` only when `middlewareBarrel` is part of `config.middleware`. With a custom middleware list that omits it, set `output.barrel` yourself if you still want a barrel.

--- a/packages/middleware-barrel/src/middleware.ts
+++ b/packages/middleware-barrel/src/middleware.ts
@@ -37,17 +37,29 @@ declare global {
 }
 
 /**
- * Generates `index.ts` barrel files for each plugin and a root barrel at `config.output.path/index.ts`.
+ * Canonical middleware name for `@kubb/middleware-barrel`. Used for driver
+ * lookups.
+ */
+export const middlewareBarrelName = 'middleware-barrel' satisfies Middleware['name']
+
+/**
+ * Generates an `index.ts` for every plugin output directory and one root
+ * barrel at `config.output.path/index.ts` after the build completes. Ships
+ * with Kubb and is registered by default in `defineConfig`.
  *
- * Each plugin inherits `output.barrel` from `config.output.barrel` (defaults to `{ type: 'named' }`).
- * Set `barrel: false` on a plugin to disable its barrel and exclude it from the root barrel.
+ * Each plugin inherits `output.barrel` from `config.output.barrel` (which
+ * defaults to `{ type: 'named' }`). Set `barrel: false` on a plugin to skip
+ * its barrel and also exclude its files from the root barrel.
  *
  * @example
  * ```ts
  * import { defineConfig } from '@kubb/core'
  * import { middlewareBarrel } from '@kubb/middleware-barrel'
+ * import { pluginTs } from '@kubb/plugin-ts'
+ * import { pluginZod } from '@kubb/plugin-zod'
  *
  * export default defineConfig({
+ *   input: { path: './petStore.yaml' },
  *   output: { path: 'src/gen', barrel: { type: 'named' } },
  *   plugins: [
  *     pluginTs({ output: { path: 'types', barrel: { type: 'all' } } }),
@@ -57,12 +69,6 @@ declare global {
  * })
  * ```
  */
-
-/**
- * Stable string identifier for the barrel middleware.
- */
-export const middlewareBarrelName = 'middleware-barrel' satisfies Middleware['name']
-
 export const middlewareBarrel = defineMiddleware(() => {
   const excludedPrefixes = new Set<string>()
 

--- a/packages/parser-ts/extension.yaml
+++ b/packages/parser-ts/extension.yaml
@@ -2,7 +2,7 @@ $schema: https://kubb.dev/schemas/extension.json
 kind: parser
 id: parser-ts
 name: TypeScript
-description: TypeScript and TSX file parser for Kubb. Converts the universal AST to `.ts`/`.tsx` source code using the official TypeScript compiler.
+description: Default file parser for Kubb. Converts the universal AST to `.ts`/`.tsx` source using the official TypeScript compiler.
 category: typescript
 type: official
 npmPackage: '@kubb/parser-ts'
@@ -29,23 +29,23 @@ featured: true
 icon:
   light: https://kubb.dev/feature/typescript.svg
 intro: |-
-  The TypeScript parser is the default file parser used by Kubb when no `parsers` option is set in `defineConfig`. It converts Kubb's universal AST into `.ts` and `.tsx` source code using the official [TypeScript compiler](https://www.typescriptlang.org/).
+  `@kubb/parser-ts` is the default file parser used by Kubb when no `parsers` option is provided in `defineConfig`. It takes the universal AST produced by your adapter and prints `.ts`/`.tsx` source code using the official [TypeScript compiler](https://www.typescriptlang.org/).
 
   Two parser instances are exported:
 
-  - `parserTs` — handles `.ts` and `.js` files
-  - `parserTsx` — handles `.tsx` and `.jsx` files
+  - `parserTs` — handles `.ts` and `.js` files.
+  - `parserTsx` — handles `.tsx` and `.jsx` files. Use this for React projects so JSX in generated components is preserved.
 
-  Both are configured globally in `defineConfig` and apply to every file produced by every plugin.
+  Configure once on `defineConfig`. The choice applies to every file every plugin produces.
 options:
   - name: extname
     type: "'.ts' | '.js' | '.tsx' | '.jsx' | string"
     required: false
     default: "'.ts'"
     description: |-
-      File extension used when rewriting relative import paths. Set to `.js` for ESM-friendly emit, `.tsx` for React projects, or leave unset to keep TypeScript's default behaviour.
+      File extension the parser writes when emitting code. Pick `.js` for an ESM-friendly emit you can publish to npm, `.tsx` for React projects, or leave unset for the standard TypeScript default.
 
-      Extension rewriting is configured via `output.extension` in `defineConfig`, not as a parser argument.
+      For rewriting relative import specifiers (`./foo` → `./foo.js`), set `output.extension` on `defineConfig` — not on the parser itself.
     codeBlock:
       lang: typescript
       title: kubb.config.ts
@@ -56,10 +56,11 @@ options:
         import { parserTs } from '@kubb/parser-ts'
 
         export default defineConfig({
-          input: { path: './petstore.yaml' },
+          input: { path: './petStore.yaml' },
           output: { path: './src/gen', extension: { '.ts': '.js' } },
           adapter: adapterOas(),
           parsers: [parserTs],
+          plugins: [],
         })
 examples:
   - name: TypeScript (default)
@@ -73,10 +74,11 @@ examples:
           import { parserTs } from '@kubb/parser-ts'
 
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen' },
             adapter: adapterOas(),
             parsers: [parserTs],
+            plugins: [],
           })
   - name: TSX (React)
     files:
@@ -89,12 +91,13 @@ examples:
           import { parserTsx } from '@kubb/parser-ts'
 
           export default defineConfig({
-            input: { path: './petstore.yaml' },
+            input: { path: './petStore.yaml' },
             output: { path: './src/gen' },
             adapter: adapterOas(),
             parsers: [parserTsx],
+            plugins: [],
           })
 notes:
   - type: tip
     body: |-
-      `parser-ts` is bundled with Kubb and used automatically when no `parsers` option is provided. You only need to install it explicitly when combining it with other parsers or providing a fully custom parsers list.
+      `parser-ts` is bundled with Kubb and used automatically when no `parsers` option is set. Install it explicitly only when you need to combine it with other parsers or provide a fully custom parser list.

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -9,10 +9,28 @@ export { createExport, createImport, print, safePrint, validateNodes } from './u
 export { printArrowFunction, printCodeNode, printConst, printFunction, printJSDoc, printSource, printType } from './utils.ts'
 
 /**
- * Parser that converts `.ts` and `.js` files to strings using the TypeScript
- * compiler. Handles import/export statement generation from file metadata.
+ * Default Kubb parser for `.ts` and `.js` files. Takes the universal AST
+ * produced by an adapter and prints it as TypeScript source using the official
+ * TypeScript compiler. Imports and exports are rewritten based on each file's
+ * metadata.
  *
- * @default Used automatically when no `parsers` option is set in `defineConfig`.
+ * Used automatically when no `parsers` option is set on `defineConfig`. Use
+ * `parserTsx` instead for React projects that emit JSX.
+ *
+ * @example
+ * ```ts
+ * import { defineConfig } from 'kubb'
+ * import { adapterOas } from '@kubb/adapter-oas'
+ * import { parserTs } from '@kubb/parser-ts'
+ *
+ * export default defineConfig({
+ *   input: { path: './petStore.yaml' },
+ *   output: { path: './src/gen' },
+ *   adapter: adapterOas(),
+ *   parsers: [parserTs],
+ *   plugins: [],
+ * })
+ * ```
  */
 export const parserTs: Parser = defineParser({
   name: 'typescript',

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -3,13 +3,26 @@ import { defineParser } from '@kubb/core'
 import { parserTs } from './parserTs.ts'
 
 /**
- * Parser that converts `.tsx` and `.jsx` files to strings.
- * Delegates to `typescriptParser` since the TypeScript compiler natively
- * supports JSX/TSX syntax via `ScriptKind.TSX`.
+ * Kubb parser for `.tsx` and `.jsx` files. Delegates to `parserTs` because the
+ * TypeScript compiler handles JSX natively via `ScriptKind.TSX`.
  *
- * Add this parser to the `parsers` option in `defineConfig` when generating `.tsx`/`.jsx` files.
+ * Add to the `parsers` array on `defineConfig` when generating components for
+ * React (or any framework that emits JSX).
  *
- * @default extname '.tsx'
+ * @example
+ * ```ts
+ * import { defineConfig } from 'kubb'
+ * import { adapterOas } from '@kubb/adapter-oas'
+ * import { parserTsx } from '@kubb/parser-ts'
+ *
+ * export default defineConfig({
+ *   input: { path: './petStore.yaml' },
+ *   output: { path: './src/gen' },
+ *   adapter: adapterOas(),
+ *   parsers: [parserTsx],
+ *   plugins: [],
+ * })
+ * ```
  */
 export const parserTsx: Parser = defineParser({
   name: 'tsx',


### PR DESCRIPTION
## Summary

Rewrite the standalone extension YAMLs for `adapter-oas`, `parser-ts`, and `middleware-barrel` for clarity, and add type-safe examples. The companion JSDoc in `AdapterOasOptions` and `ParserOptions` was updated to match.

- Adapter-oas: expand every option description (validate, contentType, serverIndex, serverVariables, discriminator, dateType, integerType, unknownType, emptySchemaType, enumSuffix) with concrete OpenAPI snippets and a separate variant per choice so users can preview the generated output.
- Parser-ts: rewrite the intro, expand `extname`, and ship complete `kubb.config.ts` examples for both `parserTs` and `parserTsx`.
- Middleware-barrel: rewrite the intro and the `barrel` option with examples for `'named'`, `'all'`, `nested: true`, plugin-level opt-out, and root-only opt-out.
- Sync JSDoc in `AdapterOasOptions` (`adapter-oas/src/types.ts`) and `ParserOptions` (`ast/src/infer.ts`) with the YAML descriptions. `@default` is kept only when the property is optional.

## Test plan

- [x] `pnpm typecheck` passes for every package.
- [x] All 3 `extension.yaml` files parse with `yaml`.
- [x] All 3 `extension.yaml` files validate against `schemas/extension.json` (ajv).

https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs)_