### PR TITLE
feat(parser-ts)!: expose `print` on `parserTs`/`parserTsx`, slim public API

### DIFF
--- a/.changeset/parser-ts-print-on-parser.md
+++ b/.changeset/parser-ts-print-on-parser.md
@@ -1,0 +1,10 @@
+---
+'@kubb/core': minor
+'@kubb/parser-ts': major
+---
+
+Expose `print` on `parserTs` and `parserTsx`, slim `@kubb/parser-ts` public API to just those two parsers.
+
+`Parser` (from `@kubb/core`) now requires a `print(...nodes): string` method that renders compiler AST nodes for the parser's language. The TypeScript and TSX parsers implement it via `parserTs.print(...)` / `parserTsx.print(...)`.
+
+`@kubb/parser-ts` no longer re-exports the standalone helpers `print`, `safePrint`, `createImport`, `createExport`, or `validateNodes`. Plugins that depended on `print` / `safePrint` should call `parserTs.print(...)` instead. Custom parsers built with `defineParser` need to add a `print` implementation matching their AST node shape.

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -38,6 +38,7 @@ describe('FileProcessor', () => {
         extNames: ['.ts' as const],
         install: vi.fn(),
         parse: mockParse,
+        print: vi.fn().mockReturnValue(''),
       }
       const parsers = new Map([['.ts' as const, parser]])
       const result = await processor.parse(file, { parsers })

--- a/packages/core/src/defineParser.ts
+++ b/packages/core/src/defineParser.ts
@@ -9,7 +9,7 @@ type PrintOptions = {
  * written to disk. Kubb ships with TypeScript and TSX parsers; add your own
  * for new file types (JSON, Markdown, ...).
  */
-export type Parser<TMeta extends object = any> = {
+export type Parser<TMeta extends object = any, TNode = unknown> = {
   /**
    * Display name used in diagnostics and the parser registry.
    */
@@ -26,6 +26,12 @@ export type Parser<TMeta extends object = any> = {
    * Serialise the file's AST into source code.
    */
   parse(file: FileNode<TMeta>, options?: PrintOptions): string
+  /**
+   * Render compiler AST nodes for this parser's language into source text.
+   * Plugins call this to format the nodes they assemble before handing them
+   * back to the parser as `FileNode.sources`.
+   */
+  print(...nodes: TNode[]): string
 }
 
 /**
@@ -44,9 +50,12 @@ export type Parser<TMeta extends object = any> = {
  *       .map((source) => ast.extractStringsFromNodes(source.nodes ?? []))
  *       .join('\n')
  *   },
+ *   print(...nodes) {
+ *     return nodes.map(String).join('\n')
+ *   },
  * })
  * ```
  */
-export function defineParser<TMeta extends object = any>(parser: Parser<TMeta>): Parser<TMeta> {
+export function defineParser<T extends Parser>(parser: T): T {
   return parser
 }

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -34,11 +34,23 @@ npm install @kubb/parser-ts
 ## Usage
 
 ```typescript
-import { print, createImport, createExport } from '@kubb/parser-ts'
+import { defineConfig } from 'kubb'
+import { parserTs, parserTsx } from '@kubb/parser-ts'
+
+export default defineConfig({
+  input: { path: './petstore.yaml' },
+  output: { path: './src/gen' },
+  parsers: [parserTs, parserTsx],
+})
+```
+
+To render compiler AST nodes to source text from inside a plugin, call `print` on the parser instance:
+
+```typescript
+import { parserTs } from '@kubb/parser-ts'
 import ts from 'typescript'
 
-// Print a TypeScript source file from compiler AST nodes
-const source = print([
+const source = parserTs.print(
   ts.factory.createVariableStatement(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     ts.factory.createVariableDeclarationList(
@@ -46,45 +58,22 @@ const source = print([
       ts.NodeFlags.Const,
     ),
   ),
-])
+)
 // → export const hello = 'world'
-
-// Create an import declaration
-const importNode = createImport({ name: 'axios', path: 'axios' })
-
-// Create an export declaration
-const exportNode = createExport({ name: 'MyType', path: './types' })
 ```
 
 ## API
 
-### `print(nodes, options?)`
-
-Converts an array of TypeScript compiler `Node` instances into a formatted source string. Returns the printed source code.
-
-### `safePrint(nodes, options?)`
-
-Same as `print` but catches formatting errors and returns the unformatted output as a fallback.
-
 ### `parserTs`
 
-Parser instance for `.ts` files. Use with Kubb's file system to emit TypeScript source files.
+Parser instance for `.ts` and `.js` files. Pass to `defineConfig({ parsers: [...] })` to emit TypeScript source files.
+
+- `parserTs.parse(file, options?)` — serialise a `FileNode` to TypeScript source.
+- `parserTs.print(...nodes)` — convert TypeScript compiler `Node` instances to a formatted source string.
 
 ### `parserTsx`
 
-Parser instance for `.tsx` files. Use with Kubb's file system to emit TSX source files.
-
-### `createImport(options)`
-
-Factory helper that creates a TypeScript `ImportDeclaration` node.
-
-### `createExport(options)`
-
-Factory helper that creates a TypeScript `ExportDeclaration` node.
-
-### `validateNodes(nodes)`
-
-Validates an array of TypeScript AST nodes for correctness before printing.
+Parser instance for `.tsx` and `.jsx` files. Same API as `parserTs` with JSX support.
 
 ## Supporting Kubb
 

--- a/packages/parser-ts/src/index.ts
+++ b/packages/parser-ts/src/index.ts
@@ -1,2 +1,2 @@
-export { createExport, createImport, parserTs, print, safePrint, validateNodes } from './parserTs.ts'
+export { parserTs } from './parserTs.ts'
 export { parserTsx } from './parserTsx.ts'

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -1,12 +1,7 @@
 import type { FileNode, SourceNode } from '@kubb/ast'
-import type { Parser } from '@kubb/core'
 import { defineParser } from '@kubb/core'
 import type * as ts from 'typescript'
 import { createExport, createImport, getRelativePath, print, printSource, resolveOutputPath } from './utils.ts'
-
-export { createExport, createImport, print, safePrint, validateNodes } from './utils.ts'
-
-export { printArrowFunction, printCodeNode, printConst, printFunction, printJSDoc, printSource, printType } from './utils.ts'
 
 /**
  * Default Kubb parser for `.ts` and `.js` files. Takes the universal AST
@@ -32,9 +27,12 @@ export { printArrowFunction, printCodeNode, printConst, printFunction, printJSDo
  * })
  * ```
  */
-export const parserTs: Parser = defineParser({
+export const parserTs = defineParser({
   name: 'typescript',
   extNames: ['.ts', '.js'],
+  print(...nodes: ts.Node[]) {
+    return print(...nodes)
+  },
   parse(file, options = { extname: '.ts' }) {
     const sourceParts: Array<string> = []
     for (const item of file.sources) {

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -1,6 +1,7 @@
-import type { Parser } from '@kubb/core'
 import { defineParser } from '@kubb/core'
+import type * as ts from 'typescript'
 import { parserTs } from './parserTs.ts'
+import { print } from './utils.ts'
 
 /**
  * Kubb parser for `.tsx` and `.jsx` files. Delegates to `parserTs` because the
@@ -24,9 +25,12 @@ import { parserTs } from './parserTs.ts'
  * })
  * ```
  */
-export const parserTsx: Parser = defineParser({
+export const parserTsx = defineParser({
   name: 'tsx',
   extNames: ['.tsx', '.jsx'],
+  print(...nodes: ts.Node[]) {
+    return print(...nodes)
+  },
   parse(file, options = { extname: '.tsx' }) {
     return parserTs.parse(file, options)
   },

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -103,26 +103,6 @@ export function formatReturnType(returnType: string | null | undefined, isAsync:
 }
 
 /**
- * Validates TypeScript AST nodes before printing.
- * Throws an error if any node has SyntaxKind.Unknown which would cause the
- * TypeScript printer to crash.
- */
-export function validateNodes(...nodes: ts.Node[]): void {
-  for (const node of nodes) {
-    if (!node) {
-      throw new Error('Attempted to print undefined or null TypeScript node')
-    }
-    if (node.kind === ts.SyntaxKind.Unknown) {
-      throw new Error(
-        'Invalid TypeScript AST node detected with SyntaxKind.Unknown. ' +
-          'This typically indicates a schema pattern that could not be properly converted to TypeScript. ' +
-          `Node: ${JSON.stringify(node, null, 2)}`,
-      )
-    }
-  }
-}
-
-/**
  * Module-scoped TypeScript printer instance. `ts.createPrinter()` is stateless across calls
  * (it does not mutate the source file) so a single instance can be safely reused for every
  * `print()` call. Hoisting it out of `print()` avoids re-running the printer initialization
@@ -156,14 +136,6 @@ export function print(...elements: Array<ts.Node>): string {
   const output = TS_PRINTER.printList(ts.ListFormat.MultiLine, factory.createNodeArray(filtered), PRINT_SOURCE_FILE)
 
   return output.replace(CRLF_PATTERN, '\n')
-}
-
-/**
- * Like `print` but validates nodes first to surface issues early.
- */
-export function safePrint(...elements: Array<ts.Node>): string {
-  validateNodes(...elements)
-  return print(...elements)
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add a required `print(...nodes: TNode[]): string` method to `Parser` in `@kubb/core`, generic over the AST node type, so any parser can declare a printer for its own AST.
- Implement `print` on `parserTs` and `parserTsx` via the existing module-scoped TypeScript printer.
- Slim `@kubb/parser-ts` public surface to just `parserTs` and `parserTsx` — the standalone helpers `print`, `safePrint`, `createImport`, `createExport`, and `validateNodes` are no longer exported, and `safePrint` / `validateNodes` are removed from the package.

## Breaking changes

- `@kubb/parser-ts`: removes standalone helper exports. Call `parserTs.print(...)` instead of the standalone `print` / `safePrint`. Plugin-ts is updated in [kubb-labs/plugins#TBD](https://github.com/kubb-labs/plugins).
- `@kubb/core`: `Parser` now requires a `print` method. Custom parsers built with `defineParser` need a one-line addition matching their AST node shape.

## Test plan

- [x] `pnpm --filter @kubb/core test` (132 passed)
- [x] `pnpm --filter @kubb/parser-ts test` (66 passed)
- [x] `pnpm typecheck` (all 11 packages clean)
- [x] `pnpm build` succeeds
- [x] Verified built bundle exposes only `parserTs` / `parserTsx`, each with a `print` method:
  ```
  exports: [ 'parserTs', 'parserTsx' ]
  parserTs.print: function
  parserTsx.print: function
  ```
- [x] `pnpm format` + `pnpm lint` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01XSW2n8JhiJ5eqMDELwGMa5)_