### PR TITLE
chore: enforce Array<T> via oxlint typescript/array-type rule

### DIFF
--- a/.changeset/enforce-array-type-syntax.md
+++ b/.changeset/enforce-array-type-syntax.md
@@ -1,0 +1,16 @@
+---
+'@kubb/adapter-oas': patch
+'@kubb/agent': patch
+'@kubb/ast': patch
+'@kubb/cli': patch
+'@kubb/core': patch
+'kubb': patch
+'@kubb/mcp': patch
+'@kubb/middleware-barrel': patch
+'@kubb/parser-md': patch
+'@kubb/parser-ts': patch
+'@kubb/renderer-jsx': patch
+'unplugin-kubb': patch
+---
+
+Enforce `Array<T>` syntax (over `T[]`) via the oxlint `typescript/array-type` rule. Internal-only change; no runtime or API impact.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     'no-else-return': 'error',
     'default-param-last': 'error',
     'prefer-exponentiation-operator': 'error',
+    'typescript/array-type': ['error', { default: 'generic' }],
     'typescript/consistent-type-imports': ['error', { disallowTypeAnnotations: false }],
     'typescript/no-inferrable-types': 'error',
     'typescript/prefer-function-type': 'error',

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -33,7 +33,7 @@ describe('adapterOas.stream', () => {
     const adapter = adapterOas({ validate: false })
 
     const node = await adapter.stream!({ type: 'data', data: minimalSpec })
-    const schemas: ast.SchemaNode[] = []
+    const schemas: Array<ast.SchemaNode> = []
     for await (const schema of node.schemas) {
       schemas.push(schema)
     }
@@ -46,10 +46,10 @@ describe('adapterOas.stream', () => {
     const adapter = adapterOas({ validate: false })
     const node = await adapter.stream!({ type: 'data', data: minimalSpec })
 
-    const first: ast.SchemaNode[] = []
+    const first: Array<ast.SchemaNode> = []
     for await (const schema of node.schemas) first.push(schema)
 
-    const second: ast.SchemaNode[] = []
+    const second: Array<ast.SchemaNode> = []
     for await (const schema of node.schemas) second.push(schema)
 
     expect(second.length).toBe(first.length)
@@ -60,7 +60,7 @@ describe('adapterOas.stream', () => {
     const adapter = adapterOas({ validate: false })
     const node = await adapter.stream!({ type: 'data', data: minimalSpec })
 
-    const operations: ast.OperationNode[] = []
+    const operations: Array<ast.OperationNode> = []
     for await (const op of node.operations) {
       operations.push(op)
     }

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -153,8 +153,8 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     async parse(source) {
       const streamNode = await createStream(source)
 
-      const collect = async <T>(iter: AsyncIterable<T>): Promise<T[]> => {
-        const out: T[] = []
+      const collect = async <T>(iter: AsyncIterable<T>): Promise<Array<T>> => {
+        const out: Array<T> = []
         for await (const item of iter) out.push(item)
         return out
       }

--- a/packages/adapter-oas/src/discriminator.ts
+++ b/packages/adapter-oas/src/discriminator.ts
@@ -14,7 +14,7 @@ export type DiscriminatorTarget = {
  * small pre-parsed subset of schemas (only the discriminator parents) rather than on all
  * schemas at once.
  */
-export function buildDiscriminatorChildMap(schemas: ast.SchemaNode[]): Map<string, DiscriminatorTarget> {
+export function buildDiscriminatorChildMap(schemas: Array<ast.SchemaNode>): Map<string, DiscriminatorTarget> {
   const childMap = new Map<string, DiscriminatorTarget>()
 
   for (const schema of schemas) {

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1416,7 +1416,7 @@ describe('parseSchema object properties', () => {
         type: 'object',
         // OAS 2.0 allows `required: true` (boolean) on individual properties.
         // Cast simulates an OAS 2.0 spec parsed at runtime where the type diverges from the TS definition.
-        required: true as unknown as string[],
+        required: true as unknown as Array<string>,
         properties: { id: { type: 'integer' }, tag: { type: 'string' } },
       },
     })

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -770,7 +770,7 @@ export function createSchemaParser(ctx: OasParserContext) {
     }
 
     if (Array.isArray(schema.type) && schema.type.length > 1) {
-      const nonNullTypes = schema.type.filter((t) => t !== 'null') as string[]
+      const nonNullTypes = schema.type.filter((t) => t !== 'null') as Array<string>
       const arrayNullable = schema.type.includes('null') || nullable || undefined
 
       if (nonNullTypes.length > 1) {
@@ -871,10 +871,10 @@ export function createSchemaParser(ctx: OasParserContext) {
    * Collects property names whose schema has a truthy boolean flag (`readOnly` or `writeOnly`).
    * `$ref` entries are skipped since their flags live on the dereferenced target.
    */
-  function collectPropertyKeysByFlag(schema: SchemaObject | null, flag: 'readOnly' | 'writeOnly'): string[] | null {
+  function collectPropertyKeysByFlag(schema: SchemaObject | null, flag: 'readOnly' | 'writeOnly'): Array<string> | null {
     if (!schema?.properties) return null
 
-    const keys: string[] = []
+    const keys: Array<string> = []
     for (const key in schema.properties) {
       const prop = schema.properties[key]
       if (prop && !isReference(prop) && (prop as Record<string, unknown>)[flag]) {

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -86,7 +86,7 @@ export type OperationsOptions = {
  * ```
  */
 export function getParameters(document: Document, operation: Operation): Array<ParameterObject> {
-  const resolveParams = (params: unknown[]): Array<ParameterObject> =>
+  const resolveParams = (params: Array<unknown>): Array<ParameterObject> =>
     params.map((p) => dereferenceWithRef(document, p)).filter((p): p is ParameterObject => !!p && typeof p === 'object' && 'in' in p && 'name' in p)
 
   const operationParams = resolveParams(operation.schema?.parameters || [])
@@ -108,7 +108,7 @@ export function getParameters(document: Document, operation: Operation): Array<P
   return Array.from(paramMap.values())
 }
 
-function getResponseBody(responseBody: boolean | ResponseObject, contentType?: string): MediaTypeObject | false | [string, MediaTypeObject, ...string[]] {
+function getResponseBody(responseBody: boolean | ResponseObject, contentType?: string): MediaTypeObject | false | [string, MediaTypeObject, ...Array<string>] {
   if (!responseBody) return false
   if (isReference(responseBody)) return false
 
@@ -260,7 +260,7 @@ function hasStructuralKeywords(fragment: SchemaObject): boolean {
 export function flattenSchema(schema: SchemaObject | null): SchemaObject | null {
   if (!schema?.allOf || schema.allOf.length === 0) return schema ?? null
 
-  const allOfFragments = schema.allOf as SchemaObject[]
+  const allOfFragments = schema.allOf as Array<SchemaObject>
   if (allOfFragments.some((item) => isRef(item))) return schema
   if (allOfFragments.some(hasStructuralKeywords)) return schema
 
@@ -339,13 +339,13 @@ function* collectRefs(schema: unknown): Generator<string, void, undefined> {
  * ```
  */
 export function sortSchemas(schemas: Record<string, SchemaObject>): Record<string, SchemaObject> {
-  const deps = new Map<string, string[]>()
+  const deps = new Map<string, Array<string>>()
 
   for (const [name, schema] of Object.entries(schemas)) {
     deps.set(name, [...new Set(collectRefs(schema))])
   }
 
-  const sorted: string[] = []
+  const sorted: Array<string> = []
   const visited = new Set<string>()
 
   function visit(name: string, stack: Set<string>) {
@@ -402,7 +402,7 @@ function resolveSchemaRef(document: Document, schema: SchemaObject): SchemaObjec
 export function getSchemas(document: Document, { contentType }: GetSchemasOptions): GetSchemasResult {
   const components = document.components
 
-  const candidates: SchemaWithMetadata[] = [
+  const candidates: Array<SchemaWithMetadata> = [
     ...Object.entries((components?.schemas as Record<string, SchemaObject>) ?? {}).map(([name, schema]) => ({
       schema: resolveSchemaRef(document, schema),
       source: 'schemas' as const,
@@ -424,7 +424,7 @@ export function getSchemas(document: Document, { contentType }: GetSchemasOption
     ),
   ]
 
-  const normalizedNames = new Map<string, SchemaWithMetadata[]>()
+  const normalizedNames = new Map<string, Array<SchemaWithMetadata>>()
   for (const item of candidates) {
     const key = pascalCase(item.originalName)
     const bucket = normalizedNames.get(key) ?? []
@@ -529,7 +529,7 @@ export function buildSchemaNode(schema: SchemaObject, name: string | null | unde
  * // ['application/json', 'multipart/form-data']
  * ```
  */
-export function getRequestBodyContentTypes(document: Document, operation: Operation): string[] {
+export function getRequestBodyContentTypes(document: Document, operation: Operation): Array<string> {
   if (operation.schema.requestBody) {
     operation.schema.requestBody = dereferenceWithRef(document, operation.schema.requestBody)
   }

--- a/packages/adapter-oas/src/stream.test.ts
+++ b/packages/adapter-oas/src/stream.test.ts
@@ -144,7 +144,7 @@ describe('createInputStream', () => {
       meta: { circularNames: [], enumNames: [] },
     })
 
-    const collected: ast.SchemaNode[] = []
+    const collected: Array<ast.SchemaNode> = []
     for await (const schema of node.schemas) collected.push(schema)
 
     expect(collected).toHaveLength(1)
@@ -167,10 +167,10 @@ describe('createInputStream', () => {
       meta: { circularNames: [], enumNames: [] },
     })
 
-    const first: string[] = []
+    const first: Array<string> = []
     for await (const s of node.schemas) first.push(s.name ?? '')
 
-    const second: string[] = []
+    const second: Array<string> = []
     for await (const s of node.schemas) second.push(s.name ?? '')
 
     expect(second).toEqual(first)
@@ -205,7 +205,7 @@ describe('createInputStream', () => {
       meta: { circularNames: [], enumNames: [] },
     })
 
-    const collected: ast.SchemaNode[] = []
+    const collected: Array<ast.SchemaNode> = []
     for await (const s of node.schemas) collected.push(s)
 
     const alias = collected.find((s) => s.name === 'PetAlias')
@@ -227,7 +227,7 @@ describe('createInputStream', () => {
       meta: { circularNames: [], enumNames: [] },
     })
 
-    const operations: ast.OperationNode[] = []
+    const operations: Array<ast.OperationNode> = []
     for await (const op of node.operations) operations.push(op)
 
     expect(operations).toHaveLength(1)

--- a/packages/adapter-oas/src/stream.ts
+++ b/packages/adapter-oas/src/stream.ts
@@ -8,8 +8,8 @@ import type { AdapterOas, Document, SchemaObject } from './types.ts'
 
 export type PreScanResult = {
   refAliasMap: Map<string, ast.SchemaNode>
-  enumNames: string[]
-  circularNames: string[]
+  enumNames: Array<string>
+  circularNames: Array<string>
   discriminatorChildMap: Map<string, DiscriminatorTarget> | null
 }
 
@@ -74,10 +74,10 @@ export function preScan({
   parserOptions: ast.ParserOptions
   discriminator: AdapterOas['options']['discriminator']
 }): PreScanResult {
-  const allNodes: ast.SchemaNode[] = []
+  const allNodes: Array<ast.SchemaNode> = []
   const refAliasMap = new Map<string, ast.SchemaNode>()
-  const enumNames: string[] = []
-  const discriminatorParentNodes: ast.SchemaNode[] = []
+  const enumNames: Array<string> = []
+  const discriminatorParentNodes: Array<ast.SchemaNode> = []
 
   for (const [name, schema] of Object.entries(schemas)) {
     const node = parseSchema({ schema, name }, parserOptions)

--- a/packages/agent/server/mocks/websocket.ts
+++ b/packages/agent/server/mocks/websocket.ts
@@ -3,7 +3,7 @@
  * Stores event listeners and supports async-safe triggering.
  */
 export class MockWebSocket {
-  private listeners = new Map<string, Array<(...args: any[]) => any>>()
+  private listeners = new Map<string, Array<(...args: Array<any>) => any>>()
 
   /** Simulates the OPEN ready state so sendAgentMessage does not bail early. */
   public readyState = 1
@@ -11,12 +11,12 @@ export class MockWebSocket {
   /** Tracks whether close() has been called */
   public closed = false
 
-  addEventListener(event: string, cb: (...args: any[]) => any): void {
+  addEventListener(event: string, cb: (...args: Array<any>) => any): void {
     if (!this.listeners.has(event)) this.listeners.set(event, [])
     this.listeners.get(event)!.push(cb)
   }
 
-  removeEventListener(event: string, cb: (...args: any[]) => any): void {
+  removeEventListener(event: string, cb: (...args: Array<any>) => any): void {
     const list = this.listeners.get(event)
     if (list) {
       const idx = list.indexOf(cb)

--- a/packages/agent/server/utils/agentCache.ts
+++ b/packages/agent/server/utils/agentCache.ts
@@ -3,7 +3,7 @@ import type { JSONKubbConfig } from '~/types/agent.ts'
 type Config = { config: JSONKubbConfig; storedAt: string }
 
 function getStorage() {
-  return useStorage<Config[]>('kubb')
+  return useStorage<Array<Config>>('kubb')
 }
 
 /**

--- a/packages/agent/server/utils/generate.ts
+++ b/packages/agent/server/utils/generate.ts
@@ -37,7 +37,7 @@ export async function generate({ config, hooks }: GenerateProps): Promise<void> 
   const hasFailures = failedPlugins.size > 0 || error
   if (hasFailures) {
     // Collect all errors from failed plugins and general error
-    const allErrors: Error[] = [
+    const allErrors: Array<Error> = [
       error,
       ...Array.from(failedPlugins)
         .filter((it) => it.error)

--- a/packages/ast/src/infer.ts
+++ b/packages/ast/src/infer.ts
@@ -77,7 +77,7 @@ type ResolveDateTimeNode<TDateType extends ParserOptions['dateType']> = DateTime
 type SchemaNodeMap<TDateType extends ParserOptions['dateType'] = 'string'> = [
   [{ $ref: string }, RefSchemaNode],
   [{ allOf: ReadonlyArray<unknown>; properties: object }, IntersectionSchemaNode],
-  [{ allOf: readonly [unknown, unknown, ...unknown[]] }, IntersectionSchemaNode],
+  [{ allOf: readonly [unknown, unknown, ...Array<unknown>] }, IntersectionSchemaNode],
   [{ allOf: ReadonlyArray<unknown> }, SchemaNode],
   [{ oneOf: ReadonlyArray<unknown> }, UnionSchemaNode],
   [{ anyOf: ReadonlyArray<unknown> }, UnionSchemaNode],

--- a/packages/ast/src/nodes/code.ts
+++ b/packages/ast/src/nodes/code.ts
@@ -145,7 +145,7 @@ export type FunctionNode = BaseNode & {
    * TypeScript generic type parameters.
    * @example ['T', 'U extends string']
    */
-  generics?: string | string[] | null
+  generics?: string | Array<string> | null
   /**
    * Return type annotation.
    * @example 'Pet'
@@ -206,7 +206,7 @@ export type ArrowFunctionNode = BaseNode & {
    * TypeScript generic type parameters.
    * @example ['T', 'U extends string']
    */
-  generics?: string | string[] | null
+  generics?: string | Array<string> | null
   /**
    * Return type annotation.
    * @example 'Pet'

--- a/packages/ast/src/nodes/root.ts
+++ b/packages/ast/src/nodes/root.ts
@@ -45,7 +45,7 @@ export type InputMeta = {
    * if (circular.has(schema.name)) { ... }
    * ```
    */
-  circularNames: readonly string[]
+  circularNames: ReadonlyArray<string>
   /**
    * Names of schemas whose type is `enum`.
    * Computed once during the adapter pre-scan — use this instead of filtering
@@ -58,7 +58,7 @@ export type InputMeta = {
    * `const enums = new Set(meta.enumNames)`
    * `const isEnum = enums.has(schemaName)`
    */
-  enumNames: readonly string[]
+  enumNames: ReadonlyArray<string>
 }
 
 /**

--- a/packages/ast/src/utils.ts
+++ b/packages/ast/src/utils.ts
@@ -726,7 +726,7 @@ export function extractStringsFromNodes(nodes: Array<CodeNode> | undefined): str
       if (node.kind === 'Break') return ''
       if (node.kind === 'Jsx') return node.value
 
-      const parts: string[] = []
+      const parts: Array<string> = []
 
       if ('params' in node && node.params) parts.push(node.params)
       if ('generics' in node && node.generics) parts.push(Array.isArray(node.generics) ? node.generics.join(', ') : node.generics)
@@ -878,7 +878,7 @@ const findCircularSchemasMemo = memoize(new WeakMap<ReadonlyArray<SchemaNode>, S
   const circular = new Set<string>()
   for (const start of graph.keys()) {
     const visited = new Set<string>()
-    const stack: string[] = [...(graph.get(start) ?? [])]
+    const stack: Array<string> = [...(graph.get(start) ?? [])]
     while (stack.length > 0) {
       const node = stack.pop()!
       if (node === start) {

--- a/packages/cli/src/loggers/fileSystemLogger.ts
+++ b/packages/cli/src/loggers/fileSystemLogger.ts
@@ -11,7 +11,7 @@ type CachedEvent = {
   /**
    * Accumulated log lines for this event.
    */
-  logs: string[]
+  logs: Array<string>
   /**
    * Optional override for the output filename inside `.kubb/`. When omitted, the filename is derived from `date`.
    */
@@ -41,7 +41,7 @@ export const fileSystemLogger = defineLogger({
         return []
       }
 
-      const files: Record<string, string[]> = {}
+      const files: Record<string, Array<string>> = {}
 
       for (const log of state.cachedLogs) {
         const baseName = log.fileName || `${['kubb', name, state.startDate].filter(Boolean).join('-')}.log`

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -104,7 +104,7 @@ type ProgressState = {
  * Returns null when there is nothing to display.
  */
 export function buildProgressLine(state: ProgressState): string | null {
-  const parts: string[] = []
+  const parts: Array<string> = []
   const duration = formatHrtime(state.hrStart)
 
   if (state.totalPlugins > 0) {
@@ -131,7 +131,7 @@ export function buildProgressLine(state: ProgressState): string | null {
  * Join a command and its optional args into a single display string.
  * e.g. ("prettier", ["--write", "."]) → "prettier --write ."
  */
-export function formatCommandWithArgs(command: string, args?: readonly string[]): string {
+export function formatCommandWithArgs(command: string, args?: ReadonlyArray<string>): string {
   return args?.length ? `${command} ${args.join(' ')}` : command
 }
 
@@ -200,7 +200,7 @@ type SummaryProps = {
  * Builds the generation summary lines rendered in the end-of-run box.
  * Returns an array of styled strings, one per summary row.
  */
-export function getSummary({ failedPlugins, filesCreated, status, hrStart, config, pluginTimings }: SummaryProps): string[] {
+export function getSummary({ failedPlugins, filesCreated, status, hrStart, config, pluginTimings }: SummaryProps): Array<string> {
   const duration = formatHrtime(hrStart)
 
   const pluginsCount = config.plugins?.length ?? 0
@@ -226,7 +226,7 @@ export function getSummary({ failedPlugins, filesCreated, status, hrStart, confi
   }
   const maxLength = Math.max(0, ...[...Object.values(labels), ...(pluginTimings ? Array.from(pluginTimings.keys()) : [])].map((s) => s.length))
 
-  const summaryLines: string[] = []
+  const summaryLines: Array<string> = []
   summaryLines.push(`${labels.plugins.padEnd(maxLength + 2)} ${meta.plugins}`)
 
   if (meta.pluginsFailed) {

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -49,7 +49,7 @@ function waitForHookEnd(
   fallbackErrorMessage: string,
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    const handler = (ctx: { id?: string; command: string; args?: readonly string[]; success: boolean; error: Error | null }) => {
+    const handler = (ctx: { id?: string; command: string; args?: ReadonlyArray<string>; success: boolean; error: Error | null }) => {
       if (ctx.id !== hookId) return
       hooks.off('kubb:hook:end', handler)
       if (!ctx.success) {
@@ -169,7 +169,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
     sendTelemetry(buildTelemetryEvent({ command: 'generate', kubbVersion: version, plugins: telemetryPlugins, hrStart, filesCreated: files.length, status }))
 
   if (failedPlugins.size > 0 || error) {
-    const allErrors = [error, ...Array.from(failedPlugins, (it) => it.error)].filter(Boolean) as Error[]
+    const allErrors = [error, ...Array.from(failedPlugins, (it) => it.error)].filter(Boolean) as Array<Error>
 
     for (const err of allErrors) {
       await hooks.emit('kubb:error', { error: err })
@@ -215,7 +215,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
       onStart: () => hooks.emit('kubb:lint:start'),
       onEnd: () => hooks.emit('kubb:lint:end'),
     },
-  ].filter(Boolean) as Omit<RunToolPassOptions, 'configName' | 'outputPath' | 'logLevel' | 'hooks'>[]
+  ].filter(Boolean) as Array<Omit<RunToolPassOptions, 'configName' | 'outputPath' | 'logLevel' | 'hooks'>>
 
   for (const pass of toolPasses) {
     await runToolPass({ ...pass, configName: config.name, outputPath, logLevel, hooks, makeSink })

--- a/packages/cli/src/runners/generate/utils.ts
+++ b/packages/cli/src/runners/generate/utils.ts
@@ -142,7 +142,7 @@ export async function executeHooks({ configHooks, hooks, makeSink }: ExecuteHook
 type RunHookOptions = {
   id: string
   command: string
-  args?: readonly string[]
+  args?: ReadonlyArray<string>
   commandWithArgs: string
   context: AsyncEventEmitter<KubbHooks>
   stream?: boolean
@@ -200,8 +200,8 @@ type WatcherLog = {
  * Ignores `.git` and `node_modules` directories.
  */
 export async function startWatcher(
-  path: string[],
-  cb: (path: string[]) => Promise<void>,
+  path: Array<string>,
+  cb: (path: Array<string>) => Promise<void>,
   log: WatcherLog = { info: console.log, error: console.log },
 ): Promise<void> {
   const { watch } = await import('chokidar')

--- a/packages/cli/src/runners/init/run.ts
+++ b/packages/cli/src/runners/init/run.ts
@@ -114,10 +114,10 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
     )
 
     // Plugin selection
-    const defaultPlugins = availablePlugins.filter((p) => (initDefaults.plugins as readonly string[]).includes(p.value))
-    const pluginLabel = (plugins: PluginOption[]) => styleText('cyan', plugins.map((p) => p.label).join(', '))
+    const defaultPlugins = availablePlugins.filter((p) => (initDefaults.plugins as ReadonlyArray<string>).includes(p.value))
+    const pluginLabel = (plugins: Array<PluginOption>) => styleText('cyan', plugins.map((p) => p.label).join(', '))
 
-    const selectedPlugins: PluginOption[] = await (async () => {
+    const selectedPlugins: Array<PluginOption> = await (async () => {
       if (pluginsFlag) {
         const requested = pluginsFlag
           .split(',')
@@ -142,7 +142,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
         required: true,
       })
       if (clack.isCancel(values)) cancelAndExit()
-      return availablePlugins.filter((p) => (values as string[]).includes(p.value))
+      return availablePlugins.filter((p) => (values as Array<string>).includes(p.value))
     })()
 
     // Install packages

--- a/packages/cli/src/runners/init/utils.test.ts
+++ b/packages/cli/src/runners/init/utils.test.ts
@@ -46,7 +46,7 @@ describe('packageManager', () => {
   })
 
   describe('initPackageJson', () => {
-    it.each<{ pm: PackageManagerInfo; expectedArgs: string[] }>([
+    it.each<{ pm: PackageManagerInfo; expectedArgs: Array<string> }>([
       {
         pm: {
           name: 'npm',

--- a/packages/cli/src/runners/init/utils.ts
+++ b/packages/cli/src/runners/init/utils.ts
@@ -15,7 +15,7 @@ export function hasPackageJson(cwd: string = process.cwd()): boolean {
  * Initializes a new `package.json` at `cwd` using the detected package manager.
  */
 export async function initPackageJson(cwd: string, packageManager: PackageManagerInfo): Promise<void> {
-  const commands: Record<PackageManagerName, string[]> = {
+  const commands: Record<PackageManagerName, Array<string>> = {
     npm: ['init', '-y'],
     pnpm: ['init'],
     yarn: ['init', '-y'],
@@ -28,6 +28,6 @@ export async function initPackageJson(cwd: string, packageManager: PackageManage
 /**
  * Installs the given packages at `cwd` using the detected package manager.
  */
-export async function installPackages(packages: string[], packageManager: PackageManagerInfo, cwd: string = process.cwd()): Promise<void> {
+export async function installPackages(packages: Array<string>, packageManager: PackageManagerInfo, cwd: string = process.cwd()): Promise<void> {
   await spawnAsync(packageManager.name, [...packageManager.installCommand, ...packages], { cwd })
 }

--- a/packages/cli/src/telemetry.test.ts
+++ b/packages/cli/src/telemetry.test.ts
@@ -51,7 +51,7 @@ describe('isTelemetryDisabled', () => {
 describe('buildTelemetryEvent', () => {
   it('should build a telemetry event with safe anonymous data only', () => {
     const hrStart = process.hrtime()
-    const plugins: TelemetryPlugin[] = [
+    const plugins: Array<TelemetryPlugin> = [
       { name: 'plugin-ts', options: { output: { path: 'types' } } },
       { name: 'plugin-client', options: { output: { path: 'clients' } } },
     ]

--- a/packages/cli/src/telemetry.ts
+++ b/packages/cli/src/telemetry.ts
@@ -13,8 +13,8 @@ type OtlpBoolValue = { boolValue: boolean }
 type OtlpIntValue = { intValue: number }
 type OtlpDoubleValue = { doubleValue: number }
 type OtlpBytesValue = { bytesValue: string }
-type OtlpArrayValue = { arrayValue: { values: OtlpAnyValue[] } }
-type OtlpKvListValue = { kvlistValue: { values: OtlpKeyValue[] } }
+type OtlpArrayValue = { arrayValue: { values: Array<OtlpAnyValue> } }
+type OtlpKvListValue = { kvlistValue: { values: Array<OtlpKeyValue> } }
 
 type OtlpAnyValue = OtlpStringValue | OtlpBoolValue | OtlpIntValue | OtlpDoubleValue | OtlpBytesValue | OtlpArrayValue | OtlpKvListValue
 
@@ -24,14 +24,14 @@ type OtlpKeyValue = {
 }
 
 type OtlpResource = {
-  attributes: OtlpKeyValue[]
+  attributes: Array<OtlpKeyValue>
   droppedAttributesCount?: number
 }
 
 type OtlpInstrumentationScope = {
   name: string
   version?: string
-  attributes?: OtlpKeyValue[]
+  attributes?: Array<OtlpKeyValue>
   droppedAttributesCount?: number
 }
 
@@ -55,11 +55,11 @@ type OtlpSpan = {
   kind: OtlpSpanKind
   startTimeUnixNano: string
   endTimeUnixNano: string
-  attributes?: OtlpKeyValue[]
+  attributes?: Array<OtlpKeyValue>
   droppedAttributesCount?: number
-  events?: OtlpSpanEvent[]
+  events?: Array<OtlpSpanEvent>
   droppedEventsCount?: number
-  links?: OtlpSpanLink[]
+  links?: Array<OtlpSpanLink>
   droppedLinksCount?: number
   status?: OtlpStatus
 }
@@ -67,7 +67,7 @@ type OtlpSpan = {
 type OtlpSpanEvent = {
   timeUnixNano: string
   name: string
-  attributes?: OtlpKeyValue[]
+  attributes?: Array<OtlpKeyValue>
   droppedAttributesCount?: number
 }
 
@@ -75,25 +75,25 @@ type OtlpSpanLink = {
   traceId: string
   spanId: string
   traceState?: string
-  attributes?: OtlpKeyValue[]
+  attributes?: Array<OtlpKeyValue>
   droppedAttributesCount?: number
 }
 
 type OtlpScopeSpans = {
   scope: OtlpInstrumentationScope
-  spans: OtlpSpan[]
+  spans: Array<OtlpSpan>
   schemaUrl?: string
 }
 
 type OtlpResourceSpans = {
   resource: OtlpResource
-  scopeSpans: OtlpScopeSpans[]
+  scopeSpans: Array<OtlpScopeSpans>
   schemaUrl?: string
 }
 
 /** Root payload sent to POST /v1/traces */
 type OtlpExportTraceServiceRequest = {
-  resourceSpans: OtlpResourceSpans[]
+  resourceSpans: Array<OtlpResourceSpans>
 }
 
 /**
@@ -116,7 +116,7 @@ type TelemetryEvent = {
   nodeVersion: string
   platform: string
   ci: boolean
-  plugins: TelemetryPlugin[]
+  plugins: Array<TelemetryPlugin>
   duration: number
   filesCreated: number
   status: 'success' | 'failed'
@@ -151,7 +151,7 @@ export function buildOtlpPayload(event: TelemetryEvent): OtlpExportTraceServiceR
   const endTimeNs = BigInt(Date.now()) * 1_000_000n
   const startTimeNs = endTimeNs - BigInt(event.duration) * 1_000_000n
 
-  const attributes: OtlpKeyValue[] = [
+  const attributes: Array<OtlpKeyValue> = [
     { key: 'kubb.command', value: { stringValue: event.command } },
     { key: 'kubb.version', value: { stringValue: event.kubbVersion } },
     { key: 'kubb.node_version', value: { stringValue: event.nodeVersion } },
@@ -258,7 +258,7 @@ export async function sendTelemetry(event: TelemetryEvent): Promise<void> {
 export function buildTelemetryEvent(options: {
   command: 'generate' | 'mcp' | 'validate' | 'agent'
   kubbVersion: string
-  plugins?: TelemetryPlugin[]
+  plugins?: Array<TelemetryPlugin>
   hrStart: [number, number]
   filesCreated?: number
   status: 'success' | 'failed'

--- a/packages/core/src/FileProcessor.ts
+++ b/packages/core/src/FileProcessor.ts
@@ -25,7 +25,7 @@ export type ParsedFile = {
 function joinSources(file: FileNode): string {
   const sources = file.sources
   if (sources.length === 0) return ''
-  const parts: string[] = []
+  const parts: Array<string> = []
   for (const source of sources) {
     const s = extractStringsFromNodes(source.nodes as Array<CodeNode>)
     if (s) parts.push(s)

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -81,7 +81,7 @@ export class KubbDriver {
   // middleware hooks for any event fire after all plugin hooks for that event.
   // Handlers are tracked so they can be removed after each build (disposeMiddleware),
   // preventing accumulation when multiple configs share the same hooks instance.
-  #middlewareListeners: Array<[keyof KubbHooks & string, (...args: never[]) => void | Promise<void>]> = []
+  #middlewareListeners: Array<[keyof KubbHooks & string, (...args: Array<never>) => void | Promise<void>]> = []
 
   /**
    * Central file store for all generated files.
@@ -100,7 +100,7 @@ export class KubbDriver {
   readonly #eventGeneratorPlugins = new Set<string>()
   readonly #resolvers = new Map<string, Resolver>()
   readonly #defaultResolvers = new Map<string, Resolver>()
-  readonly #hookListeners = new Map<keyof KubbHooks, Set<(...args: never[]) => void | Promise<void>>>()
+  readonly #hookListeners = new Map<keyof KubbHooks, Set<(...args: Array<never>) => void | Promise<void>>>()
 
   constructor(config: Config, options: Options) {
     this.config = config
@@ -109,7 +109,7 @@ export class KubbDriver {
   }
 
   async setup() {
-    const normalized: NormalizedPlugin[] = this.config.plugins.map((rawPlugin) => this.#normalizePlugin(rawPlugin as Plugin))
+    const normalized: Array<NormalizedPlugin> = this.config.plugins.map((rawPlugin) => this.#normalizePlugin(rawPlugin as Plugin))
 
     normalized.sort((a, b) => {
       if (b.dependencies?.includes(a.name)) return -1
@@ -199,7 +199,7 @@ export class KubbDriver {
     }
 
     this.hooks.on(event, handler)
-    this.#middlewareListeners.push([event, handler as (...args: never[]) => void | Promise<void>])
+    this.#middlewareListeners.push([event, handler as (...args: Array<never>) => void | Promise<void>])
   }
 
   /**
@@ -253,15 +253,15 @@ export class KubbDriver {
       }
 
       this.hooks.on('kubb:plugin:setup', setupHandler)
-      this.#trackHookListener('kubb:plugin:setup', setupHandler as (...args: never[]) => void | Promise<void>)
+      this.#trackHookListener('kubb:plugin:setup', setupHandler as (...args: Array<never>) => void | Promise<void>)
     }
 
     // All other hooks are registered as direct pass-through listeners on the shared emitter.
-    for (const [event, handler] of Object.entries(hooks) as Array<[keyof KubbHooks, ((...args: never[]) => void | Promise<void>) | undefined]>) {
+    for (const [event, handler] of Object.entries(hooks) as Array<[keyof KubbHooks, ((...args: Array<never>) => void | Promise<void>) | undefined]>) {
       if (event === 'kubb:plugin:setup' || !handler) continue
 
       this.hooks.on(event, handler as never)
-      this.#trackHookListener(event, handler as (...args: never[]) => void | Promise<void>)
+      this.#trackHookListener(event, handler as (...args: Array<never>) => void | Promise<void>)
     }
   }
 
@@ -315,7 +315,7 @@ export class KubbDriver {
       }
 
       this.hooks.on('kubb:generate:schema', schemaHandler)
-      this.#trackHookListener('kubb:generate:schema', schemaHandler as (...args: never[]) => void | Promise<void>)
+      this.#trackHookListener('kubb:generate:schema', schemaHandler as (...args: Array<never>) => void | Promise<void>)
     }
 
     if (gen.operation) {
@@ -326,7 +326,7 @@ export class KubbDriver {
       }
 
       this.hooks.on('kubb:generate:operation', operationHandler)
-      this.#trackHookListener('kubb:generate:operation', operationHandler as (...args: never[]) => void | Promise<void>)
+      this.#trackHookListener('kubb:generate:operation', operationHandler as (...args: Array<never>) => void | Promise<void>)
     }
 
     if (gen.operations) {
@@ -337,7 +337,7 @@ export class KubbDriver {
       }
 
       this.hooks.on('kubb:generate:operations', operationsHandler)
-      this.#trackHookListener('kubb:generate:operations', operationsHandler as (...args: never[]) => void | Promise<void>)
+      this.#trackHookListener('kubb:generate:operations', operationsHandler as (...args: Array<never>) => void | Promise<void>)
     }
 
     this.#eventGeneratorPlugins.add(pluginName)
@@ -510,7 +510,7 @@ export class KubbDriver {
     type PluginState = {
       plugin: NormalizedPlugin
       generatorContext: GeneratorContext
-      generators: Generator[]
+      generators: Array<Generator>
       hrStart: ReturnType<typeof process.hrtime>
       failed: boolean
       error: Error | null
@@ -520,7 +520,7 @@ export class KubbDriver {
 
     const driver = this
     const { schemas, operations } = this.inputNode!
-    const states: PluginState[] = entries.map(({ plugin, context, hrStart }) => {
+    const states: Array<PluginState> = entries.map(({ plugin, context, hrStart }) => {
       const { exclude, include, override } = plugin.options
       const hasExclude = Array.isArray(exclude) && exclude.length > 0
       const hasInclude = Array.isArray(include) && include.length > 0
@@ -550,10 +550,10 @@ export class KubbDriver {
     })
 
     if (pruningStates.length > 0) {
-      const allSchemas: SchemaNode[] = []
+      const allSchemas: Array<SchemaNode> = []
       for await (const schema of schemas) allSchemas.push(schema)
 
-      const includedOpsByState = new Map<PluginState, OperationNode[]>(pruningStates.map((s) => [s, []]))
+      const includedOpsByState = new Map<PluginState, Array<OperationNode>>(pruningStates.map((s) => [s, []]))
       for await (const operation of operations) {
         for (const state of pruningStates) {
           const { exclude, include, override } = state.plugin.options
@@ -632,7 +632,7 @@ export class KubbDriver {
     // Saves an N-sized allocation that lives until the build ends, on the common
     // path where plugins only define per-node `gen.operation`.
     const needsCollectedOperations = this.hooks.listenerCount('kubb:generate:operations') > 0 || states.some((s) => s.generators.some((g) => !!g.operations))
-    const collectedOperations: OperationNode[] = needsCollectedOperations ? [] : (undefined as never)
+    const collectedOperations: Array<OperationNode> = needsCollectedOperations ? [] : (undefined as never)
 
     // Run schemas before operations: the two passes share `flushPending` and the
     // FileProcessor's event emitter, so running them concurrently would interleave
@@ -731,7 +731,7 @@ export class KubbDriver {
     this.dispose()
   }
 
-  #trackHookListener(event: keyof KubbHooks, handler: (...args: never[]) => void | Promise<void>): void {
+  #trackHookListener(event: keyof KubbHooks, handler: (...args: Array<never>) => void | Promise<void>): void {
     let handlers = this.#hookListeners.get(event)
     if (!handlers) {
       handlers = new Set()

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -342,7 +342,12 @@ describe('createKubb', () => {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas, operations: [] }),
+            parse: async () => ({
+              kind: 'Input' as const,
+              meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+              schemas,
+              operations: [],
+            }),
           }),
           plugins: [makeBatchPlugin(generatedPaths) as unknown as Plugin],
         },
@@ -381,7 +386,12 @@ describe('createKubb', () => {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas: [], operations }),
+            parse: async () => ({
+              kind: 'Input' as const,
+              meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+              schemas: [],
+              operations,
+            }),
           }),
           plugins: [orderPlugin as unknown as Plugin],
         },
@@ -402,7 +412,12 @@ describe('createKubb', () => {
       async function* asyncOps() {}
 
       const streamAdapter = createMockedAdapter({
-        parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas: [], operations: [] }),
+        parse: async () => ({
+          kind: 'Input' as const,
+          meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+          schemas: [],
+          operations: [],
+        }),
       })
       Object.assign(streamAdapter, {
         stream: async () => createStreamInput(asyncSchemas(), asyncOps()),
@@ -460,7 +475,12 @@ describe('createKubb', () => {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas, operations: [] }),
+            parse: async () => ({
+              kind: 'Input' as const,
+              meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+              schemas,
+              operations: [],
+            }),
           }),
           plugins: [flushPlugin as unknown as Plugin],
         },

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -245,7 +245,7 @@ describe('createKubb', () => {
       adapter: createMockedAdapter({
         parse: async () => ({
           kind: 'Input' as const,
-          meta: { circularNames: [] as string[], enumNames: [] as string[] },
+          meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
           schemas: [createSchema({ name: 'Pet', type: 'string' })],
           operations: [],
         }),
@@ -306,7 +306,7 @@ describe('createKubb', () => {
   })
 
   describe('schema-level parallelism', () => {
-    function makeBatchPlugin(generatedPaths: string[]) {
+    function makeBatchPlugin(generatedPaths: Array<string>) {
       return definePlugin(() => ({
         name: 'batch-plugin',
         hooks: {
@@ -335,14 +335,14 @@ describe('createKubb', () => {
     it('generates all files when schema count exceeds SCHEMA_PARALLEL', async () => {
       const count = SCHEMA_PARALLEL * 3 + 1
       const schemas = Array.from({ length: count }, (_, i) => createSchema({ name: `Schema${i}`, type: 'string' }))
-      const generatedPaths: string[] = []
+      const generatedPaths: Array<string> = []
 
       const { files } = await createKubb(
         {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as string[], enumNames: [] as string[] }, schemas, operations: [] }),
+            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas, operations: [] }),
           }),
           plugins: [makeBatchPlugin(generatedPaths) as unknown as Plugin],
         },
@@ -359,7 +359,7 @@ describe('createKubb', () => {
       const operations = Array.from({ length: opCount }, (_, i) =>
         createOperation({ operationId: `op${i}`, method: 'GET', path: `/path${i}`, parameters: [], responses: [], tags: [] }),
       )
-      const receivedOrder: string[] = []
+      const receivedOrder: Array<string> = []
 
       const orderPlugin = definePlugin(() => ({
         name: 'order-plugin',
@@ -381,7 +381,7 @@ describe('createKubb', () => {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as string[], enumNames: [] as string[] }, schemas: [], operations }),
+            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas: [], operations }),
           }),
           plugins: [orderPlugin as unknown as Plugin],
         },
@@ -394,7 +394,7 @@ describe('createKubb', () => {
     it('processes schemas from adapter.stream() across batches', async () => {
       const count = SCHEMA_PARALLEL * 2 + 1
       const schemas = Array.from({ length: count }, (_, i) => createSchema({ name: `StreamSchema${i}`, type: 'string' }))
-      const generatedPaths: string[] = []
+      const generatedPaths: Array<string> = []
 
       async function* asyncSchemas() {
         for (const s of schemas) yield s
@@ -402,7 +402,7 @@ describe('createKubb', () => {
       async function* asyncOps() {}
 
       const streamAdapter = createMockedAdapter({
-        parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as string[], enumNames: [] as string[] }, schemas: [], operations: [] }),
+        parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas: [], operations: [] }),
       })
       Object.assign(streamAdapter, {
         stream: async () => createStreamInput(asyncSchemas(), asyncOps()),
@@ -428,7 +428,7 @@ describe('createKubb', () => {
       const count = STREAM_FLUSH_EVERY + 10
       const schemas = Array.from({ length: count }, (_, i) => createSchema({ name: `FlushSchema${i}`, type: 'string' }))
       const hooks = new AsyncEventEmitter<KubbHooks>()
-      const flushEvents: number[] = []
+      const flushEvents: Array<number> = []
       hooks.on('kubb:files:processing:start', ({ files }) => {
         flushEvents.push(files.length)
       })
@@ -460,7 +460,7 @@ describe('createKubb', () => {
           ...config,
           storage: memoryStorage(),
           adapter: createMockedAdapter({
-            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as string[], enumNames: [] as string[] }, schemas, operations: [] }),
+            parse: async () => ({ kind: 'Input' as const, meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> }, schemas, operations: [] }),
           }),
           plugins: [flushPlugin as unknown as Plugin],
         },
@@ -475,7 +475,7 @@ describe('createKubb', () => {
   describe('parallel file writes', () => {
     it('writes all files correctly when flush batch exceeds STREAM_FLUSH_EVERY', async () => {
       const fileCount = STREAM_FLUSH_EVERY * 2 + 5
-      const writtenPaths: string[] = []
+      const writtenPaths: Array<string> = []
       const storage = memoryStorage()
       const originalSetItem = storage.setItem.bind(storage)
       storage.setItem = async (key, value) => {

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -790,7 +790,7 @@ export type KubbHookStartContext = {
   /**
    * Parsed argument list, when available.
    */
-  args?: readonly string[]
+  args?: ReadonlyArray<string>
 }
 
 export type KubbHookEndContext = {
@@ -805,7 +805,7 @@ export type KubbHookEndContext = {
   /**
    * Parsed argument list, when available.
    */
-  args?: readonly string[]
+  args?: ReadonlyArray<string>
   /**
    * `true` when the command exited with code `0`.
    */
@@ -846,8 +846,8 @@ export type CLIOptions = {
  * Accepts `Config`/`Config[]`/promise or a factory (optionally receiving `TCliOptions`.
  */
 export type PossibleConfig<TCliOptions = undefined> =
-  | PossiblePromise<Config | Config[]>
-  | ((...args: [TCliOptions] extends [undefined] ? [] : [TCliOptions]) => PossiblePromise<Config | Config[]>)
+  | PossiblePromise<Config | Array<Config>>
+  | ((...args: [TCliOptions] extends [undefined] ? [] : [TCliOptions]) => PossiblePromise<Config | Array<Config>>)
 
 /**
  * Full output produced by a successful or failed build.

--- a/packages/core/src/defineMiddleware.test.ts
+++ b/packages/core/src/defineMiddleware.test.ts
@@ -155,7 +155,7 @@ describe('middleware runtime integration with createKubb', () => {
   })
 
   it('middleware listeners fire after plugin listeners for the same event', async () => {
-    const callOrder: string[] = []
+    const callOrder: Array<string> = []
 
     const plugin = definePlugin(() => ({
       name: 'ordering-plugin',
@@ -191,7 +191,7 @@ describe('middleware runtime integration with createKubb', () => {
   })
 
   it('middleware can observe kubb:build:end and access files', async () => {
-    const capturedFiles: unknown[] = []
+    const capturedFiles: Array<unknown> = []
 
     const middleware = defineMiddleware(() => ({
       name: 'build-end-observer',

--- a/packages/core/src/defineParser.ts
+++ b/packages/core/src/defineParser.ts
@@ -31,7 +31,7 @@ export type Parser<TMeta extends object = any, TNode = unknown> = {
    * Plugins call this to format the nodes they assemble before handing them
    * back to the parser as `FileNode.sources`.
    */
-  print(...nodes: TNode[]): string
+  print(...nodes: Array<TNode>): string
 }
 
 /**

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -142,7 +142,7 @@ describe('PluginDriver — hook-style plugin registration', () => {
   })
 
   it('options passed to definePlugin are forwarded via ctx.options', async () => {
-    const capturedOptions: unknown[] = []
+    const capturedOptions: Array<unknown> = []
     const hookPlugin = definePlugin<TestPluginOptions>((options) => ({
       name: 'hook-plugin',
       options,

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -205,7 +205,7 @@ describe('defineConfig', () => {
 
   test('handles function array config', async () => {
     const fn = defineConfig(() => [{ ...baseConfig }])
-    const typedFn: (cli: CLIOptions) => Promise<UserConfig[]> = fn
+    const typedFn: (cli: CLIOptions) => Promise<Array<UserConfig>> = fn
 
     expect(typeof typedFn).toBe('function')
     const result = await fn({})
@@ -215,7 +215,7 @@ describe('defineConfig', () => {
 
   test('handles async function array config', async () => {
     const fn = defineConfig(async () => [{ ...baseConfig }])
-    const typedFn: (cli: CLIOptions) => Promise<UserConfig[]> = fn
+    const typedFn: (cli: CLIOptions) => Promise<Array<UserConfig>> = fn
 
     expect(typeof typedFn).toBe('function')
     const result = await fn({})

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -3,6 +3,6 @@ import { startServer } from './server.ts'
 export { createMcpServer } from './server.ts'
 export type { ServerOptions } from './server.ts'
 
-export async function run(_argv?: string[], options?: import('./server.ts').ServerOptions): Promise<void> {
+export async function run(_argv?: Array<string>, options?: import('./server.ts').ServerOptions): Promise<void> {
   await startServer(options)
 }

--- a/packages/mcp/src/tools/generate.ts
+++ b/packages/mcp/src/tools/generate.ts
@@ -20,7 +20,7 @@ export const generateTool = defineTool(
 
     try {
       const hooks = new AsyncEventEmitter<KubbHooks>()
-      const messages: string[] = []
+      const messages: Array<string> = []
 
       const notify = async (type: string, message: string, _data?: Record<string, unknown>) => {
         messages.push(`${type}: ${message}`)
@@ -123,7 +123,7 @@ export const generateTool = defineTool(
       await notify(NotifyTypes.BUILD_END, `Build complete - Generated ${files.length} files`)
 
       if (error || failedPlugins.size > 0) {
-        const allErrors: Error[] = [
+        const allErrors: Array<Error> = [
           error,
           ...Array.from(failedPlugins)
             .filter((it) => it.error)

--- a/packages/mcp/src/tools/init.ts
+++ b/packages/mcp/src/tools/init.ts
@@ -6,7 +6,7 @@ import { defineTool } from 'tmcp/tool'
 import { tool } from 'tmcp/utils'
 import { initSchema } from '../schemas/initSchema.ts'
 
-export function resolvePlugins(pluginsFlag: string | undefined): PluginOption[] {
+export function resolvePlugins(pluginsFlag: string | undefined): Array<PluginOption> {
   if (!pluginsFlag) {
     return []
   }

--- a/packages/middleware-barrel/src/utils.ts
+++ b/packages/middleware-barrel/src/utils.ts
@@ -102,7 +102,7 @@ type LeafWalkParams = {
  * Post-order walk that yields a barrel per visited directory.
  * Returns the list of leaf file paths collected in this subtree (used by the parent call).
  */
-function* walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean): Generator<FileNode, string[]> {
+function* walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolean): Generator<FileNode, Array<string>> {
   const subtreeLeaves: Array<string> = []
 
   for (const child of node.children) {

--- a/packages/parser-md/src/parserMd.ts
+++ b/packages/parser-md/src/parserMd.ts
@@ -36,11 +36,11 @@ export type MdMeta = {
 export const parserMd = defineParser({
   name: 'markdown',
   extNames: ['.md', '.markdown'],
-  print(...parts: PrintInput[]) {
+  print(...parts: Array<PrintInput>) {
     return print(...parts)
   },
   parse(file) {
-    const sourceParts: string[] = []
+    const sourceParts: Array<string> = []
     for (const source of file.sources) {
       const text = ast.extractStringsFromNodes(source.nodes as Array<ast.CodeNode>)
       if (text) sourceParts.push(text.trimEnd())

--- a/packages/parser-md/src/utils.ts
+++ b/packages/parser-md/src/utils.ts
@@ -35,7 +35,7 @@ export function printFrontmatter(data: Record<string, unknown> | null | undefine
  * ```
  */
 export function print(...parts: Array<PrintInput | null | undefined>): string {
-  const rendered: string[] = []
+  const rendered: Array<string> = []
   for (const part of parts) {
     if (part === null || part === undefined || part === '') continue
     const text = typeof part === 'string' ? part : printFrontmatter(part)

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -30,7 +30,7 @@ import { createExport, createImport, getRelativePath, print, printSource, resolv
 export const parserTs = defineParser({
   name: 'typescript',
   extNames: ['.ts', '.js'],
-  print(...nodes: ts.Node[]) {
+  print(...nodes: Array<ts.Node>) {
     return print(...nodes)
   },
   parse(file, options = { extname: '.ts' }) {

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -28,7 +28,7 @@ import { print } from './utils.ts'
 export const parserTsx = defineParser({
   name: 'tsx',
   extNames: ['.tsx', '.jsx'],
-  print(...nodes: ts.Node[]) {
+  print(...nodes: Array<ts.Node>) {
     return print(...nodes)
   },
   parse(file, options = { extname: '.tsx' }) {

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -63,7 +63,7 @@ export function resolveOutputPath(path: string, options: { extname?: string } | 
 export function printNodes(nodes: Array<CodeNode> | undefined): string {
   if (!nodes || nodes.length === 0) return ''
 
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   for (const node of nodes) {
     parts.push(printCodeNode(node))
@@ -187,7 +187,7 @@ export function printConst(node: ConstNode): string {
   const jsDocStr = JSDoc ? printJSDoc(JSDoc) : ''
   const body = printNodes(nodes)
 
-  const parts: string[] = []
+  const parts: Array<string> = []
   if (canExport) parts.push('export ')
   parts.push('const ')
   parts.push(name)
@@ -219,7 +219,7 @@ export function printType(node: TypeNode): string {
   const jsDocStr = JSDoc ? printJSDoc(JSDoc) : ''
   const body = printNodes(nodes)
 
-  const parts: string[] = []
+  const parts: Array<string> = []
   if (canExport) parts.push('export ')
   parts.push('type ')
   parts.push(name)
@@ -254,7 +254,7 @@ export function printFunction(node: FunctionNode): string {
   const body = printNodes(nodes)
   const indented = body ? indentLines(body) : ''
 
-  const parts: string[] = []
+  const parts: Array<string> = []
   if (canExport) parts.push('export ')
   if (isDefault) parts.push('default ')
   if (isAsync) parts.push('async ')
@@ -297,7 +297,7 @@ export function printArrowFunction(node: ArrowFunctionNode): string {
   const body = printNodes(nodes)
   const arrowBody = singleLine ? ` => ${body}` : body ? ` => {\n${indentLines(body)}\n}` : ' => {}'
 
-  const parts: string[] = []
+  const parts: Array<string> = []
   if (canExport) parts.push('export ')
   if (isDefault) parts.push('default ')
   parts.push('const ')
@@ -351,7 +351,7 @@ export function printSource(node: SourceNode): string {
   const nodes = node.nodes
 
   if (!nodes || nodes.length === 0) return ''
-  const parts: string[] = []
+  const parts: Array<string> = []
 
   for (const child of nodes) {
     parts.push(printCodeNode(child as CodeNode))

--- a/packages/renderer-jsx/src/Runtime.tsx
+++ b/packages/renderer-jsx/src/Runtime.tsx
@@ -22,7 +22,7 @@ export class Runtime {
 
   exitPromise?: Promise<void>
 
-  nodes: FileNode[] = []
+  nodes: Array<FileNode> = []
   readonly #container: FiberRoot
   readonly #rootNode: DOMElement
 

--- a/packages/renderer-jsx/src/SyncRuntime.tsx
+++ b/packages/renderer-jsx/src/SyncRuntime.tsx
@@ -60,13 +60,13 @@ function toBool(val: unknown): boolean {
   return (val ?? false) as boolean
 }
 
-function collectCodeNodes(props: Record<string, unknown>): CodeNode[] {
-  const nodes: CodeNode[] = []
+function collectCodeNodes(props: Record<string, unknown>): Array<CodeNode> {
+  const nodes: Array<CodeNode> = []
   collectCode(props['children'], nodes)
   return nodes
 }
 
-function collectCode(element: unknown, nodes: CodeNode[]): void {
+function collectCode(element: unknown, nodes: Array<CodeNode>): void {
   walkElement(
     element,
     (text) => {
@@ -76,7 +76,7 @@ function collectCode(element: unknown, nodes: CodeNode[]): void {
   )
 }
 
-function resolveCodeNode(type: string, props: Record<string, unknown>, nodes: CodeNode[]): void {
+function resolveCodeNode(type: string, props: Record<string, unknown>, nodes: Array<CodeNode>): void {
   if (type === 'br') {
     nodes.push(createBreak())
     return
@@ -103,7 +103,7 @@ function resolveCodeNode(type: string, props: Record<string, unknown>, nodes: Co
         export: props['export'] as boolean | null | undefined,
         default: props['default'] as boolean | null | undefined,
         async: props['async'] as boolean | null | undefined,
-        generics: props['generics'] as string | string[] | null | undefined,
+        generics: props['generics'] as string | Array<string> | null | undefined,
         returnType: props['returnType'] as string | null | undefined,
         JSDoc: props['JSDoc'] as JSDocNode | null | undefined,
         nodes: collectCodeNodes(props),
@@ -120,7 +120,7 @@ function resolveCodeNode(type: string, props: Record<string, unknown>, nodes: Co
         export: props['export'] as boolean | null | undefined,
         default: props['default'] as boolean | null | undefined,
         async: props['async'] as boolean | null | undefined,
-        generics: props['generics'] as string | string[] | null | undefined,
+        generics: props['generics'] as string | Array<string> | null | undefined,
         returnType: props['returnType'] as string | null | undefined,
         singleLine: props['singleLine'] as boolean | null | undefined,
         JSDoc: props['JSDoc'] as JSDocNode | null | undefined,
@@ -157,12 +157,12 @@ function resolveCodeNode(type: string, props: Record<string, unknown>, nodes: Co
   }
 }
 
-type FileChildren = { sources: SourceNode[]; exports: ExportNode[]; imports: ImportNode[] }
+type FileChildren = { sources: Array<SourceNode>; exports: Array<ExportNode>; imports: Array<ImportNode> }
 
 function collectFileChildren(element: unknown): FileChildren {
-  const sources: SourceNode[] = []
-  const exports: ExportNode[] = []
-  const imports: ImportNode[] = []
+  const sources: Array<SourceNode> = []
+  const exports: Array<ExportNode> = []
+  const imports: Array<ImportNode> = []
 
   walkElement(
     element,
@@ -278,7 +278,7 @@ export class SyncRuntime {
   /**
    * Accumulated {@link FileNode} results from every {@link render} call.
    */
-  nodes: FileNode[] = []
+  nodes: Array<FileNode> = []
 
   /**
    * Walks `element` synchronously, converts every `<kubb-file>` subtree into

--- a/packages/renderer-jsx/src/components/Function.tsx
+++ b/packages/renderer-jsx/src/components/Function.tsx
@@ -46,7 +46,7 @@ type Props = {
    * @example Multiple generics
    * `generics: ['TData', 'TError = unknown']`
    */
-  generics?: string | string[] | null
+  generics?: string | Array<string> | null
   /**
    * TypeScript return type annotation written verbatim after `:`.
    * When `async` is `true`, the value is automatically wrapped in `Promise<…>`.

--- a/packages/renderer-jsx/src/createRenderer.test.tsx
+++ b/packages/renderer-jsx/src/createRenderer.test.tsx
@@ -147,7 +147,7 @@ describe('jsxRendererSync', () => {
 
   it('should stream files one at a time', async () => {
     const renderer = jsxRendererSync()
-    const order: string[] = []
+    const order: Array<string> = []
 
     const element = (
       <>
@@ -176,7 +176,7 @@ describe('jsxRendererSync', () => {
   })
 
   it('should yield the first file before evaluating the second component', () => {
-    const callOrder: string[] = []
+    const callOrder: Array<string> = []
 
     function First() {
       callOrder.push('First called')
@@ -248,7 +248,7 @@ describe('jsxRendererSync', () => {
     )
 
     const streamRenderer = jsxRendererSync()
-    const streamed: unknown[] = []
+    const streamed: Array<unknown> = []
     for await (const file of streamRenderer.stream(element)) {
       streamed.push(file)
     }

--- a/packages/renderer-jsx/src/types.ts
+++ b/packages/renderer-jsx/src/types.ts
@@ -76,7 +76,7 @@ export type DOMElement = {
   /**
    * Ordered list of child nodes attached to this element.
    */
-  childNodes: DOMNode[]
+  childNodes: Array<DOMNode>
   internal_transform?: OutputTransformer
 
   // Internal properties

--- a/packages/renderer-jsx/src/utils.ts
+++ b/packages/renderer-jsx/src/utils.ts
@@ -37,8 +37,8 @@ function toBool(val: unknown): boolean {
  * `kubb-type`, and similar elements are converted into their respective {@link CodeNode}s.
  * Any unrecognized element names are silently skipped.
  */
-function collectCodeNodes(element: DOMElement): CodeNode[] {
-  const result: CodeNode[] = []
+function collectCodeNodes(element: DOMElement): Array<CodeNode> {
+  const result: Array<CodeNode> = []
 
   for (const child of element.childNodes) {
     if (!child) continue
@@ -63,7 +63,7 @@ function collectCodeNodes(element: DOMElement): CodeNode[] {
           export: attrs['export'] as boolean | null | undefined,
           default: attrs['default'] as boolean | null | undefined,
           async: attrs['async'] as boolean | null | undefined,
-          generics: attrs['generics'] as string | string[] | null | undefined,
+          generics: attrs['generics'] as string | Array<string> | null | undefined,
           returnType: attrs['returnType'] as string | null | undefined,
           JSDoc: attrs['JSDoc'] as JSDocNode | null | undefined,
           nodes: collectCodeNodes(child),
@@ -81,7 +81,7 @@ function collectCodeNodes(element: DOMElement): CodeNode[] {
           export: attrs['export'] as boolean | null | undefined,
           default: attrs['default'] as boolean | null | undefined,
           async: attrs['async'] as boolean | null | undefined,
-          generics: attrs['generics'] as string | string[] | null | undefined,
+          generics: attrs['generics'] as string | Array<string> | null | undefined,
           returnType: attrs['returnType'] as string | null | undefined,
           singleLine: attrs['singleLine'] as boolean | null | undefined,
           JSDoc: attrs['JSDoc'] as JSDocNode | null | undefined,
@@ -187,9 +187,9 @@ function* collectFileEntries(node: DOMElement): Generator<SourceNode | ExportNod
  * node by its `.kind`.
  */
 function createFileNode(child: DOMElement): FileNode {
-  const sources: SourceNode[] = []
-  const exports: ExportNode[] = []
-  const imports: ImportNode[] = []
+  const sources: Array<SourceNode> = []
+  const exports: Array<ExportNode> = []
+  const imports: Array<ImportNode> = []
 
   for (const node of collectFileEntries(child)) {
     if (node.kind === 'Source') {
@@ -241,6 +241,6 @@ export function* streamFiles(node: DOMElement): Generator<FileNode> {
  * Returns the list of file nodes in document order. Nested files are supported;
  * the walker descends into non-file elements and recurses through them.
  */
-export function collectFiles(node: DOMElement): FileNode[] {
+export function collectFiles(node: DOMElement): Array<FileNode> {
   return [...streamFiles(node)]
 }

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -110,7 +110,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     const hasFailures = failedPlugins.size > 0 || error
     if (hasFailures) {
       // Collect all errors from failed plugins and general error
-      const allErrors: Error[] = [
+      const allErrors: Array<Error> = [
         error,
         ...Array.from(failedPlugins)
           .filter((it) => it.error)


### PR DESCRIPTION
## Summary

- Adds `typescript/array-type` to oxlint config with `default: 'generic'`, enforcing `Array<T>` instead of `T[]`.
- Applies the autofix across `packages/` (49 files, source-code only; no example/snapshot churn).

## Test plan

- [ ] `pnpm lint` is clean
- [ ] `pnpm build && pnpm typecheck` pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGA78Pm3Ud1Q1VPQp1Crdz)_