### PR TITLE
docs(core): apply review feedback to recent JSDoc

### DIFF
--- a/packages/ast/src/nodes/file.ts
+++ b/packages/ast/src/nodes/file.ts
@@ -181,7 +181,7 @@ export type FileNode<TMeta extends object = object> = BaseNode & {
   kind: 'File'
   /**
    * Unique identifier derived from a SHA256 hash of the file path. Computed
-   * by `createFile` — callers do not need to provide it.
+   * by `createFile`; callers do not need to provide it.
    */
   id: string
   /**

--- a/packages/ast/src/visitor.ts
+++ b/packages/ast/src/visitor.ts
@@ -326,7 +326,7 @@ function* getChildren(node: Node, recurse: boolean): Generator<Node, void, undef
 
 /**
  * Async depth-first traversal for side effects. Visitor return values are
- * ignored — use `transform` when you want to rewrite nodes.
+ * ignored. Use `transform` when you want to rewrite nodes.
  *
  * Sibling nodes at each depth run concurrently up to `options.concurrency`
  * (defaults to `WALK_CONCURRENCY`). Higher values overlap I/O-bound visitor
@@ -388,7 +388,7 @@ async function _walk(node: Node, visitor: AsyncVisitor, recurse: boolean, limit:
  * Synchronous depth-first transform. Each visitor callback gets a chance to
  * return a replacement node; `undefined` keeps the original.
  *
- * The transform is immutable — the original tree is not mutated; a new tree
+ * The transform is immutable. The original tree is not mutated; a new tree
  * is returned. Use `depth: 'shallow'` to skip recursion into children.
  *
  * @example Prefix every operationId

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -5,19 +5,19 @@ import type { ImportNode, InputNode, InputStreamNode, SchemaNode } from '@kubb/a
  * Source data handed to an adapter's `parse` function. Mirrors the config
  * input shape with paths resolved to absolute.
  *
- * - `{ type: 'path' }` — single file on disk.
- * - `{ type: 'paths' }` — multiple files (e.g. split spec).
- * - `{ type: 'data' }` — raw string or parsed object provided inline.
+ * - `{ type: 'path' }`: single file on disk.
+ * - `{ type: 'paths' }`: multiple files (e.g. split spec).
+ * - `{ type: 'data' }`: raw string or parsed object provided inline.
  */
 export type AdapterSource = { type: 'path'; path: string } | { type: 'data'; data: string | unknown } | { type: 'paths'; paths: Array<string> }
 
 /**
  * Generic parameters used by `createAdapter` and the resulting `Adapter` type.
  *
- * - `TName` — unique adapter identifier (`'oas'`, `'asyncapi'`, ...).
- * - `TOptions` — user-facing options accepted by the adapter factory.
- * - `TResolvedOptions` — options after defaults are applied.
- * - `TDocument` — type of the parsed source document.
+ * - `TName`: unique adapter identifier (`'oas'`, `'asyncapi'`, ...).
+ * - `TOptions`: user-facing options accepted by the adapter factory.
+ * - `TResolvedOptions`: options after defaults are applied.
+ * - `TDocument`: type of the parsed source document.
  */
 export type AdapterFactoryOptions<
   TName extends string = string,
@@ -85,8 +85,8 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
    * Memory-efficient streaming variant of `parse()`.
    *
    * Returns an `InputStreamNode` whose `schemas` and `operations` are `AsyncIterable`.
-   * Each `for await` loop creates a fresh parse pass over the cached in-memory document —
-   * no pre-built arrays are held in memory.
+   * Each `for await` loop creates a fresh parse pass over the cached in-memory document.
+   * No pre-built arrays are held in memory.
    */
   stream?: (source: AdapterSource) => Promise<InputStreamNode>
 }
@@ -99,12 +99,12 @@ type AdapterBuilder<T extends AdapterFactoryOptions> = (options: T['options']) =
  * domain-specific schema. Built-in adapters: `@kubb/adapter-oas` for
  * OpenAPI/Swagger documents.
  *
- * Adapters must return an `InputNode` from `parse` — that node is what every
+ * Adapters must return an `InputNode` from `parse`. That node is what every
  * plugin in the build consumes.
  *
  * @example
  * ```ts
- * import { createAdapter, ast } from '@kubb/core'
+ * import { createAdapter, ast, type AdapterFactoryOptions } from '@kubb/core'
  *
  * type MyAdapter = AdapterFactoryOptions<'my-adapter', { validate?: boolean }>
  *
@@ -112,12 +112,14 @@ type AdapterBuilder<T extends AdapterFactoryOptions> = (options: T['options']) =
  *   name: 'my-adapter',
  *   options,
  *   document: null,
- *   async parse(source) {
+ *   async parse(_source) {
  *     // Convert `source` (path or inline data) into an InputNode.
  *     return ast.createInput()
  *   },
  *   getImports: () => [],
- *   validate: async () => {},
+ *   async validate() {
+ *     // Throw or call ctx.error here when the spec is invalid.
+ *   },
  * }))
  * ```
  */

--- a/packages/core/src/defineLogger.ts
+++ b/packages/core/src/defineLogger.ts
@@ -8,7 +8,7 @@ import type { KubbHooks } from './types.ts'
 export type LoggerOptions = {
   /**
    * Output verbosity. Use the `logLevel` constants exported from `@kubb/core`
-   * (`silent`, `info`, `verbose`, `debug`).
+   * (`silent`, `error`, `warn`, `info`, `verbose`, `debug`).
    */
   logLevel: (typeof logLevel)[keyof typeof logLevel]
 }
@@ -32,7 +32,7 @@ export type Logger<TOptions extends LoggerOptions = LoggerOptions, TInstallRetur
   /**
    * Called once per build with the shared event emitter. Subscribe to events
    * here. The return value (if any) is forwarded to whoever installed the
-   * logger — handy for sink factories.
+   * logger, which is handy for sink factories.
    */
   install: (context: LoggerContext, options?: TOptions) => TInstallReturn | Promise<TInstallReturn>
 }
@@ -41,8 +41,8 @@ export type UserLogger<TOptions extends LoggerOptions = LoggerOptions, TInstallR
 
 /**
  * Defines a typed logger. Use the second type parameter to declare a return
- * value from `install` — handy when the logger exposes a sink factory or
- * cleanup callback to the caller.
+ * value from `install`, which is handy when the logger exposes a sink factory
+ * or cleanup callback to the caller.
  *
  * @example Basic logger
  * ```ts
@@ -51,8 +51,8 @@ export type UserLogger<TOptions extends LoggerOptions = LoggerOptions, TInstallR
  * export const myLogger = defineLogger({
  *   name: 'my-logger',
  *   install(context) {
- *     context.on('kubb:info', (message) => console.log('ℹ', message))
- *     context.on('kubb:error', (error) => console.error('✗', error.message))
+ *     context.on('kubb:info', ({ message }) => console.log('ℹ', message))
+ *     context.on('kubb:error', ({ error }) => console.error('✗', error.message))
  *   },
  * })
  * ```

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -379,10 +379,10 @@ export function definePlugin<TFactory extends PluginFactoryOptions = PluginFacto
  * Detects whether an output path points at a single file (`'single'`) or a
  * directory (`'split'`). Decided purely from the presence of a file extension.
  *
- * @example
+ * @example Directory
  * `getMode('./types') // 'split'`
  *
- * @example
+ * @example Single file
  * `getMode('./api.ts') // 'single'`
  */
 export function getMode(fileOrFolder: string | undefined | null): 'single' | 'split' {

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -577,10 +577,10 @@ export function defaultResolveFooter(meta: InputMeta | undefined, { output }: Re
 }
 
 /**
- * Defines a plugin resolver — the object that decides what every generated
- * symbol and file path is called. Built-in defaults handle name casing,
- * include/exclude/override filtering, output path computation, and file
- * construction; supply your own to override any of them:
+ * Defines a plugin resolver. The resolver is the object that decides what
+ * every generated symbol and file path is called. Built-in defaults handle
+ * name casing, include/exclude/override filtering, output path computation,
+ * and file construction. Supply your own to override any of them:
  *
  * - `default` — name casing strategy (camelCase / PascalCase).
  * - `resolveOptions` — include/exclude/override filtering.

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -89,10 +89,9 @@ function normalizeConfig<TInput>(config: UserConfig<TInput> | Array<UserConfig<T
  * ```ts
  * import { defineConfig } from 'kubb'
  *
- * export default defineConfig(({ logLevel }) => ({
- *   input: { path: './petStore.yaml' },
+ * export default defineConfig(({ input }) => ({
+ *   input: { path: input ?? './petStore.yaml' },
  *   output: { path: './src/gen' },
- *   logger: { logLevel: logLevel ?? 'info' },
  *   plugins: [],
  * }))
  * ```

--- a/packages/renderer-jsx/src/createRenderer.tsx
+++ b/packages/renderer-jsx/src/createRenderer.tsx
@@ -6,8 +6,8 @@ import type { KubbReactElement } from './types.ts'
 /**
  * Renderer factory that turns the JSX produced by a generator into
  * `FileNode`s using React's reconciler under the hood. Pass as the `renderer`
- * property on `defineGenerator`. Kubb core stays generic — no hard dependency
- * on `@kubb/renderer-jsx`.
+ * property on `defineGenerator`. Kubb core stays generic, with no hard
+ * dependency on `@kubb/renderer-jsx`.
  *
  * Use this when generators rely on React features (hooks, suspense, context).
  * For pure-function components, see {@link jsxRendererSync} for ~2-4× faster


### PR DESCRIPTION
## Summary

Code-review follow-ups to #3349. Fixes a few examples that would not compile when copy-pasted and tightens em-dash usage across the JSDoc I touched.

- `defineConfig` — the function-form example referenced a `logger` config field that does not exist. Replaced with an example that uses the `input` CLI option.
- `createAdapter` — example now imports `AdapterFactoryOptions` as a type, the `parse` callback is shaped so the snippet compiles in isolation, and a few em-dashes used as commas/colons are normalized.
- `defineLogger` — the `kubb:info`/`kubb:error` example handlers were called with bare strings; the real payloads are `{ message }` / `{ error }` context objects. Fixed. The `logLevel` constants list was also missing `error` and `warn` — added.
- `ast/visitor` — drop em-dashes in `walk`/`transform` descriptions.
- `ast/nodes/file` — drop the em-dash on `id`; keep the prior `@default hash` cleanup.
- `definePlugin.getMode` — add `@example` labels per the jsdoc skill.
- `defineResolver`, `renderer-jsx/createRenderer` — replace mid-sentence em-dashes with proper punctuation.

## Test plan

- [x] `pnpm typecheck` passes for every package.

https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xugqs6g85WLdc1RbKfcMEs)_